### PR TITLE
feat(localstack): use persisted state by default PE-6154

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,3 @@ test-results.xml
 
 # Exceptions
 !/data/.gitkeep
-
-# Localstack
-volume/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -237,8 +237,10 @@ services:
       - NODE_ENV=${NODE_ENV:-local}
       - ARWEAVE_WALLET=${ARWEAVE_WALLET:-$BUNDLER_ARWEAVE_WALLET}
       - TURBO_OPTICAL_KEY=${TURBO_OPTICAL_KEY:-$BUNDLER_ARWEAVE_WALLET}
+      - PERSIST_DEFAULT=${PERSIST_LOCALSTACK:-1} # set to 0 to disable persistence of resources and s3 objects between restarts
     volumes:
       - '${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack'
+      - '${LOCALSTACK_VOLUME_DIR:-./volume}:/persisted-data'
       - '/var/run/docker.sock:/var/run/docker.sock'
     healthcheck:
       test:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -225,7 +225,6 @@ services:
     profiles: ['bundler']
 
   localstack:
-    container_name: '${LOCALSTACK_DOCKER_NAME:-localstack}'
     image: ghcr.io/ardriveapp/turbo-upload-service-localstack:${UPLOAD_SERVICE_IMAGE_TAG:-latest}
     ports:
       - '127.0.0.1:4566:4566'
@@ -239,8 +238,8 @@ services:
       - TURBO_OPTICAL_KEY=${TURBO_OPTICAL_KEY:-$BUNDLER_ARWEAVE_WALLET}
       - PERSIST_DEFAULT=${PERSIST_LOCALSTACK:-1} # set to 0 to disable persistence of resources and s3 objects between restarts
     volumes:
-      - '${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack'
-      - '${LOCALSTACK_VOLUME_DIR:-./volume}:/persisted-data'
+      - '${LOCALSTACK_VOLUME_DIR:-./data/localstack}:/var/lib/localstack'
+      - '${LOCALSTACK_VOLUME_DIR:-./data/localstack}:/persisted-data'
       - '/var/run/docker.sock:/var/run/docker.sock'
     healthcheck:
       test:


### PR DESCRIPTION
This PR updates the docker compose to take advantage of persisted localstack state between docker compose. This way, the sidecar bundler pipeline can continue to access data items and bundles that may be in flight during restarts