### PR TITLE
Fix CodeDeploy BeforeInstall script

### DIFF
--- a/scripts/codedeploy/before-install
+++ b/scripts/codedeploy/before-install
@@ -5,6 +5,11 @@ set -e
 
 cd /opt/ar-io-node
 
+# ensure containers are shut down
+if [ "$(docker ps -q)" ]; then
+  docker-compose down
+fi
+
 # cleanup existing files that might conflict on first deploy
 shopt -s extglob
 rm -rf .!(env) || true
@@ -16,15 +21,12 @@ instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 mkdir -p /efs/backups/$instance_id/sqlite/previous-before-install
 mkdir -p /efs/backups/$instance_id/sqlite/before-install
 
-# ensure containers are shut down
-if [ "$(docker ps -q)" ]; then
-  docker-compose down
-fi
-
 # keep an archive of the previous backup in case the copy fails
 if [ "$(ls /efs/backups/$instance_id/before-install/*.db)" ]; then
   mv /efs/backups/$instance_id/before-install/* /efs/backups/$instance_id/previous-before-install/
 fi
 
 # copy the live DBs to the backup directory
-cp /data/sqlite/*.db /efs/backups/$instance_id/sqlite/before-install/
+if [ "$(ls /data/sqlite/*.db)" ]; then
+  cp /data/sqlite/*.db /efs/backups/$instance_id/sqlite/before-install/
+fi


### PR DESCRIPTION
- Calling docker-compose before deleting `docker-compose.yaml`
- Checking that DB files exist before attempting a copy