### PR TITLE
[WIP] Expose X-ArNS-* HTTP headers for CORS requests

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -57,7 +57,11 @@ const app = express();
 //  }),
 //);
 
-app.use(cors());
+app.use(
+  cors({
+    exposedHeaders: ['X-ArNS-Resolved-Id', 'X-ArNS-TTL-Seconds'],
+  }),
+);
 
 app.use(
   promMid({


### PR DESCRIPTION
This allows browser-based cross-origin requests to access the `X-ArNS-Resolved-Id` and `X-ArNS-TTL-Seconds` HTTP headers, i.e. for implementing the Observer Incentive Protocol.