### PR TITLE
chore(PE-5507): bump observer to latest image and add warp cache vol…

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,7 +85,7 @@ services:
     volumes:
       - ${TEMP_DATA_PATH:-./data/tmp}:/app/data/tmp
       - ${REPORTS_DATA_PATH:-./data/reports}:/app/data/reports
-      - ${WARP_CACHE_PATH:./cache/warp}:/app/cache/warp
+      - ${WARP_CACHE_PATH:-./cache/warp}:/app/cache/warp
       - ${WALLETS_PATH:-./wallets}:/app/wallets
     environment:
       - PORT=5000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,13 +78,14 @@ services:
       - ${REDIS_DATA_PATH:-./data/redis}:/data
 
   observer:
-    image: ghcr.io/ar-io/ar-io-observer:${OBSERVER_IMAGE_TAG:-39783cb6ab7586a443b0b3907e18b5cca914e72d}
+    image: ghcr.io/ar-io/ar-io-observer:${OBSERVER_IMAGE_TAG:-5bad8c827fe19158f61c4aab090e37899b5e5328}
     restart: on-failure:5
     ports:
       - 5000:5000
     volumes:
       - ${TEMP_DATA_PATH:-./data/tmp}:/app/data/tmp
       - ${REPORTS_DATA_PATH:-./data/reports}:/app/data/reports
+      - ${WARP_CACHE_PATH:./cache/warp}:/app/cache/warp
       - ${WALLETS_PATH:-./wallets}:/app/wallets
     environment:
       - PORT=5000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,7 +85,7 @@ services:
     volumes:
       - ${TEMP_DATA_PATH:-./data/tmp}:/app/data/tmp
       - ${REPORTS_DATA_PATH:-./data/reports}:/app/data/reports
-      - ${WARP_CACHE_PATH:-./cache/warp}:/app/cache/warp
+      - ${WARP_CACHE_PATH:-./data/warp/cache}:/app/cache/warp
       - ${WALLETS_PATH:-./wallets}:/app/wallets
     environment:
       - PORT=5000


### PR DESCRIPTION
…ume to docker-compose

This version of the observer uses lmdb as its contract store for improved performance. The volume allows the observer to persist cache accross restarts