### PR TITLE
docs: add comments describing events PE-5900

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -16,19 +16,56 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const ANS104_BUNDLE_INDEXED = 'ans104-bundle-indexed';
-export const ANS104_DATA_ITEM_BUNDLE_MATCHED =
-  'ans104-data-item-bundle-matched';
-export const ANS104_DATA_ITEM_DATA_INDEXED = 'ans104-data-item-data-indexed';
-export const ANS104_DATA_ITEM_INDEXED = 'ans104-data-item-indexed';
-export const ANS104_DATA_ITEM_MATCHED = 'ans104-data-item-matched';
-export const ANS104_NESTED_BUNDLE_INDEXED = 'ans104-nested-bundle-indexed';
-export const ANS104_TX_INDEXED = 'ans104-tx-indexed';
-export const ANS104_UNBUNDLE_COMPLETE = 'ans104-unbundle-complete';
+//==============================================================================
+// Arweave chain fetching and indexing
+//==============================================================================
+
+/** An Arweave block was fetched from the network */
 export const BLOCK_FETCHED = 'block-fetched';
+
+/** An Arweave block was indexed */
 export const BLOCK_INDEXED = 'block-indexed';
+
+/** An Arweave TX from a mined block was fetched from the network */
 export const BLOCK_TX_FETCHED = 'block-tx-fetched';
+
+/** An error occurred while fetching an Arweave TX for a mined block */
 export const BLOCK_TX_FETCH_FAILED = 'block-tx-fetch-failed';
+
+/** An Arweave TX from a mined block was indexed */
 export const BLOCK_TX_INDEXED = 'block-tx-indexed';
+
+/** An Arweave TX was fetch asynchonously from the network */
 export const TX_FETCHED = 'tx-fetched';
+
+/** An Arweave TX was indexed */
 export const TX_INDEXED = 'tx-indexed';
+
+//==============================================================================
+// ANS-104 bundle matching and unbundling
+//==============================================================================
+
+/** An Arweave TX containing an ANS-104 bundle was indexed */
+export const ANS104_TX_INDEXED = 'ans104-tx-indexed';
+
+/** A transaction or data item containing an ANS-104 bundle was indexed */
+export const ANS104_BUNDLE_INDEXED = 'ans104-bundle-indexed';
+
+/** An ANS-104 data item that contains a bundle was indexed */
+export const ANS104_NESTED_BUNDLE_INDEXED = 'ans104-nested-bundle-indexed';
+
+/** An ANS-104 bundle was fully unbundled */
+export const ANS104_UNBUNDLE_COMPLETE = 'ans104-unbundle-complete';
+
+//==============================================================================
+// ANS-104 data item matching and indexing
+//==============================================================================
+
+/** A data item matching the ANS-104 indexing filter was unbundled */
+export const ANS104_DATA_ITEM_MATCHED = 'ans104-data-item-matched';
+
+/** Data item metadata (tags, owner, etc.) was indexed */
+export const ANS104_DATA_ITEM_INDEXED = 'ans104-data-item-indexed';
+
+/** Data item data (hash, offset, size, etc.) was indexed */
+export const ANS104_DATA_ITEM_DATA_INDEXED = 'ans104-data-item-data-indexed';


### PR DESCRIPTION
Groups events and adds descriptive comments for them. JSDoc style comments are used so that they show up as LSP hover text. @constant annotations were omitted since they seem redundant, but we can add them though if there's utity in doing so.