### PR TITLE
feat(farcaster): add initial frame support

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -50,7 +50,13 @@ tags:
       Get data from the AR.IO Gateway index using GQL
   - name: Admin
     description: |
-      Access several password protected features and functions specific to your AR.IO Gateway.  
+      Access several password protected features and functions specific to your AR.IO Gateway.
+  - name: Admin
+    description: |
+      Access several password protected features and functions specific to your AR.IO Gateway.
+  - name: Farcaster Frames
+    description: |
+      Retrieve and interact with Farcaster Frames using Arweave transactions.
 components:
   securitySchemes:
     bearerAuth:
@@ -735,8 +741,8 @@ paths:
     put:
       tags: [Admin]
       summary: Blocks transactions or data-items so your AR.IO Gateway will not serve them.
-      description: | 
-        Submits a TX ID/data-item ID or sha-256 content hash for content you do not want your AR.IO Gateway to serve. Once submitted, your Gateway will not respond to requests for these transactions or data-items.  
+      description: |
+        Submits a TX ID/data-item ID or sha-256 content hash for content you do not want your AR.IO Gateway to serve. Once submitted, your Gateway will not respond to requests for these transactions or data-items.
 
 
         WARNING - Testing a TX ID here WILL result in that data being blocked by your Gateway.
@@ -770,3 +776,42 @@ paths:
           description: Unauthorized, API key likely incorrect.
       security:
         - bearerAuth: []
+  '/local/farcaster/frame/{txId}':
+    get:
+      tags: [Farcaster Frames]
+      summary: Get transaction.
+      description: Get the content of a specified transaction.
+      parameters:
+        - name: txId
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^[0-9a-zA-Z_-]{43}$'
+      responses:
+        '200':
+          description: |-
+            Successful operation.
+          content:
+            application/json:
+              schema:
+                '$ref': '#/components/schemas/Transaction'
+    post:
+      tags: [Farcaster Frames]
+      summary: Get transaction.
+      description: Get the content of a specified transaction.
+      parameters:
+        - name: txId
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^[0-9a-zA-Z_-]{43}$'
+      responses:
+        '200':
+          description: |-
+            Successful operation.
+          content:
+            application/json:
+              schema:
+                '$ref': '#/components/schemas/Transaction'

--- a/envoy/envoy.template.yaml
+++ b/envoy/envoy.template.yaml
@@ -96,6 +96,16 @@ static_resources:
                             retry_policy:
                               retry_on: '5xx,reset'
                               num_retries: 5
+                        - match:
+                            safe_regex:
+                              google_re2: { max_program_size: 200 }
+                              regex: '^\/local\/farcaster\/frame\/[a-zA-Z0-9_-]{43}$'
+                          route:
+                            timeout: 0s
+                            cluster: ario_gateways
+                            retry_policy:
+                              retry_on: '5xx,reset'
+                              num_retries: 5
                         - match: { prefix: '/' }
                           response_headers_to_add:
                             - header:

--- a/src/routes/data/index.ts
+++ b/src/routes/data/index.ts
@@ -24,6 +24,8 @@ import { createDataHandler, createRawDataHandler } from './handlers.js';
 const DATA_PATH_REGEX =
   /^\/?([a-zA-Z0-9-_]{43})\/?$|^\/?([a-zA-Z0-9-_]{43})\/(.*)$/i;
 const RAW_DATA_PATH_REGEX = /^\/raw\/([a-zA-Z0-9-_]{43})\/?$/i;
+const FARCASTER_FRAME_DATA_PATH_REGEX =
+  /^\/local\/farcaster\/frame\/([a-zA-Z0-9-_]{43})\/?$/i;
 
 // Used by ArNS Router
 export const dataHandler = createDataHandler({
@@ -45,3 +47,5 @@ dataRouter.get(
     blockListValidator: system.blockListValidator,
   }),
 );
+dataRouter.get(FARCASTER_FRAME_DATA_PATH_REGEX, dataHandler);
+dataRouter.post(FARCASTER_FRAME_DATA_PATH_REGEX, dataHandler);


### PR DESCRIPTION
ar.io gateways now support (GET and POST) calls to /local/farcaster/frame/<txId>