### PR TITLE
chore(imports): use proper import convention in kv stores for types.js

### DIFF
--- a/src/store/fs-kv-store.ts
+++ b/src/store/fs-kv-store.ts
@@ -18,7 +18,7 @@
 import fse from 'fs-extra';
 import fs from 'node:fs';
 
-import { KVBufferStore } from '../types';
+import { KVBufferStore } from '../types.js';
 
 export class FsKVStore implements KVBufferStore {
   private baseDir: string;

--- a/src/store/lmdb-kv-store.ts
+++ b/src/store/lmdb-kv-store.ts
@@ -17,7 +17,7 @@
  */
 import { RootDatabase, open } from 'lmdb';
 
-import { KVBufferStore } from '../types';
+import { KVBufferStore } from '../types.js';
 
 export class LmdbKVStore implements KVBufferStore {
   private db: RootDatabase<Buffer, string>;


### PR DESCRIPTION
This is not breaking, but if we're to upgrade our tsconfig to use `NodeNext` these will error.