### PR TITLE
Add subdomain support

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -83,6 +83,7 @@ if (config.ARNS_ROOT_HOST !== undefined) {
   app.use(
     createArnsMiddleware({
       dataHandler,
+      rootHost: config.ARNS_ROOT_HOST,
       nameResolver: system.nameResolver,
     }),
   );

--- a/src/app.ts
+++ b/src/app.ts
@@ -83,14 +83,12 @@ if (config.ARNS_ROOT_HOST !== undefined) {
   app.use(
     createArnsMiddleware({
       dataHandler,
-      rootHost: config.ARNS_ROOT_HOST,
       nameResolver: system.nameResolver,
     }),
   );
 
   app.use(
     createSandboxMiddleware({
-      rootHost: config.ARNS_ROOT_HOST,
       sandboxProtocol: config.SANDBOX_PROTOCOL,
     }),
   );

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,6 +70,8 @@ export const ANS104_INDEX_FILTER = createFilter(
   JSON.parse(ANS104_INDEX_FILTER_STRING),
 );
 export const ARNS_ROOT_HOST = env.varOrUndefined('ARNS_ROOT_HOST');
+export const ROOT_HOST_SUBDOMAIN_LENGTH =
+  ARNS_ROOT_HOST !== undefined ? ARNS_ROOT_HOST.split('.').length - 2 : 0;
 export const SANDBOX_PROTOCOL = env.varOrUndefined('SANDBOX_PROTOCOL');
 export const START_WRITERS =
   env.varOrDefault('START_WRITERS', 'true') === 'true';

--- a/src/middleware/arns.ts
+++ b/src/middleware/arns.ts
@@ -18,6 +18,7 @@
 import { Handler } from 'express';
 import { asyncMiddleware } from 'middleware-async';
 
+import * as config from '../config.js';
 import { sendNotFound } from '../routes/data.js';
 import { NameResolver } from '../types.js';
 
@@ -25,24 +26,21 @@ const EXCLUDED_SUBDOMAINS = new Set('www');
 
 export const createArnsMiddleware = ({
   dataHandler,
-  rootHost,
   nameResolver,
 }: {
   dataHandler: Handler;
-  rootHost: string;
   nameResolver: NameResolver;
 }): Handler =>
   asyncMiddleware(async (req, res, next) => {
-    const rootHostSubdomainLength = rootHost.split('.').length - 2;
     if (
       // Ignore subdomains that are part of the ArNS root hostname.
       !Array.isArray(req.subdomains) ||
-      req.subdomains.length === rootHostSubdomainLength
+      req.subdomains.length === config.ROOT_HOST_SUBDOMAIN_LENGTH
     ) {
       next();
       return;
     }
-    const arnsSubdomain = req.subdomains[req.subdomains.length - 1];
+    const arnsSubdomain = req.subdomains[config.ROOT_HOST_SUBDOMAIN_LENGTH - 1];
     if (
       EXCLUDED_SUBDOMAINS.has(arnsSubdomain) ||
       // Avoid collisions with sandbox URLs by ensuring the subdomain length

--- a/src/middleware/sandbox.ts
+++ b/src/middleware/sandbox.ts
@@ -21,9 +21,10 @@ import { base32 } from 'rfc4648';
 
 import { fromB64Url } from '../lib/encoding.js';
 
-function getRequestSandbox(req: Request): string | undefined {
-  if (req.subdomains.length === 1) {
-    return req.subdomains[0];
+function getRequestSandbox(req: Request, rootHost: string): string | undefined {
+  const rootHostSubdomainLength = rootHost.split('.').length - 2;
+  if (req.subdomains.length > rootHostSubdomainLength) {
+    return req.subdomains[req.subdomains.length - 1];
   }
   return undefined;
 }
@@ -55,7 +56,7 @@ export function createSandboxMiddleware({
       return;
     }
 
-    const reqSandbox = getRequestSandbox(req);
+    const reqSandbox = getRequestSandbox(req, rootHost);
     const idSandbox = sandboxFromId(id);
     if (reqSandbox !== idSandbox) {
       const queryString = url.parse(req.originalUrl).query ?? '';


### PR DESCRIPTION
The sandbox and ArNS middleware didn't work when the node was hosted on a subdomain.

This PR adds subdomain support to both middlewares, so the node doesn't require a dedicated apex domain for hosting.