### PR TITLE
feat(apollo): disable persistedQueries

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -177,6 +177,7 @@ app.post('/ar-io/admin/queue-tx', express.json(), async (req, res) => {
 // GraphQL
 const apolloServerInstanceGql = apolloServer(system.db, {
   introspection: true,
+  persistedQueries: false,
 });
 apolloServerInstanceGql.start().then(() => {
   apolloServerInstanceGql.applyMiddleware({


### PR DESCRIPTION
This should disable the warning (by addressing the issue)

```
...
Your server is vulnerable to denial of service attacks via memory exhaustion.
...
```