### PR TITLE
refactor(metrics): consolidate metric definitions into metrics.ts

### DIFF
--- a/src/database/standalone-sqlite.test.ts
+++ b/src/database/standalone-sqlite.test.ts
@@ -20,7 +20,6 @@ import arbundles from 'arbundles/stream/index.js';
 import { expect } from 'chai';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
-import * as promClient from 'prom-client';
 
 import {
   StandaloneSqliteDatabase,
@@ -160,17 +159,13 @@ describe('SQLite data conversion functions', () => {
 });
 
 describe('StandaloneSqliteDatabase', () => {
-  let metricsRegistry: promClient.Registry;
   let chainSource: ArweaveChainSourceStub;
   let db: StandaloneSqliteDatabase;
   let dbWorker: StandaloneSqliteDatabaseWorker;
 
   before(() => {
-    metricsRegistry = promClient.register;
-    metricsRegistry.clear();
     db = new StandaloneSqliteDatabase({
       log,
-      metricsRegistry,
       coreDbPath,
       dataDbPath,
       moderationDbPath,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,32 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import * as promClient from 'prom-client';
+
+//
+// Global error metrics
+//
+
+export const errorsCounter = new promClient.Counter({
+  name: 'errors_total',
+  help: 'Total error count',
+});
+
+export const uncaughtExceptionCounter = new promClient.Counter({
+  name: 'uncaught_exceptions_total',
+  help: 'Count of uncaught exceptions',
+});

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -53,3 +53,46 @@ export const methodDurationSummary = new promClient.Summary({
   help: 'Count of failed Arweave peer info requests',
   labelNames: ['worker', 'role', 'method'],
 });
+
+//
+// Block importer metrics
+//
+export const blockImporterRunningGauge = new promClient.Gauge({
+  name: 'block_importer_running',
+  help: 'Depth of the last observed chain fork',
+});
+
+export const forksCounter = new promClient.Counter({
+  name: 'forks_total',
+  help: 'Count of chain forks observed',
+});
+
+export const lastForkDepthGauge = new promClient.Gauge({
+  name: 'last_fork_depth',
+  help: 'Depth of the last observed chain fork',
+});
+
+export const blocksImportedCounter = new promClient.Counter({
+  name: 'blocks_imported_total',
+  help: 'Count of blocks imported',
+});
+
+export const transactionsImportedCounter = new promClient.Counter({
+  name: 'block_transactions_imported_total',
+  help: 'Count of transactions imported',
+});
+
+export const missingTransactionsCounter = new promClient.Counter({
+  name: 'missing_block_transactions_total',
+  help: 'Count of block transactions that could not be immediately fetched',
+});
+
+export const blockImportErrorsCounter = new promClient.Counter({
+  name: 'block_import_errors_total',
+  help: 'Count of block import errors',
+});
+
+export const lastHeightImported = new promClient.Gauge({
+  name: 'last_height_imported',
+  help: 'Height of the last block imported',
+});

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -32,6 +32,40 @@ export const uncaughtExceptionCounter = new promClient.Counter({
 });
 
 //
+// Global bundle metrics
+//
+
+export const bundlesCounter = new promClient.Counter({
+  name: 'bundles_total',
+  help: 'Count of all bundles seen',
+  labelNames: ['bundle_format', 'parent_type'],
+});
+
+export const bundlesMatchedCounter = new promClient.Counter({
+  name: 'bundles_matched_total',
+  help: 'Count of bundles matched for unbundling',
+  labelNames: ['bundle_format'],
+});
+
+export const bundlesQueuedCounter = new promClient.Counter({
+  name: 'bundles_queued_total',
+  help: 'Count of bundles queued for unbundling',
+  labelNames: ['bundle_format'],
+});
+
+export const bundlesUnbundledCounter = new promClient.Counter({
+  name: 'bundles_unbundled_total',
+  help: 'Count of bundles unbundled',
+  labelNames: ['bundle_format'],
+});
+
+export const dataItemsQueuedCounter = new promClient.Counter({
+  name: 'data_items_queued_total',
+  help: 'Count of data items queued for indexing',
+  labelNames: ['bundle_format'],
+});
+
+//
 // Arweave client metrics
 //
 
@@ -48,6 +82,7 @@ export const arweavePeerRefreshErrorCounter = new promClient.Counter({
 //
 // SQLite metrics
 //
+
 export const methodDurationSummary = new promClient.Summary({
   name: 'standalone_sqlite_method_duration_seconds',
   help: 'Count of failed Arweave peer info requests',
@@ -57,6 +92,7 @@ export const methodDurationSummary = new promClient.Summary({
 //
 // Block importer metrics
 //
+
 export const blockImporterRunningGauge = new promClient.Gauge({
   name: 'block_importer_running',
   help: 'Depth of the last observed chain fork',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -44,3 +44,12 @@ export const arweavePeerRefreshErrorCounter = new promClient.Counter({
   name: 'arweave_peer_referesh_errors_total',
   help: 'Count of errors refreshing the Arweave peers list',
 });
+
+//
+// SQLite metrics
+//
+export const methodDurationSummary = new promClient.Summary({
+  name: 'standalone_sqlite_method_duration_seconds',
+  help: 'Count of failed Arweave peer info requests',
+  labelNames: ['worker', 'role', 'method'],
+});

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -30,3 +30,17 @@ export const uncaughtExceptionCounter = new promClient.Counter({
   name: 'uncaught_exceptions_total',
   help: 'Count of uncaught exceptions',
 });
+
+//
+// Arweave client metrics
+//
+
+export const arweavePeerInfoErrorCounter = new promClient.Counter({
+  name: 'arweave_peer_info_errors_total',
+  help: 'Count of failed Arweave peer info requests',
+});
+
+export const arweavePeerRefreshErrorCounter = new promClient.Counter({
+  name: 'arweave_peer_referesh_errors_total',
+  help: 'Count of errors refreshing the Arweave peers list',
+});

--- a/src/system.ts
+++ b/src/system.ts
@@ -32,6 +32,7 @@ import { MatchTags } from './filters.js';
 import { UniformFailureSimulator } from './lib/chaos.js';
 import { currentUnixTimestamp } from './lib/time.js';
 import log from './log.js';
+import * as metrics from './metrics.js';
 import { MemoryCacheArNSResolver } from './resolution/memory-cache-arns-resolver.js';
 import { StreamingManifestPathResolver } from './resolution/streaming-manifest-path-resolver.js';
 import { TrustedGatewayArNSResolver } from './resolution/trusted-gateway-arns-resolver.js';
@@ -59,19 +60,8 @@ import { TransactionFetcher } from './workers/transaction-fetcher.js';
 import { TransactionImporter } from './workers/transaction-importer.js';
 import { TransactionRepairWorker } from './workers/transaction-repair-worker.js';
 
-// Global errors counter
-export const errorsCounter = new promClient.Counter({
-  name: 'errors_total',
-  help: 'Total error count',
-});
-
-// Uncaught exception handler
-export const uncaughtExceptionCounter = new promClient.Counter({
-  name: 'uncaught_exceptions_total',
-  help: 'Count of uncaught exceptions',
-});
 process.on('uncaughtException', (error) => {
-  uncaughtExceptionCounter.inc();
+  metrics.uncaughtExceptionCounter.inc();
   log.error('Uncaught exception:', error);
 });
 
@@ -120,7 +110,7 @@ const eventEmitter = new EventEmitter();
 export const blockImporter = new BlockImporter({
   log,
   metricsRegistry: promClient.register,
-  errorsCounter,
+  errorsCounter: metrics.errorsCounter,
   chainSource: arweaveClient,
   chainIndex,
   eventEmitter,

--- a/src/system.ts
+++ b/src/system.ts
@@ -17,7 +17,6 @@
  */
 import { default as Arweave } from 'arweave';
 import EventEmitter from 'node:events';
-import * as promClient from 'prom-client';
 
 import { ArweaveCompositeClient } from './arweave/composite-client.js';
 import * as config from './config.js';
@@ -123,17 +122,11 @@ const ans104TxMatcher = new MatchTags([
   { name: 'Bundle-Version', valueStartsWith: '2.' },
 ]);
 
-const bundlesCounter = new promClient.Counter({
-  name: 'bundles_total',
-  help: 'Count of all bundles seen',
-  labelNames: ['bundle_format', 'parent_type'],
-});
-
 export const prioritizedTxIds = new Set<string>();
 
 eventEmitter.on(events.TX_INDEXED, async (tx: MatchableItem) => {
   if (await ans104TxMatcher.match(tx)) {
-    bundlesCounter.inc({
+    metrics.bundlesCounter.inc({
       bundle_format: 'ans-104',
       parent_type: 'transaction',
     });
@@ -146,7 +139,7 @@ eventEmitter.on(
   events.ANS104_DATA_ITEM_DATA_INDEXED,
   async (item: MatchableItem) => {
     if (await ans104TxMatcher.match(item)) {
-      bundlesCounter.inc({
+      metrics.bundlesCounter.inc({
         bundle_format: 'ans-104',
         parent_type: 'data_item',
       });
@@ -194,7 +187,7 @@ export const bundleRepairWorker = new BundleRepairWorker({
   filtersChanged: config.FILTER_CHANGE_REPROCESS,
 });
 
-// Configure contigous data source
+// Configure contiguous data source
 const chunkDataSource = new ReadThroughChunkDataCache({
   log,
   chunkSource: arweaveClient,
@@ -230,18 +223,6 @@ const ans104Unbundler = new Ans104Unbundler({
   dataItemIndexFilterString: config.ANS104_INDEX_FILTER_STRING,
 });
 
-const bundlesMatchedCounter = new promClient.Counter({
-  name: 'bundles_matched_total',
-  help: 'Count of bundles matched for unbundling',
-  labelNames: ['bundle_format'],
-});
-
-const bundlesQueuedCounter = new promClient.Counter({
-  name: 'bundles_queued_total',
-  help: 'Count of bundles queued for unbundling',
-  labelNames: ['bundle_format'],
-});
-
 eventEmitter.on(
   events.ANS104_BUNDLE_INDEXED,
   async (item: NormalizedDataItem | PartialJsonTransaction) => {
@@ -254,7 +235,7 @@ eventEmitter.on(
       const prioritized = prioritizedTxIds.has(item.id);
       prioritizedTxIds.delete(item.id);
       if (await config.ANS104_UNBUNDLE_FILTER.match(item)) {
-        bundlesMatchedCounter.inc({ bundle_format: 'ans-104' });
+        metrics.bundlesMatchedCounter.inc({ bundle_format: 'ans-104' });
         await db.saveBundle({
           id: item.id,
           format: 'ans-104',
@@ -272,7 +253,7 @@ eventEmitter.on(
           },
           prioritized,
         );
-        bundlesQueuedCounter.inc({ bundle_format: 'ans-104' });
+        metrics.bundlesQueuedCounter.inc({ bundle_format: 'ans-104' });
       } else {
         await db.saveBundle({
           id: item.id,
@@ -287,15 +268,9 @@ eventEmitter.on(
   },
 );
 
-const bundlesUnbundledCounter = new promClient.Counter({
-  name: 'bundles_unbundled_total',
-  help: 'Count of bundles unbundled',
-  labelNames: ['bundle_format'],
-});
-
 eventEmitter.on(events.ANS104_UNBUNDLE_COMPLETE, async (bundleEvent: any) => {
   try {
-    bundlesUnbundledCounter.inc({ bundle_format: 'ans-104' });
+    metrics.bundlesUnbundledCounter.inc({ bundle_format: 'ans-104' });
     db.saveBundle({
       id: bundleEvent.parentId,
       format: 'ans-104',
@@ -320,14 +295,8 @@ const ans104DataIndexer = new Ans104DataIndexer({
   indexWriter: nestedDataIndexWriter,
 });
 
-const dataItemsQueuedCounter = new promClient.Counter({
-  name: 'data_items_queued_total',
-  help: 'Count of data items queued for indexing',
-  labelNames: ['bundle_format'],
-});
-
 eventEmitter.on(events.ANS104_DATA_ITEM_MATCHED, async (dataItem: any) => {
-  dataItemsQueuedCounter.inc({ bundle_format: 'ans-104' });
+  metrics.dataItemsQueuedCounter.inc({ bundle_format: 'ans-104' });
   dataItemIndexer.queueDataItem(dataItem);
   ans104DataIndexer.queueDataItem(dataItem);
 });

--- a/src/system.ts
+++ b/src/system.ts
@@ -107,8 +107,6 @@ const eventEmitter = new EventEmitter();
 
 export const blockImporter = new BlockImporter({
   log,
-  metricsRegistry: promClient.register,
-  errorsCounter: metrics.errorsCounter,
   chainSource: arweaveClient,
   chainIndex,
   eventEmitter,

--- a/src/system.ts
+++ b/src/system.ts
@@ -69,7 +69,6 @@ const arweave = Arweave.init({});
 
 export const arweaveClient = new ArweaveCompositeClient({
   log,
-  metricsRegistry: promClient.register,
   arweave,
   trustedNodeUrl: config.TRUSTED_NODE_URL,
   skipCache: config.SKIP_CACHE,

--- a/src/system.ts
+++ b/src/system.ts
@@ -89,7 +89,6 @@ export const arweaveClient = new ArweaveCompositeClient({
 
 export const db = new StandaloneSqliteDatabase({
   log,
-  metricsRegistry: promClient.register,
   coreDbPath: 'data/sqlite/core.db',
   dataDbPath: 'data/sqlite/data.db',
   moderationDbPath: 'data/sqlite/moderation.db',

--- a/src/workers/block-importer.test.ts
+++ b/src/workers/block-importer.test.ts
@@ -18,7 +18,6 @@
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { EventEmitter } from 'node:events';
-import * as promClient from 'prom-client';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { default as wait } from 'wait';
@@ -38,7 +37,6 @@ chai.use(chaiAsPromised);
 chai.use(sinonChai);
 
 describe('BlockImporter', () => {
-  let metricsRegistry: promClient.Registry;
   let eventEmitter: EventEmitter;
   let blockImporter: BlockImporter;
   let chainSource: ArweaveChainSourceStub;
@@ -54,11 +52,6 @@ describe('BlockImporter', () => {
   }) => {
     return new BlockImporter({
       log,
-      metricsRegistry,
-      errorsCounter: new promClient.Counter({
-        name: 'errors_total',
-        help: 'Total error count',
-      }),
       chainSource,
       chainIndex: db,
       eventEmitter,
@@ -68,13 +61,10 @@ describe('BlockImporter', () => {
   };
 
   before(async () => {
-    metricsRegistry = promClient.register;
-    metricsRegistry.clear();
     eventEmitter = new EventEmitter();
     chainSource = new ArweaveChainSourceStub();
     db = new StandaloneSqliteDatabase({
       log,
-      metricsRegistry,
       bundlesDbPath,
       coreDbPath,
       dataDbPath,
@@ -88,8 +78,6 @@ describe('BlockImporter', () => {
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
-    metricsRegistry = promClient.register;
-    metricsRegistry.clear();
   });
 
   afterEach(async () => {


### PR DESCRIPTION
Consolidates metrics into `metrics.ts` and removes passing `prom-client.Registry` to various classes.