### PR TITLE
feat: refactor 'nix develop' flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,57 @@
 {
   "nodes": {
-    "nixpkgs": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1648219316,
-        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1693505331,
+        "narHash": "sha256-lQ5cQqzRY4VietVXvcoyO2Oye+DlVxLqYQ9dEi1ZZY4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e919958b42b090606b8d070a676de62d832db67a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,29 @@
 {
   description = "AR.IO Node";
 
-  outputs = { self, nixpkgs }:
-    let pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    in {
-      devShell.x86_64-linux = import ./shell.nix { inherit pkgs; };
-    };
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+        let pkgs = (import nixpkgs {
+          inherit system;
+        });
+        in {
+          devShells = {
+            default = pkgs.mkShell {
+              name = "ar-io-node-shell";
+              buildInputs = with pkgs; [
+                nodejs
+                sqlite-interactive
+              ];
+            };
+          };
+        }
+    );
+
+  nixConfig.bash-prompt = "\\e[32m\[ar-io-node-shell\]$\\e[0m ";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,0 @@
-{ pkgs ? import <nixpkgs> { } }:
-with pkgs;
-mkShell {
-  buildInputs = [
-    nodejs
-    sqlite-interactive
-  ];
-}


### PR DESCRIPTION
using the legacy nixpkgs caused an issue on my aarch64-darwin system, as it tried to execute linux binaries, therefore I pass the system variable into the import of nixpkgs, and the issue is gone.