### PR TITLE
feat(lmdb): introduce `KvBufferStore` and lmdb/fs based implementations for header cache 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
       - ${HEADERS_DATA_PATH:-./data/headers}:/app/data/headers
       - ${SQLITE_DATA_PATH:-./data/sqlite}:/app/data/sqlite
       - ${TEMP_DATA_PATH:-./data/tmp}:/app/data/tmp
+      - ${LMDB_DATA_PATH:-./data/lmdb}:/app/data/lmdb
     environment:
       - NODE_ENV=${NODE_ENV:-production}
       - LOG_FORMAT=${LOG_FORMAT:-simple}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,6 +52,7 @@ services:
       - SANDBOX_PROTOCOL=${SANDBOX_PROTOCOL:-}
       - START_WRITERS=${START_WRITERS:-}
       - CONTRACT_ID=${CONTRACT_ID:-}
+      - CHAIN_CACHE_TYPE=${CHAIN_CACHE_TYPE:-}
 
   observer:
     image: ghcr.io/ar-io/ar-io-observer:${OBSERVER_IMAGE_TAG:-a5b9b3a0246ba2912c610ad28ffe849d8184d752}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "fs-extra": "^11.1.0",
     "graphql": "^16.5.0",
     "json-canonicalize": "^1.0.6",
+    "lmdb": "^2.8.5",
     "middleware-async": "^1.3.5",
     "msgpackr": "^1.6.2",
     "node-cache": "^5.1.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,3 +79,4 @@ export const CONTRACT_ID = env.varOrDefault(
   'CONTRACT_ID',
   'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U',
 );
+export const CHAIN_CACHE_TYPE = env.varOrDefault('CHAIN_CACHE_TYPE', 'fs');

--- a/src/lib/kvstore.ts
+++ b/src/lib/kvstore.ts
@@ -15,9 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { FsKVStore } from '../store/fs-kv-store';
-import { LmdbKVStore } from '../store/lmdb-kv-store';
-import { KVBufferStore } from '../types';
+import { FsKVStore } from '../store/fs-kv-store.js';
+import { LmdbKVStore } from '../store/lmdb-kv-store.js';
+import { KVBufferStore } from '../types.js';
 
 export const getKvBufferStore = ({
   pathKey,

--- a/src/lib/kvstore.ts
+++ b/src/lib/kvstore.ts
@@ -1,0 +1,46 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { FsKVStore } from '../store/fs-kv-store';
+import { LmdbKVStore } from '../store/lmdb-kv-store';
+import { KVBufferStore } from '../types';
+
+export const getKvBufferStore = ({
+  pathKey,
+  type,
+}: {
+  pathKey: string;
+  type: string;
+}): KVBufferStore => {
+  switch (type) {
+    case 'lmdb': {
+      return new LmdbKVStore({
+        dbPath: `data/lmdb/${pathKey}`,
+      });
+    }
+    case 'fs': {
+      return new FsKVStore({
+        baseDir: `data/headers/${pathKey}`,
+        tmpDir: `data/tmp/${pathKey}`,
+      });
+    }
+    // TODO: implement redis
+    default: {
+      throw new Error(`Invalid chain cache type: ${type}`);
+    }
+  }
+};

--- a/src/store/fs-kv-store.ts
+++ b/src/store/fs-kv-store.ts
@@ -17,26 +17,14 @@
  */
 import fse from 'fs-extra';
 import fs from 'node:fs';
-import winston from 'winston';
 
 import { KVBufferStore } from '../types';
 
 export class FsKVStore implements KVBufferStore {
-  private log: winston.Logger;
   private baseDir: string;
   private tmpDir: string;
 
-  constructor({
-    log,
-    baseDir,
-    tmpDir,
-  }: {
-    log: winston.Logger;
-    baseDir: string;
-    tmpDir: string;
-  }) {
-    this.log = log.child({ class: this.constructor.name });
-    this.log.info('Using filesystem based key/value store');
+  constructor({ baseDir, tmpDir }: { baseDir: string; tmpDir: string }) {
     this.baseDir = baseDir;
     this.tmpDir = tmpDir;
     fs.mkdirSync(tmpDir, { recursive: true });

--- a/src/store/fs-kv-store.ts
+++ b/src/store/fs-kv-store.ts
@@ -1,0 +1,104 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import fse from 'fs-extra';
+import fs from 'node:fs';
+import winston from 'winston';
+
+import { KVBufferStore } from '../types';
+
+export class FsKVStore implements KVBufferStore {
+  private log: winston.Logger;
+  private baseDir: string;
+  private tmpDir: string;
+
+  constructor({
+    log,
+    baseDir,
+    tmpDir,
+  }: {
+    log: winston.Logger;
+    baseDir: string;
+    tmpDir: string;
+  }) {
+    this.log = log.child({ class: this.constructor.name });
+    this.baseDir = baseDir;
+    this.tmpDir = tmpDir;
+    fs.mkdirSync(tmpDir, { recursive: true });
+  }
+
+  async get(key: string): Promise<Buffer | undefined> {
+    try {
+      if (await this.has(key)) {
+        return await fs.promises.readFile(this.bufferPath(key));
+      }
+    } catch (error: any) {
+      this.log.error('Failed to get buffer data from key/value store', {
+        key,
+        message: error.message,
+        stack: error.stack,
+      });
+    }
+    return undefined;
+  }
+
+  bufferPath(key: string): string {
+    return `${this.baseDir}/${key}`;
+  }
+
+  async has(key: string): Promise<boolean> {
+    try {
+      await fs.promises.access(this.bufferPath(key), fs.constants.F_OK);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  async del(key: string): Promise<void> {
+    try {
+      if (await this.has(key)) {
+        await fs.promises.unlink(this.bufferPath(key));
+      }
+    } catch (error: any) {
+      this.log.error('Failed to delete buffer data from key/value store', {
+        key,
+        message: error.message,
+        stack: error.stack,
+      });
+    }
+  }
+
+  async set(key: string, buffer: Buffer): Promise<void> {
+    try {
+      if (!(await this.has(key))) {
+        // Write the block data to the temporary file in case it fails
+        const tmpPath = `${this.tmpDir}/${key}`;
+        await fs.promises.writeFile(tmpPath, buffer);
+
+        // copy the temporary file to the final location
+        await fse.move(tmpPath, this.bufferPath(key));
+      }
+    } catch (error: any) {
+      this.log.error('Failed to set buffer data in key/value store', {
+        key,
+        message: error.message,
+        stack: error.stack,
+      });
+    }
+  }
+}

--- a/src/store/fs-kv-store.ts
+++ b/src/store/fs-kv-store.ts
@@ -42,15 +42,15 @@ export class FsKVStore implements KVBufferStore {
     fs.mkdirSync(tmpDir, { recursive: true });
   }
 
+  private bufferPath(key: string): string {
+    return `${this.baseDir}/${key}`;
+  }
+
   async get(key: string): Promise<Buffer | undefined> {
     if (await this.has(key)) {
       return fs.promises.readFile(this.bufferPath(key));
     }
     return undefined;
-  }
-
-  bufferPath(key: string): string {
-    return `${this.baseDir}/${key}`;
   }
 
   async has(key: string): Promise<boolean> {

--- a/src/store/kv-block-store.ts
+++ b/src/store/kv-block-store.ts
@@ -23,6 +23,7 @@ import {
   msgpackToJsonBlock,
   toB64Url,
 } from '../lib/encoding.js';
+import { sanityCheckBlock } from '../lib/validation.js';
 import { KVBufferStore, PartialJsonBlockStore } from '../types.js';
 import { PartialJsonBlock } from '../types.js';
 
@@ -92,8 +93,9 @@ export class KvBlockStore implements PartialJsonBlockStore {
         if (blockDataBuffer === undefined) {
           throw new Error('Missing block data in key/value store');
         }
-        const blockData = msgpackToJsonBlock(blockDataBuffer);
-        return blockData;
+        const block = msgpackToJsonBlock(blockDataBuffer);
+        sanityCheckBlock(block);
+        return block;
       }
     } catch (error: any) {
       this.log.error('Failed to get block by hash', {

--- a/src/store/kv-block-store.ts
+++ b/src/store/kv-block-store.ts
@@ -1,0 +1,204 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import winston from 'winston';
+
+import { jsonBlockToMsgpack, msgpackToJsonBlock } from '../lib/encoding.js';
+import { KVBufferStore, PartialJsonBlockStore } from '../types.js';
+import { PartialJsonBlock } from '../types.js';
+
+export class KvTransactionStore implements PartialJsonBlockStore {
+  private log: winston.Logger;
+  private kvBufferStore: KVBufferStore;
+
+  constructor({
+    log,
+    kvBufferStore,
+  }: {
+    log: winston.Logger;
+    kvBufferStore: KVBufferStore;
+  }) {
+    this.log = log.child({ class: this.constructor.name });
+    this.kvBufferStore = kvBufferStore;
+  }
+
+  private blockHash(hash: string) {
+    return `${hash}-hash`;
+  }
+
+  private blockHeight(height: number) {
+    return `${height}-height`;
+  }
+
+  async hasHash(hash: string): Promise<boolean> {
+    try {
+      const hasHash = await this.kvBufferStore.has(this.blockHash(hash));
+      return hasHash;
+    } catch (error: any) {
+      this.log.error(
+        'Failed to verify if block hash exists in key/value store',
+        {
+          hash,
+          message: error.message,
+          stack: error.stack,
+        },
+      );
+    }
+    return false;
+  }
+
+  async hasHeight(height: number): Promise<boolean> {
+    try {
+      const hasHeight = await this.kvBufferStore.has(this.blockHeight(height));
+      return hasHeight;
+    } catch (error: any) {
+      this.log.error(
+        'Failed to verify if block height exists in key/value store',
+        {
+          height,
+          message: error.message,
+          stack: error.stack,
+        },
+      );
+    }
+    return false;
+  }
+  async getByHash(hash: string): Promise<PartialJsonBlock | undefined> {
+    try {
+      if (await this.hasHash(hash)) {
+        const blockData = await this.kvBufferStore.get(this.blockHash(hash));
+        if (blockData === undefined) {
+          throw new Error('Missing block data in key/value store');
+        }
+        return msgpackToJsonBlock(blockData);
+      }
+    } catch (error: any) {
+      this.log.error('Failed to get block by hash', {
+        hash,
+        message: error.message,
+        stack: error.stack,
+      });
+    }
+    return undefined;
+  }
+
+  async getByHeight(number: number): Promise<PartialJsonBlock | undefined> {
+    try {
+      if (await this.hasHeight(number)) {
+        const blockHashBuffer = await this.kvBufferStore.get(
+          this.blockHeight(number),
+        );
+        if (blockHashBuffer === undefined) {
+          throw new Error('Missing block hash in key/value store for height.');
+        }
+        const blockHash = blockHashBuffer.toString();
+        const blockData = await this.kvBufferStore.get(
+          this.blockHash(blockHash),
+        );
+        if (blockData === undefined) {
+          throw new Error('Missing block data in key/value store for hash.');
+        }
+        return msgpackToJsonBlock(blockData);
+      }
+    } catch (error: any) {
+      this.log.error('Failed to get block by height', {
+        height: number,
+        message: error.message,
+        stack: error.stack,
+      });
+    }
+    return undefined;
+  }
+
+  async delByHash(hash: string): Promise<void> {
+    try {
+      if (await this.hasHash(hash)) {
+        const blockData = await this.getByHash(hash);
+        // remove the hash to block data reference
+        await this.kvBufferStore.del(this.blockHash(hash));
+
+        // remove the block height to hash reference
+        if (
+          blockData !== undefined &&
+          (await this.hasHeight(blockData.height))
+        ) {
+          // TODO: should we check the hash stored in the table matches the blockData, or delete regardless
+          await this.kvBufferStore.del(this.blockHeight(blockData.height));
+        }
+      }
+    } catch (error: any) {
+      this.log.error('Failed to delete block by height', {
+        hash,
+        message: error.message,
+        stack: error.stack,
+      });
+    }
+  }
+
+  async delByHeight(number: number): Promise<void> {
+    try {
+      if (await this.hasHeight(number)) {
+        const blockHashBuffer = await this.kvBufferStore.get(
+          this.blockHeight(number),
+        );
+        // remove height to block hash reference
+        await this.kvBufferStore.del(this.blockHeight(number));
+
+        if (
+          blockHashBuffer !== undefined &&
+          (await this.hasHash(blockHashBuffer.toString()))
+        ) {
+          // remove the block hash
+          const blockHash = blockHashBuffer.toString();
+          await this.kvBufferStore.del(this.blockHash(blockHash));
+        }
+      }
+    } catch (error: any) {
+      this.log.error('Failed to delete block by height', {
+        height: number,
+        message: error.message,
+        stack: error.stack,
+      });
+    }
+  }
+
+  async set(block: PartialJsonBlock, height?: number): Promise<void> {
+    const hash = block.indep_hash;
+    try {
+      if (!(await this.hasHash(hash))) {
+        const blockData = jsonBlockToMsgpack(block);
+        await this.kvBufferStore.set(this.blockHash(hash), blockData);
+
+        // store the hash by height separately, instead of also storing the height against the block data
+        if (height !== undefined && !(await this.hasHeight(height))) {
+          const blockHashBuffer = Buffer.from(hash);
+          await this.kvBufferStore.set(
+            this.blockHeight(height),
+            blockHashBuffer,
+          );
+        }
+      }
+    } catch (error: any) {
+      this.log.error('Failed to set block data in key/value store', {
+        hash,
+        height,
+        message: error.message,
+        stack: error.stack,
+      });
+    }
+  }
+}

--- a/src/store/kv-transaction-store.ts
+++ b/src/store/kv-transaction-store.ts
@@ -1,0 +1,88 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import winston from 'winston';
+
+import { jsonTxToMsgpack, msgpackToJsonTx } from '../lib/encoding.js';
+import { sanityCheckTx } from '../lib/validation.js';
+import {
+  KVBufferStore,
+  PartialJsonTransaction,
+  PartialJsonTransactionStore,
+} from '../types.js';
+
+/**
+ * TODO: currently our KvBufferStore is handling errors. We may want to refactor that to handle errors here instead.
+ */
+
+export class KvTransactionStore implements PartialJsonTransactionStore {
+  private log: winston.Logger;
+  private kvBufferStore: KVBufferStore;
+
+  constructor({
+    log,
+    kvBufferStore,
+  }: {
+    log: winston.Logger;
+    kvBufferStore: KVBufferStore;
+  }) {
+    this.log = log.child({ class: this.constructor.name });
+    this.kvBufferStore = kvBufferStore;
+  }
+
+  async has(txId: string) {
+    return this.kvBufferStore.has(txId);
+  }
+
+  async get(txId: string) {
+    try {
+      if (await this.has(txId)) {
+        // kv buffer store currently catches errors and returns undefined, so throw if empty here
+        const txData = await this.kvBufferStore.get(txId);
+        if (txData === undefined) {
+          throw new Error('Missing transaction data in kv store');
+        }
+        const tx = msgpackToJsonTx(txData);
+        sanityCheckTx(tx);
+        return tx;
+      }
+    } catch (error: any) {
+      this.log.error('Failed to get transaction', {
+        txId,
+        message: error.message,
+        stack: error.stack,
+      });
+    }
+    return undefined;
+  }
+
+  async set(tx: PartialJsonTransaction) {
+    if (!(await this.has(tx.id))) {
+      // Encode the transaction data
+      const txData = jsonTxToMsgpack(tx);
+
+      // Write the block data to the kv store
+      return this.kvBufferStore.set(tx.id, txData);
+    }
+  }
+
+  async del(txId: string) {
+    if (await this.has(txId)) {
+      return this.kvBufferStore.del(txId);
+    }
+  }
+}

--- a/src/store/kv-transaction-store.ts
+++ b/src/store/kv-transaction-store.ts
@@ -60,10 +60,9 @@ export class KvTransactionStore implements PartialJsonTransactionStore {
   async get(txId: string) {
     try {
       if (await this.has(txId)) {
-        // kv buffer store currently catches errors and returns undefined, so throw if empty here
         const txData = await this.kvBufferStore.get(txId);
         if (txData === undefined) {
-          throw new Error('Missing transaction data in kv store');
+          throw new Error('Missing transaction data in key/value store');
         }
         const tx = msgpackToJsonTx(txData);
         sanityCheckTx(tx);

--- a/src/store/lmdb-kv-store.test.ts
+++ b/src/store/lmdb-kv-store.test.ts
@@ -1,0 +1,77 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { expect } from 'chai';
+import fs from 'node:fs';
+
+import { fromB64Url, toB64Url } from '../lib/encoding.js';
+import { LmdbKVStore } from './lmdb-kv-store.js';
+
+const tempLmdbDir = new URL('./lmdb', import.meta.url).pathname;
+
+describe('LmdbKvStore', () => {
+  const lmdbKvStore = new LmdbKVStore({
+    dbPath: tempLmdbDir,
+  });
+
+  after(() => {
+    if (fs.existsSync(tempLmdbDir)) {
+      fs.rmSync(tempLmdbDir, { recursive: true });
+    }
+  });
+
+  it('should properly set and get a buffer', async () => {
+    const key = 'key';
+    const value = fromB64Url('test');
+    await lmdbKvStore.set(key, value);
+    const result = await lmdbKvStore.get(key);
+    expect(result).not.to.be.undefined;
+    expect(toB64Url(result!)).to.equal('test');
+  });
+
+  it('should properly delete buffer', async () => {
+    const key = 'key';
+    const value = fromB64Url('test');
+    await lmdbKvStore.set(key, value);
+    await lmdbKvStore.del(key);
+    const result = await lmdbKvStore.get(key);
+    expect(result).to.be.undefined;
+  });
+
+  it('should not override existing buffer when key already exists in cache', async () => {
+    const key = 'key';
+    const value = Buffer.from('test', 'base64url');
+    await lmdbKvStore.set(key, value);
+    await lmdbKvStore.set(key, Buffer.from('test2', 'base64url'));
+    const result = await lmdbKvStore.get(key);
+    expect(result).not.to.be.undefined;
+    expect(toB64Url(result!)).to.equal('test');
+  });
+
+  it('should return a buffer when a Uint8Array is stored in the cache', async () => {
+    const key = 'key';
+    const value = new Uint8Array(Buffer.from('test', 'base64url'));
+    // sanity check
+    expect(Buffer.isBuffer(value)).to.equal(false);
+    // intentional cast as LMDB does this under the hood
+    await lmdbKvStore.set(key, value as Buffer);
+    const result = await lmdbKvStore.get(key);
+    expect(result).not.to.be.undefined;
+    expect(Buffer.isBuffer(result)).to.equal(true);
+    expect(toB64Url(result!)).to.equal('test');
+  });
+});

--- a/src/store/lmdb-kv-store.test.ts
+++ b/src/store/lmdb-kv-store.test.ts
@@ -40,7 +40,7 @@ describe('LmdbKvStore', () => {
     await lmdbKvStore.set(key, value);
     const result = await lmdbKvStore.get(key);
     expect(result).not.to.be.undefined;
-    expect(toB64Url(result!)).to.equal('test');
+    expect(toB64Url(result!)).to.equal('test'); // eslint-disable-line
   });
 
   it('should properly delete buffer', async () => {

--- a/src/store/lmdb-kv-store.ts
+++ b/src/store/lmdb-kv-store.ts
@@ -15,24 +15,18 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { RootDatabase, RootDatabaseOptionsWithPath, open } from 'lmdb';
+import { RootDatabase, open } from 'lmdb';
 
 import { KVBufferStore } from '../types';
 
 export class LmdbKVStore implements KVBufferStore {
   private db: RootDatabase<Buffer, string>;
 
-  constructor({
-    lmdbOptions,
-  }: {
-    lmdbOptions: Pick<
-      RootDatabaseOptionsWithPath,
-      'compression' | 'mapSize' | 'noSync' | 'path' | 'commitDelay'
-    >;
-  }) {
+  constructor({ dbPath }: { dbPath: string }) {
     this.db = open({
-      ...lmdbOptions,
+      path: dbPath,
       encoding: 'binary',
+      commitDelay: 100, // 100ms delay - increases writes per transaction to reduce I/O
     });
   }
 

--- a/src/store/lmdb-kv-store.ts
+++ b/src/store/lmdb-kv-store.ts
@@ -35,7 +35,7 @@ export class LmdbKVStore implements KVBufferStore {
     >;
   }) {
     this.log = log.child({ class: this.constructor.name });
-    this.log.info('Opening LMDB database', { lmdbOptions });
+    this.log.info('Using LMDB database', { lmdbOptions });
     this.db = open({
       ...lmdbOptions,
       encoding: 'binary',

--- a/src/store/lmdb-kv-store.ts
+++ b/src/store/lmdb-kv-store.ts
@@ -31,7 +31,7 @@ export class LmdbKVStore implements KVBufferStore {
   }
 
   async get(key: string): Promise<Buffer | undefined> {
-    return this.db.getBinary(key);
+    return this.db.get(key);
   }
 
   async has(key: string): Promise<boolean> {

--- a/src/store/lmdb-kv-store.ts
+++ b/src/store/lmdb-kv-store.ts
@@ -25,6 +25,7 @@ export class LmdbKVStore implements KVBufferStore {
   constructor({ dbPath }: { dbPath: string }) {
     this.db = open({
       path: dbPath,
+      encoding: 'binary',
       commitDelay: 100, // 100ms delay - increases writes per transaction to reduce I/O
     });
   }

--- a/src/store/lmdb-kv-store.ts
+++ b/src/store/lmdb-kv-store.ts
@@ -1,0 +1,67 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { RootDatabase, RootDatabaseOptionsWithPath, open } from 'lmdb';
+import winston from 'winston';
+
+import { KVBufferStore } from '../types';
+
+export class LmdbKVStore implements KVBufferStore {
+  private log: winston.Logger;
+  private db: RootDatabase<Buffer, string>;
+
+  constructor({
+    log,
+    lmdbOptions,
+  }: {
+    log: winston.Logger;
+    lmdbOptions: Pick<
+      RootDatabaseOptionsWithPath,
+      'compression' | 'mapSize' | 'noSync' | 'path'
+    >;
+  }) {
+    this.log = log.child({ class: this.constructor.name });
+    this.log.info('Opening LMDB database', { lmdbOptions });
+    this.db = open({
+      ...lmdbOptions,
+      encoding: 'binary',
+    });
+  }
+
+  async get(key: string): Promise<Buffer | undefined> {
+    if (await this.has(key)) {
+      return this.db.getBinary(key);
+    }
+    return undefined;
+  }
+
+  async has(key: string): Promise<boolean> {
+    return this.db.doesExist(key);
+  }
+
+  async del(key: string): Promise<void> {
+    if (await this.has(key)) {
+      await this.db.remove(key);
+    }
+  }
+
+  async set(key: string, buffer: Buffer): Promise<void> {
+    if (!(await this.has(key))) {
+      await this.db.put(key, buffer);
+    }
+  }
+}

--- a/src/system.ts
+++ b/src/system.ts
@@ -29,7 +29,7 @@ import { StandaloneSqliteDatabase } from './database/standalone-sqlite.js';
 import * as events from './events.js';
 import { MatchTags } from './filters.js';
 import { UniformFailureSimulator } from './lib/chaos.js';
-import { getKvBufferStore } from './lib/kvstore';
+import { getKvBufferStore } from './lib/kvstore.js';
 import { currentUnixTimestamp } from './lib/time.js';
 import log from './log.js';
 import * as metrics from './metrics.js';

--- a/src/system.ts
+++ b/src/system.ts
@@ -79,11 +79,7 @@ const txStore = new KvTransactionStore({
     switch (config.CHAIN_CACHE_TYPE) {
       case 'lmdb': {
         return new LmdbKVStore({
-          lmdbOptions: {
-            path: 'data/lmdb/partial-txs',
-            compression: true,
-            commitDelay: 100, // 100ms - reduces I/O usage but increases latency
-          },
+          dbPath: 'data/lmdb/partial-txs',
         });
       }
       case 'fs': {

--- a/src/system.ts
+++ b/src/system.ts
@@ -81,7 +81,8 @@ const txStore = new KvTransactionStore({
         return new LmdbKVStore({
           lmdbOptions: {
             path: 'data/lmdb/partial-txs',
-            // TODO: set sensible default options for LMDB client
+            compression: true,
+            commitDelay: 100, // 100ms - reduces I/O usage but increases latency
           },
         });
       }

--- a/src/system.ts
+++ b/src/system.ts
@@ -73,10 +73,12 @@ const arweave = Arweave.init({});
 const txStore = new KvTransactionStore({
   log,
   kvBufferStore: (() => {
+    log.info('Creating chain cache key/value store', {
+      type: config.CHAIN_CACHE_TYPE,
+    });
     switch (config.CHAIN_CACHE_TYPE) {
       case 'lmdb': {
         return new LmdbKVStore({
-          log,
           lmdbOptions: {
             path: 'data/lmdb/partial-txs',
             // TODO: set sensible default options for LMDB client
@@ -85,7 +87,6 @@ const txStore = new KvTransactionStore({
       }
       case 'fs': {
         return new FsKVStore({
-          log,
           baseDir: 'data/headers/partial-txs',
           tmpDir: 'data/tmp/partial-txs',
         });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -479,3 +479,10 @@ export interface MatchableItem {
 export interface ItemFilter {
   match(tx: MatchableItem): Promise<boolean>;
 }
+
+export type KVBufferStore = {
+  get(key: string): Promise<Buffer | undefined>;
+  set(key: string, buffer: Buffer): Promise<void>;
+  del(key: string): Promise<void>;
+  has(key: string): Promise<boolean>;
+};

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -110,9 +110,9 @@ export interface PartialJsonBlockStore {
   hasHash(hash: string): Promise<boolean>;
   hasHeight(height: number): Promise<boolean>;
   getByHash(hash: string): Promise<PartialJsonBlock | undefined>;
-  getByHeight(number: number): Promise<PartialJsonBlock | undefined>;
+  getByHeight(height: number): Promise<PartialJsonBlock | undefined>;
   delByHash(hash: string): Promise<void>;
-  delByHeight(number: number): Promise<void>;
+  delByHeight(height: number): Promise<void>;
   set(block: PartialJsonBlock, height?: number): Promise<void>;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -868,35 +868,95 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
+"@lmdb/lmdb-darwin-arm64@2.8.5":
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.8.5.tgz#895d8cb16a9d709ce5fedd8b60022903b875e08e"
+  integrity sha512-KPDeVScZgA1oq0CiPBcOa3kHIqU+pTOwRFDIhxvmf8CTNvqdZQYp5cCKW0bUk69VygB2PuTiINFWbY78aR2pQw==
+
+"@lmdb/lmdb-darwin-x64@2.8.5":
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.8.5.tgz#ca243534c8b37d5516c557e4624256d18dd63184"
+  integrity sha512-w/sLhN4T7MW1nB3R/U8WK5BgQLz904wh+/SmA2jD8NnF7BLLoUgflCNxOeSPOWp8geP6nP/+VjWzZVip7rZ1ug==
+
+"@lmdb/lmdb-linux-arm64@2.8.5":
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.8.5.tgz#b44a8023057e21512eefb9f6120096843b531c1e"
+  integrity sha512-vtbZRHH5UDlL01TT5jB576Zox3+hdyogvpcbvVJlmU5PdL3c5V7cj1EODdh1CHPksRl+cws/58ugEHi8bcj4Ww==
+
+"@lmdb/lmdb-linux-arm@2.8.5":
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.8.5.tgz#17bd54740779c3e4324e78e8f747c21416a84b3d"
+  integrity sha512-c0TGMbm2M55pwTDIfkDLB6BpIsgxV4PjYck2HiOX+cy/JWiBXz32lYbarPqejKs9Flm7YVAKSILUducU9g2RVg==
+
+"@lmdb/lmdb-linux-x64@2.8.5":
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.8.5.tgz#6c61835b6cc58efdf79dbd5e8c72a38300a90302"
+  integrity sha512-Xkc8IUx9aEhP0zvgeKy7IQ3ReX2N8N1L0WPcQwnZweWmOuKfwpS3GRIYqLtK5za/w3E60zhFfNdS+3pBZPytqQ==
+
+"@lmdb/lmdb-win32-x64@2.8.5":
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.8.5.tgz#8233e8762440b0f4632c47a09b1b6f23de8b934c"
+  integrity sha512-4wvrf5BgnR8RpogHhtpCPJMKBmvyZPhhUtEwMJbXh0ni2BucpfF07jlmyM11zRqQ2XIq6PbC2j7W7UCCcm1rRQ==
+
 "@msgpackr-extract/msgpackr-extract-darwin-arm64@2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.1.2.tgz#9571b87be3a3f2c46de05585470bc4f3af2f6f00"
   integrity sha512-TyVLn3S/+ikMDsh0gbKv2YydKClN8HaJDDpONlaZR+LVJmsxLFUgA+O7zu59h9+f9gX1aj/ahw9wqa6rosmrYQ==
+
+"@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz#44d752c1a2dc113f15f781b7cc4f53a307e3fa38"
+  integrity sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==
 
 "@msgpackr-extract/msgpackr-extract-darwin-x64@2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.1.2.tgz#bfbc6936ede2955218f5621a675679a5fe8e6f4c"
   integrity sha512-YPXtcVkhmVNoMGlqp81ZHW4dMxK09msWgnxtsDpSiZwTzUBG2N+No2bsr7WMtBKCVJMSD6mbAl7YhKUqkp/Few==
 
+"@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz#f954f34355712212a8e06c465bc06c40852c6bb3"
+  integrity sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==
+
 "@msgpackr-extract/msgpackr-extract-linux-arm64@2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.1.2.tgz#22555e28382af2922e7450634c8a2f240bb9eb82"
   integrity sha512-vHZ2JiOWF2+DN9lzltGbhtQNzDo8fKFGrf37UJrgqxU0yvtERrzUugnfnX1wmVfFhSsF8OxrfqiNOUc5hko1Zg==
+
+"@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz#45c63037f045c2b15c44f80f0393fa24f9655367"
+  integrity sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==
 
 "@msgpackr-extract/msgpackr-extract-linux-arm@2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.1.2.tgz#ffb6ae1beea7ac572b6be6bf2a8e8162ebdd8be7"
   integrity sha512-42R4MAFeIeNn+L98qwxAt360bwzX2Kf0ZQkBBucJ2Ircza3asoY4CDbgiu9VWklq8gWJVSJSJBwDI+c/THiWkA==
 
+"@msgpackr-extract/msgpackr-extract-linux-arm@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz#35707efeafe6d22b3f373caf9e8775e8920d1399"
+  integrity sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==
+
 "@msgpackr-extract/msgpackr-extract-linux-x64@2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.1.2.tgz#7caf62eebbfb1345de40f75e89666b3d4194755f"
   integrity sha512-RjRoRxg7Q3kPAdUSC5EUUPlwfMkIVhmaRTIe+cqHbKrGZ4M6TyCA/b5qMaukQ/1CHWrqYY2FbKOAU8Hg0pQFzg==
 
+"@msgpackr-extract/msgpackr-extract-linux-x64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz#091b1218b66c341f532611477ef89e83f25fae4f"
+  integrity sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==
+
 "@msgpackr-extract/msgpackr-extract-win32-x64@2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.1.2.tgz#f2d8b9ddd8d191205ed26ce54aba3dfc5ae3e7c9"
   integrity sha512-rIZVR48zA8hGkHIK7ED6+ZiXsjRCcAVBJbm8o89OKAMTmEAQ2QvoOxoiu3w2isAaWwzgtQIOFIqHwvZDyLKCvw==
+
+"@msgpackr-extract/msgpackr-extract-win32-x64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz#0f164b726869f71da3c594171df5ebc1c4b0a407"
+  integrity sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -2707,6 +2767,11 @@ detect-libc@^2.0.0:
   resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz"
   integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
 
+detect-libc@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.2.tgz#8ccf2ba9315350e1241b88d0ac3b0e1fbd99605d"
+  integrity sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==
+
 diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz"
@@ -4258,6 +4323,24 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+lmdb@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/lmdb/-/lmdb-2.8.5.tgz#ce191110c755c0951caa062722e300c703973837"
+  integrity sha512-9bMdFfc80S+vSldBmG3HOuLVHnxRdNTlpzR6QDnzqCQtCzGUEAGTzBKYMeIM+I/sU4oZfgbcbS7X7F65/z/oxQ==
+  dependencies:
+    msgpackr "^1.9.5"
+    node-addon-api "^6.1.0"
+    node-gyp-build-optional-packages "5.1.1"
+    ordered-binary "^1.4.1"
+    weak-lru-cache "^1.2.2"
+  optionalDependencies:
+    "@lmdb/lmdb-darwin-arm64" "2.8.5"
+    "@lmdb/lmdb-darwin-x64" "2.8.5"
+    "@lmdb/lmdb-linux-arm" "2.8.5"
+    "@lmdb/lmdb-linux-arm64" "2.8.5"
+    "@lmdb/lmdb-linux-x64" "2.8.5"
+    "@lmdb/lmdb-win32-x64" "2.8.5"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -4617,12 +4700,33 @@ msgpackr-extract@^2.0.2:
     "@msgpackr-extract/msgpackr-extract-linux-x64" "2.1.2"
     "@msgpackr-extract/msgpackr-extract-win32-x64" "2.1.2"
 
+msgpackr-extract@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz#e05ec1bb4453ddf020551bcd5daaf0092a2c279d"
+  integrity sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==
+  dependencies:
+    node-gyp-build-optional-packages "5.0.7"
+  optionalDependencies:
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-darwin-x64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-linux-arm" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-linux-arm64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-linux-x64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-win32-x64" "3.0.2"
+
 msgpackr@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.6.2.tgz#176cd9f6b4437dad87a839b37f23c2dfee408d9a"
   integrity sha512-bqSQ0DYJbXbrJcrZFmMygUZmqQiDfI2ewFVWcrZY12w5XHWtPuW4WppDT/e63Uu311ajwkRRXSoF0uILroBeTA==
   optionalDependencies:
     msgpackr-extract "^2.0.2"
+
+msgpackr@^1.9.5:
+  version "1.9.9"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.9.9.tgz#ec71e37beb8729280847f683cb0a340eb35ce70f"
+  integrity sha512-sbn6mioS2w0lq1O6PpGtsv6Gy8roWM+o3o4Sqjd6DudrL/nOugY+KyJUimoWzHnf9OkO0T6broHFnYE/R05t9A==
+  optionalDependencies:
+    msgpackr-extract "^3.0.2"
 
 multer@^1.4.5-lts.1:
   version "1.4.5-lts.1"
@@ -4723,6 +4827,11 @@ node-addon-api@^2.0.0:
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
+node-addon-api@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"
+  integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
+
 node-cache@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz"
@@ -4741,6 +4850,18 @@ node-gyp-build-optional-packages@5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz#92a89d400352c44ad3975010368072b41ad66c17"
   integrity sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==
+
+node-gyp-build-optional-packages@5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz#5d2632bbde0ab2f6e22f1bbac2199b07244ae0b3"
+  integrity sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==
+
+node-gyp-build-optional-packages@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz#52b143b9dd77b7669073cbfe39e3f4118bfc603c"
+  integrity sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==
+  dependencies:
+    detect-libc "^2.0.1"
 
 node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   version "4.4.0"
@@ -4937,6 +5058,11 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
+
+ordered-binary@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/ordered-binary/-/ordered-binary-1.4.1.tgz#205cb6efd6c27fa0ef4eced994a023e081cdc911"
+  integrity sha512-9LtiGlPy982CsgxZvJGNNp2/NnrgEr6EAyN3iIEP3/8vd3YLgAZQHbQ75ZrkfBRGrNg37Dk3U6tuVb+B4Xfslg==
 
 os-homedir@^1.0.0:
   version "1.0.2"
@@ -6379,6 +6505,11 @@ wait@^0.4.2:
   version "0.4.2"
   resolved "https://registry.npmjs.org/wait/-/wait-0.4.2.tgz"
   integrity sha512-g4Uu25y9MJ3jtBcrRDDXeI/f7lBNtVmNUM3Xd78S19tm1gZutDkL/f6UEcMi/NqWvKZ74Mhrb+4LwpYbjG6XYA==
+
+weak-lru-cache@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz#fdbb6741f36bae9540d12f480ce8254060dccd19"
+  integrity sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Introduces new interface `KvBufferStore` which allows various implementations of key/buffer stores for header cache data. Initially implemented with `lmdb` but intended to be extend to also include `redis` in the near future.