### PR TITLE
fix(ci): this should be `/ar-io/healthcheck` right

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ VOLUME /app/data
 
 # EXPOSE PORT AND SETUP HEALTHCHECK
 EXPOSE 4000
-HEALTHCHECK CMD curl --fail http://localhost:4000/healthcheck || exit 1
+HEALTHCHECK CMD curl --fail http://localhost:4000/ar-io/healthcheck || exit 1
 
 # ADD LABELS
 LABEL org.opencontainers.image.title="ar.io Core Service"


### PR DESCRIPTION
```
ghcr.io/ar-io/ar-io-core:latest    "/bin/sh docker-entr…"   44 seconds ago   Up 40 seconds (healthy)   0.0.0.0:4000->4000/tcp                                      ar-io-node-core-1
```