### PR TITLE
PE-5037: FS cleanup worker

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -29,6 +29,8 @@ import * as system from './system.js';
 
 system.arweaveClient.refreshPeers();
 
+system.headerFsCacheCleanupWorker?.start();
+
 // Allow starting without writers to support SQLite replication
 if (config.START_WRITERS) {
   system.blockImporter.start();

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,5 +92,5 @@ export const REDIS_CACHE_TTL_SECONDS = +env.varOrDefault(
   'REDIS_CACHE_TTL_SECONDS',
   `${60 * 60 * 8}`, // 8 hours by default
 );
-export const ENABLE_HEADER_CLEANUP =
-  env.varOrDefault('ENABLE_HEADER_CLEANUP', 'false') === 'true';
+export const ENABLE_FS_HEADER_CACHE_CLEANUP =
+  env.varOrDefault('ENABLE_FS_HEADER_CACHE_CLEANUP', 'false') === 'true';

--- a/src/system.ts
+++ b/src/system.ts
@@ -56,6 +56,7 @@ import { Ans104Unbundler } from './workers/ans104-unbundler.js';
 import { BlockImporter } from './workers/block-importer.js';
 import { BundleRepairWorker } from './workers/bundle-repair-worker.js';
 import { DataItemIndexer } from './workers/data-item-indexer.js';
+import { FsCleanupWorker } from './workers/fs-cleanup-worker.js';
 import { TransactionFetcher } from './workers/transaction-fetcher.js';
 import { TransactionImporter } from './workers/transaction-importer.js';
 import { TransactionRepairWorker } from './workers/transaction-repair-worker.js';
@@ -123,6 +124,17 @@ export const blockImporter = new BlockImporter({
 eventEmitter.on(events.BLOCK_TX_INDEXED, (tx) => {
   eventEmitter.emit(events.TX_INDEXED, tx);
 });
+
+export const headerFsCacheCleanupWorker = config.ENABLE_FS_HEADER_CACHE_CLEANUP
+  ? new FsCleanupWorker({
+      log,
+      basePath: 'data/headers',
+      shouldDelete: async (path) => {
+        // Ignore .gitkeep
+        return !path.endsWith('.gitkeep');
+      },
+    })
+  : undefined;
 
 const ans104TxMatcher = new MatchTags([
   { name: 'Bundle-Format', value: 'binary' },

--- a/src/workers/fs-cleanup-worker.ts
+++ b/src/workers/fs-cleanup-worker.ts
@@ -1,0 +1,147 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import * as winston from 'winston';
+
+const DEFAULT_BATCH_SIZE = 1000;
+const DEFAULT_BATCH_PAUSE_DURATION = 1000 * 10;
+const DEFAULT_RESTART_PAUSE_DURATION = 1000 * 60 * 60 * 24;
+
+export class FsCleanupWorker {
+  // Dependencies
+  private log: winston.Logger;
+  private shouldDelete: (path: string) => Promise<boolean>;
+  private deleteCallback: (path: string) => Promise<void>;
+
+  private basePath: string;
+  private batchSize: number;
+  private pauseDuration: number;
+  private restartPauseDuration: number;
+
+  private shouldRun = true;
+  private lastPath: string | null = null;
+
+  constructor({
+    log,
+    basePath,
+    shouldDelete,
+    deleteCallback,
+    batchSize = DEFAULT_BATCH_SIZE,
+    pauseDuration = DEFAULT_BATCH_PAUSE_DURATION,
+    restartPauseDuration = DEFAULT_RESTART_PAUSE_DURATION,
+  }: {
+    log: winston.Logger;
+    basePath: string;
+    shouldDelete?: (path: string) => Promise<boolean>;
+    deleteCallback?: (path: string) => Promise<void>;
+    batchSize?: number;
+    pauseDuration?: number;
+    restartPauseDuration?: number;
+  }) {
+    this.log = log.child({ class: this.constructor.name });
+    this.shouldDelete = shouldDelete ?? (() => Promise.resolve(true));
+    this.deleteCallback =
+      deleteCallback ?? ((file: string) => fs.promises.unlink(file));
+
+    this.basePath = basePath;
+    this.lastPath = basePath;
+    this.batchSize = batchSize;
+    this.pauseDuration = pauseDuration;
+    this.restartPauseDuration = restartPauseDuration;
+  }
+
+  async start(): Promise<void> {
+    this.log.info('Starting worker');
+    while (this.shouldRun) {
+      try {
+        await this.processBatch();
+        await new Promise((resolve) => setTimeout(resolve, this.pauseDuration));
+      } catch (error: any) {
+        this.log.error('Error processing batch', {
+          error: error?.message,
+          stack: error?.stack,
+        });
+      }
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.log.info('Stopping worker');
+    this.shouldRun = false;
+  }
+
+  async processBatch(): Promise<void> {
+    const batch = await this.getBatch(this.basePath, this.lastPath);
+    if (batch.length === 0) {
+      this.log.info('No more files to delete, restarting from the base path');
+      this.lastPath = this.basePath;
+      await new Promise((resolve) =>
+        setTimeout(resolve, this.restartPauseDuration),
+      );
+      return;
+    }
+
+    this.log.info(`Deleting ${batch.length} files in ${this.basePath}}`);
+    await Promise.all(
+      batch.map((file) => {
+        if (this.deleteCallback !== undefined) {
+          return this.deleteCallback(file);
+        } else {
+          return fs.promises.unlink(file);
+        }
+      }),
+    );
+
+    this.lastPath = batch[batch.length - 1];
+  }
+
+  async getBatch(basePath: string, lastPath: string | null): Promise<string[]> {
+    const batch: string[] = [];
+    let totalFilesProcessed = 0;
+
+    const walk = async (dir: string) => {
+      const files = await fs.promises.readdir(dir, { withFileTypes: true });
+      files.sort((a, b) => a.name.localeCompare(b.name));
+
+      for (const file of files) {
+        if (totalFilesProcessed >= this.batchSize) break;
+
+        const fullPath = path.join(dir, file.name);
+        if (
+          lastPath !== null &&
+          (lastPath.startsWith(fullPath) || fullPath >= lastPath) &&
+          file.isDirectory()
+        ) {
+          await walk(fullPath);
+        } else {
+          if (lastPath === null || fullPath > lastPath) {
+            if (await this.shouldDelete(fullPath)) {
+              batch.push(fullPath);
+              totalFilesProcessed++;
+            }
+          }
+        }
+      }
+    };
+
+    await walk(basePath);
+
+    return batch;
+  }
+}


### PR DESCRIPTION
Now that we are using Redis as our default header cache, we would like to cleanup old headers on the filesystem. To accomplish that, this PR adds a generic filesystem cleanup worker and configures an instance of it to cleanup the files in data/headers.