### PR TITLE
feat(PE-5859): support standalone arns-resolver

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,6 +70,8 @@ services:
       - WEBHOOK_TARGET_SERVERS=${WEBHOOK_TARGET_SERVERS:-}
       - WEBHOOK_INDEX_FILTER=${WEBHOOK_INDEX_FILTER:-}
       - CONTIGUOUS_DATA_CACHE_CLEANUP_THRESHOLD=${CONTIGUOUS_DATA_CACHE_CLEANUP_THRESHOLD:-}
+      - TRUSTED_ARNS_RESOLVER_TYPE=${TRUSTED_ARNS_RESOLVER_TYPE:-gateway}
+      - TRUSTED_ARNS_RESOLVER_URL=${TRUSTED_ARNS_RESOLVER_URL:-https://__NAME__.arweave.dev}
     depends_on:
       - redis
 
@@ -103,3 +105,19 @@ services:
       - RUN_OBSERVER=${RUN_OBSERVER:-true}
       - MIN_RELEASE_NUMBER=${MIN_RELEASE_NUMBER:-0}
       - AR_IO_NODE_RELEASE=${AR_IO_NODE_RELEASE:-9-pre}
+
+  resolver:
+    image: ghcr.io/ar-io/arns-resolver:${RESOLVER_IMAGE_TAG:-latest}
+    restart: on-failure:5
+    ports:
+      - 6000:6000
+    environment:
+      - PORT=6000
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - CONTRACT_TX_ID=${CONTRACT_ID:-}
+      - RUN_RESOLVER=${RUN_RESOLVER:-false}
+      - EVALUATION_INTERVAL_MS=${EVALUATION_INTERVAL_MS:-}
+      - CONTRACT_CACHE_URL=${CONTRACT_CACHE_URL:-}
+      - ARNS_CACHE_PATH=${ARNS_CACHE_PATH:-./data/arns}
+    volumes:
+      - ${ARNS_CACHE_PATH:-./data/arns}:/app/data/arns

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,12 +57,6 @@ export const TRUSTED_GATEWAY_URL = env.varOrDefault(
   'https://arweave.net',
 );
 
-// Trusted ArNS gateway URL (for resolving ArNS names)
-export const TRUSTED_ARNS_GATEWAY_URL = env.varOrDefault(
-  'TRUSTED_ARNS_GATEWAY_URL',
-  'https://__NAME__.arweave.dev',
-);
-
 //
 // Data
 //
@@ -194,6 +188,25 @@ export const WEBHOOK_INDEX_FILTER_STRING = canonicalize(
 );
 export const WEBHOOK_INDEX_FILTER = createFilter(
   JSON.parse(WEBHOOK_INDEX_FILTER_STRING),
+);
+
+//
+// ArNS Resolution
+//
+
+export const TRUSTED_ARNS_GATEWAY_URL = env.varOrDefault(
+  'TRUSTED_ARNS_GATEWAY_URL',
+  'https://__NAME__.arweave.dev',
+);
+
+export const TRUSTED_ARNS_RESOLVER_TYPE = env.varOrDefault(
+  'TRUSTED_ARNS_RESOLVER_TYPE',
+  'gateway',
+);
+
+export const TRUSTED_ARNS_RESOLVER_URL = env.varOrDefault(
+  'TRUSTED_ARNS_RESOLVER_URL',
+  TRUSTED_ARNS_GATEWAY_URL,
 );
 
 //

--- a/src/init/resolvers.ts
+++ b/src/init/resolvers.ts
@@ -1,0 +1,50 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Logger } from 'winston';
+import { StandaloneArNSResolver } from '../resolution/standalone-arns-resolver.js';
+import { TrustedGatewayArNSResolver } from '../resolution/trusted-gateway-arns-resolver.js';
+import { NameResolver } from '../types.js';
+
+export const createArNSResolver = ({
+  log,
+  type,
+  url,
+}: {
+  log: Logger;
+  type: string;
+  url: string;
+}): NameResolver => {
+  log.info(`Using ${type} for arns name resolution`);
+  switch (type) {
+    case 'resolver': {
+      return new StandaloneArNSResolver({
+        log,
+        resolverUrl: url,
+      });
+    }
+    case 'gateway': {
+      return new TrustedGatewayArNSResolver({
+        log,
+        trustedGatewayUrl: url,
+      });
+    }
+    default: {
+      throw new Error(`Unknown ArNSResolver type: ${type}`);
+    }
+  }
+};

--- a/src/system.ts
+++ b/src/system.ts
@@ -38,7 +38,6 @@ import log from './log.js';
 import * as metrics from './metrics.js';
 import { MemoryCacheArNSResolver } from './resolution/memory-cache-arns-resolver.js';
 import { StreamingManifestPathResolver } from './resolution/streaming-manifest-path-resolver.js';
-import { TrustedGatewayArNSResolver } from './resolution/trusted-gateway-arns-resolver.js';
 import { FsChunkDataStore } from './store/fs-chunk-data-store.js';
 import { FsDataStore } from './store/fs-data-store.js';
 import {
@@ -66,6 +65,7 @@ import { TransactionRepairWorker } from './workers/transaction-repair-worker.js'
 import { TransactionOffsetImporter } from './workers/transaction-offset-importer.js';
 import { TransactionOffsetRepairWorker } from './workers/transaction-offset-repair-worker.js';
 import { WebhookEmitter } from './workers/webhook-emitter.js';
+import { createArNSResolver } from './init/resolvers.js';
 
 process.on('uncaughtException', (error) => {
   metrics.uncaughtExceptionCounter.inc();
@@ -390,9 +390,10 @@ export const manifestPathResolver = new StreamingManifestPathResolver({
 
 export const nameResolver = new MemoryCacheArNSResolver({
   log,
-  resolver: new TrustedGatewayArNSResolver({
+  resolver: createArNSResolver({
     log,
-    trustedGatewayUrl: config.TRUSTED_ARNS_GATEWAY_URL,
+    type: config.TRUSTED_ARNS_RESOLVER_TYPE,
+    url: config.TRUSTED_ARNS_RESOLVER_URL,
   }),
 });
 


### PR DESCRIPTION
Implements the `NameResolver` interface in the `StandaloneArNSResolver` class whucg  arns name data from locally hosted arns-resolver service. Continues to use gateway by default - but allows for configurability via two new environment variables to select which resolver service to use. The changes do not remove any env vars or change default behavior. Additionally, the APIs on the arns-resolver service follow existing patterns and can be added to the envoy template once testing validates the expected behavior.