### PR TITLE
Add protocol.land published badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AR.IO Gateway Node
 
 [![codecov](https://codecov.io/gh/ar-io/ar-io-node/graph/badge.svg?token=F3BJ7W74HY)](https://codecov.io/gh/ar-io/ar-io-node)
+[![protocol.land](https://arweave.net/eZp8gOeR8Yl_cyH9jJToaCrt2He1PHr0pR4o-mHbEcY)](https://protocol.land/#/repository/713c1b6f-86c8-493e-b2e6-6cb231862b93)
 
 ## Getting Started
 


### PR DESCRIPTION
This PR adds Published on protocol.land badge to the README.

![pl-badge](https://github.com/ar-io/ar-io-node/assets/57343520/602301a9-414b-472c-99ca-78326bd60e75)
