### PR TITLE
fix(data sqlite): fix method names in circuit break queueRead calls

### DIFF
--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -2266,7 +2266,7 @@ export class StandaloneSqliteDatabase
       (id: string) => {
         return this.queueRead(
           'data',
-          `${this.constructor.name}.getDataParent`,
+          `getDataParent`,
           [id],
         );
       },
@@ -2280,7 +2280,7 @@ export class StandaloneSqliteDatabase
       (id: string) => {
         return this.queueRead(
           'data',
-          `${this.constructor.name}.getDataAttributes`,
+          `getDataAttributes`,
           [id],
         );
       },


### PR DESCRIPTION
The names were incorrectly prefixed with the class name. This in turn caused reading from the cache to fail. This change fixes the prefix to resolve the caching issue.