### PR TITLE
feat(chain sqlite): index stable transaction data offsets PE-2482

### DIFF
--- a/migrations/2024.01.17T21.54.57.core.add-stable-transaction-offsets.sql
+++ b/migrations/2024.01.17T21.54.57.core.add-stable-transaction-offsets.sql
@@ -1,0 +1,5 @@
+ALTER TABLE stable_transactions ADD COLUMN offset INTEGER;
+
+CREATE INDEX IF NOT EXISTS stable_transactions_offset_idx
+  ON stable_transactions (offset)
+  WHERE format = 2 AND data_size > 0;

--- a/migrations/down/2024.01.17T21.54.57.core.add-stable-transaction-offsets.sql
+++ b/migrations/down/2024.01.17T21.54.57.core.add-stable-transaction-offsets.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS stable_transactions_offset_idx;
+ALTER TABLE stable_transactions DROP COLUMN offset;

--- a/src/app.ts
+++ b/src/app.ts
@@ -34,6 +34,7 @@ system.headerFsCacheCleanupWorker?.start();
 // Allow starting without writers to support SQLite replication
 if (config.START_WRITERS) {
   system.blockImporter.start();
+  system.txOffsetRepairWorker.start();
   system.txRepairWorker.start();
   system.bundleRepairWorker.start();
 }

--- a/src/database/sql/core/async-import.sql
+++ b/src/database/sql/core/async-import.sql
@@ -22,3 +22,16 @@ WHERE transaction_id = @transaction_id
     SELECT MAX(height)+1
     FROM stable_blocks
   )
+
+-- selectStableTransactionIdsMissingOffsets
+SELECT id
+FROM stable_transactions
+WHERE format = 2
+  AND data_size > 0
+  AND offset IS NULL
+LIMIT @limit
+
+-- updateStableTransactionOffset
+UPDATE stable_transactions
+SET "offset" = @offset
+WHERE id = @id

--- a/src/system.ts
+++ b/src/system.ts
@@ -42,6 +42,7 @@ import {
   BlockListValidator,
   BundleIndex,
   ChainIndex,
+  ChainOffsetIndex,
   ContiguousDataSource,
   ContiguousDataIndex,
   DataItemIndexWriter,
@@ -59,6 +60,8 @@ import { FsCleanupWorker } from './workers/fs-cleanup-worker.js';
 import { TransactionFetcher } from './workers/transaction-fetcher.js';
 import { TransactionImporter } from './workers/transaction-importer.js';
 import { TransactionRepairWorker } from './workers/transaction-repair-worker.js';
+import { TransactionOffsetImporter } from './workers/transaction-offset-importer.js';
+import { TransactionOffsetRepairWorker } from './workers/transaction-offset-repair-worker.js';
 
 process.on('uncaughtException', (error) => {
   metrics.uncaughtExceptionCounter.inc();
@@ -94,6 +97,7 @@ export const db = new StandaloneSqliteDatabase({
 });
 
 export const chainIndex: ChainIndex = db;
+export const chainOffsetIndex: ChainOffsetIndex = db;
 export const bundleIndex: BundleIndex = db;
 export const contiguousDataIndex: ContiguousDataIndex = db;
 export const blockListValidator: BlockListValidator = db;
@@ -185,6 +189,18 @@ export const txRepairWorker = new TransactionRepairWorker({
   log,
   chainIndex,
   txFetcher,
+});
+
+const txOffsetImporter = new TransactionOffsetImporter({
+  log,
+  chainSource: arweaveClient,
+  chainOffsetIndex,
+});
+
+export const txOffsetRepairWorker = new TransactionOffsetRepairWorker({
+  log,
+  chainOffsetIndex,
+  txOffsetIndexer: txOffsetImporter,
 });
 
 export const bundleRepairWorker = new BundleRepairWorker({

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -184,6 +184,11 @@ export interface ChainIndex {
   ): Promise<void>;
 }
 
+export interface ChainOffsetIndex {
+  getTxIdsMissingOffsets(limit: number): Promise<string[]>;
+  saveTxOffset(txId: string, offset: number): Promise<void>;
+}
+
 export interface BundleRecord {
   id: string;
   rootTransactionId?: string;

--- a/src/workers/transaction-fetcher.ts
+++ b/src/workers/transaction-fetcher.ts
@@ -86,7 +86,10 @@ export class TransactionFetcher {
         this.eventEmitter.emit(events.TX_FETCHED, tx);
         log.info('Transaction fetched.');
       } catch (error: any) {
-        log.warn('Failed to fetch transaction:', error);
+        log.warn('Failed to fetch transaction:', {
+          message: error?.message,
+          stack: error?.stack,
+        });
         await wait(this.retryWaitMs);
         attempts++;
       }

--- a/src/workers/transaction-offset-importer.ts
+++ b/src/workers/transaction-offset-importer.ts
@@ -1,0 +1,92 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { default as fastq } from 'fastq';
+import type { queueAsPromised } from 'fastq';
+import * as winston from 'winston';
+
+import { ChainOffsetIndex, ChainSource } from '../types.js';
+
+const DEFAULT_WORKER_COUNT = 10;
+const DEFAULT_MAX_QUEUE_SIZE = 1000;
+
+export class TransactionOffsetImporter {
+  // Dependencies
+  private log: winston.Logger;
+  private chainSource: ChainSource;
+  private chainOffsetIndex: ChainOffsetIndex;
+  private maxQueueSize: number;
+  private inprogressTxIds = new Set<string>();
+
+  // TX fetch queue
+  private queue: queueAsPromised<string, void>;
+
+  constructor({
+    log,
+    chainSource,
+    chainOffsetIndex,
+    workerCount = DEFAULT_WORKER_COUNT,
+    maxQueueSize = DEFAULT_MAX_QUEUE_SIZE,
+  }: {
+    log: winston.Logger;
+    chainSource: ChainSource;
+    chainOffsetIndex: ChainOffsetIndex;
+    workerCount?: number;
+    maxQueueSize?: number;
+  }) {
+    this.log = log.child({ class: this.constructor.name });
+    this.chainSource = chainSource;
+    this.chainOffsetIndex = chainOffsetIndex;
+    this.maxQueueSize = maxQueueSize;
+
+    // Initialize TX ID fetch queue
+    this.queue = fastq.promise(this.indexTxOffset.bind(this), workerCount);
+  }
+
+  async queueTxId(txId: string): Promise<void> {
+    const log = this.log.child({ method: 'queueTxId', txId });
+    if (this.inprogressTxIds.has(txId)) {
+      log.debug('Skipping offset indexing, already in progress.');
+    } else if (this.queue.length() >= this.maxQueueSize) {
+      log.debug('Skipping offset indexing, queue is full.');
+    } else {
+      this.inprogressTxIds.add(txId);
+      log.debug('Queueing transaction for offset indexing...');
+      this.queue.push(txId);
+      log.info('Transaction queued for offset indexing.');
+    }
+  }
+
+  async indexTxOffset(txId: string): Promise<void> {
+    const log = this.log.child({ txId });
+    try {
+      log.debug('Fetching transaction offset...');
+      const { offset } = await this.chainSource.getTxOffset(txId);
+      log.info('Transaction offset fetched.');
+
+      log.debug('Saving transaction offset...');
+      await this.chainOffsetIndex.saveTxOffset(txId, offset);
+      log.info('Transaction offset saved.');
+    } catch (error: any) {
+      log.warn('Failed to fetch transaction offset:', {
+        message: error?.message,
+        stack: error?.stack,
+      });
+    }
+    this.inprogressTxIds.delete(txId);
+  }
+}

--- a/src/workers/transaction-offset-repair-worker.ts
+++ b/src/workers/transaction-offset-repair-worker.ts
@@ -1,0 +1,65 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import * as winston from 'winston';
+
+import { ChainOffsetIndex } from '../types.js';
+import { TransactionOffsetImporter } from './transaction-offset-importer.js';
+
+const DEFAULT_TXS_PER_BATCH = 1000;
+const DEFAULT_INTERVAL_MS = 10 * 1000;
+
+export class TransactionOffsetRepairWorker {
+  // Dependencies
+  private log: winston.Logger;
+  private chainOffsetIndex: ChainOffsetIndex;
+  private txOffsetIndexer: TransactionOffsetImporter;
+
+  constructor({
+    log,
+    chainOffsetIndex,
+    txOffsetIndexer,
+  }: {
+    log: winston.Logger;
+    chainOffsetIndex: ChainOffsetIndex;
+    txOffsetIndexer: TransactionOffsetImporter;
+  }) {
+    this.log = log.child({ class: this.constructor.name });
+    this.chainOffsetIndex = chainOffsetIndex;
+    this.txOffsetIndexer = txOffsetIndexer;
+  }
+
+  async start(): Promise<void> {
+    this.fetchMissingOffsets();
+  }
+
+  async fetchMissingOffsets() {
+    try {
+      const txIds = await this.chainOffsetIndex.getTxIdsMissingOffsets(
+        DEFAULT_TXS_PER_BATCH,
+      );
+      for (const txId of txIds) {
+        this.log.debug('Queueing missing transaction for offset indexing...');
+        await this.txOffsetIndexer.queueTxId(txId);
+        this.log.info('Queued missing transaction for offset indexing.');
+      }
+    } catch (error: any) {
+      this.log.error('Error retrying missing transactions:', error);
+    }
+    setTimeout(this.fetchMissingOffsets.bind(this), DEFAULT_INTERVAL_MS);
+  }
+}

--- a/test/bundles-schema.sql
+++ b/test/bundles-schema.sql
@@ -136,5 +136,9 @@ CREATE INDEX bundles_last_fully_indexed_at_idx
   ON bundles (last_fully_indexed_at);
 CREATE INDEX bundles_matched_data_item_count_idx
   ON bundles (matched_data_item_count);
+CREATE INDEX bundles_unbundle_filter_id_idx
+  ON bundles (unbundle_filter_id);
+CREATE INDEX bundles_index_filter_id_idx
+  ON bundles (index_filter_id);
 CREATE INDEX bundle_data_items_parent_id_filter_id_idx
   ON bundle_data_items (parent_id, filter_id);

--- a/test/core-schema.sql
+++ b/test/core-schema.sql
@@ -36,7 +36,7 @@ CREATE TABLE stable_transactions (
 
   -- Metadata
   tag_count INTEGER NOT NULL
-);
+, offset INTEGER);
 CREATE INDEX stable_transactions_id_height_block_transaction_index_idx ON stable_transactions (height, block_transaction_index);
 CREATE INDEX stable_transactions_target_height_block_transaction_index_idx ON stable_transactions (target, height, block_transaction_index);
 CREATE INDEX stable_transactions_owner_address_height_block_transaction_index_idx ON stable_transactions (owner_address, height, block_transaction_index);
@@ -195,3 +195,6 @@ CREATE INDEX new_transaction_tags_height_created_at_idx ON new_transaction_tags 
 CREATE INDEX sable_block_transactions_transaction_id_idx
   ON stable_block_transactions (transaction_id);
 CREATE INDEX new_transaction_tags_transaction_id_idx ON new_transaction_tags (transaction_id);
+CREATE INDEX stable_transactions_offset_idx
+  ON stable_transactions (offset)
+  WHERE format = 2 AND data_size > 0;


### PR DESCRIPTION
This change adds an 'offset' column to the stable_transactions table and a worker process that queries for missing offsets in the DB and fetches them from Arweave nodes. Queries for missing offsets are made efficient through the use of a partial index on the 'offset' where 'format' is 2 and 'data_size' is greater than 0 since those are the only transactions that should have offsets. For simplicity we currently only index offsets for stable transactions given they represent the bulk of the data.

The offset index can be used in the future for serving chunks requested by absolute offset directly from contiguous data sources.