### PR TITLE
Add action to archive codebase on Arweave

### DIFF
--- a/.github/workflows/archive-codebase-to-arweave.yml
+++ b/.github/workflows/archive-codebase-to-arweave.yml
@@ -1,0 +1,29 @@
+name: Archive 
+on:
+    workflow_dispatch:
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: 'Checkout repo (default branch)'
+              uses: actions/checkout@v3
+              with:
+                  # fetch all history for all branches:
+                  fetch-depth: 0
+            - name: 'Checkout all branches'
+              run: |
+                  default_branch=$(git branch | grep '*' | sed 's/\* //')
+                  for abranch in $(git branch -a | grep -v HEAD | grep remotes | sed "s/remotes\/origin\///g"); do git checkout $abranch ; done
+                  git checkout $default_branch
+                  git branch -a
+            - name: 'Setup node 18'
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18.x
+            - name: 'Sync repo to Protocol Land'
+              run: npx @protocol.land/sync@0.1.4
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  REPO_TITLE: ${{ github.event.repository.name }}
+                  REPO_DESCRIPTION: ${{ github.event.repository.description }}
+                  WALLET: ${{ secrets.WALLET }}


### PR DESCRIPTION
This PR Adds Github action workflow that uses [Protocol.Land](https://protocol.land) and its [tools](https://github.com/labscommunity/protocol-land-sync) to archive entire codebase on Arweave.

This workflow depends on `WALLET` (arweave wallet JWK) added to the repo secrets with sufficient funds to be able to upload archive on Arweave.

Currently workflow has to be triggered manually, but I'm happy to adjust that in the action if this needs to run based on a condition like merge to master.
