### PR TITLE
feat(queue data item): init admin route for accepting data item headers before they are bundled PE-6220

### DIFF
--- a/src/database/sql/bundles/import.sql
+++ b/src/database/sql/bundles/import.sql
@@ -99,5 +99,4 @@ UPDATE SET
   height = IFNULL(@height, height),
   root_transaction_id = @root_transaction_id,
   parent_id = @parent_id,
-  data_offset = @data_offset,
-  indexed_at = @indexed_at
+  data_offset = @data_offset

--- a/src/database/sql/bundles/import.sql
+++ b/src/database/sql/bundles/import.sql
@@ -97,4 +97,7 @@ INSERT INTO new_data_items (
 ) ON CONFLICT DO
 UPDATE SET
   height = IFNULL(@height, height),
-  root_transaction_id = @root_transaction_id
+  root_transaction_id = @root_transaction_id,
+  parent_id = @parent_id,
+  data_offset = @data_offset,
+  indexed_at = @indexed_at

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -526,6 +526,12 @@ export class StandaloneSqliteDatabaseWorker {
 
         this.stmts.bundles.upsertNewDataItem.run({
           ...rows.newDataItem,
+          root_id: item.root_tx_id,
+          parent_id: item.parent_id,
+          index: item.index,
+          parent_index: item.parent_index,
+          data_hash: item.data_hash,
+          data_offset: item.data_offset,
           height,
         });
       },

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -309,7 +309,7 @@ export function dataItemToDbRows(item: NormalizedDataItem, height?: number) {
       target: fromB64Url(item.target),
       data_offset: item.data_offset,
       data_size: item.data_size,
-      content_type: contentType,
+      content_type: contentType ?? item.content_type,
       tag_count: item.tags.length,
       indexed_at: currentUnixTimestamp(),
     },

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -526,12 +526,6 @@ export class StandaloneSqliteDatabaseWorker {
 
         this.stmts.bundles.upsertNewDataItem.run({
           ...rows.newDataItem,
-          root_id: item.root_tx_id,
-          parent_id: item.parent_id,
-          index: item.index,
-          parent_index: item.parent_index,
-          data_hash: item.data_hash,
-          data_offset: item.data_offset,
           height,
         });
       },

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -179,8 +179,6 @@ arIoRouter.post(
         system.dataItemIndexer.queueDataItem({
           ...dataItemHeader,
           tags: dataItemHeader.tags ?? [],
-          content_type:
-            dataItemHeader.content_type ?? 'application/octet-stream',
           target: dataItemHeader.target ?? '',
           anchor: dataItemHeader.anchor ?? '',
           // These fields are not yet known, to be backfilled

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -129,6 +129,19 @@ arIoRouter.post(
   },
 );
 
+/** Accepted in queue data item route fields as normalized b64 */
+export interface QueueDataItemHeaders {
+  data_size: number;
+  id: string;
+  owner: string; // data item signer's public key
+  owner_address: string; // normalized address
+  signature: string;
+  tags?: { name: string; value: string }[];
+  content_type?: string;
+  target?: string;
+  anchor?: string;
+}
+
 /** Type guard for ensuring required fields on incoming data item headers */
 export function isDataItemHeaders(
   dataItemHeader: unknown,
@@ -136,29 +149,12 @@ export function isDataItemHeaders(
   return (
     typeof dataItemHeader === 'object' &&
     dataItemHeader !== null &&
-    'content_type' in dataItemHeader &&
     'data_size' in dataItemHeader &&
     'id' in dataItemHeader &&
     'owner' in dataItemHeader &&
     'owner_address' in dataItemHeader &&
-    'signature' in dataItemHeader &&
-    'tags' in dataItemHeader &&
-    'target' in dataItemHeader &&
-    'anchor' in dataItemHeader
+    'signature' in dataItemHeader
   );
-}
-
-/** Accepted in queue data item route fields as normalized b64 */
-export interface QueueDataItemHeaders {
-  content_type: string;
-  data_size: number;
-  id: string;
-  owner: string; // data item signer's public key
-  owner_address: string; // normalized address
-  signature: string;
-  tags: { name: string; value: string }[];
-  target: string;
-  anchor: string;
 }
 
 // Queue a bundle for processing
@@ -182,6 +178,11 @@ arIoRouter.post(
       for (const dataItemHeader of dataItemHeaders) {
         system.dataItemIndexer.queueDataItem({
           ...dataItemHeader,
+          tags: dataItemHeader.tags ?? [],
+          content_type:
+            dataItemHeader.content_type ?? 'application/octet-stream',
+          target: dataItemHeader.target ?? '',
+          anchor: dataItemHeader.anchor ?? '',
           // These fields are not yet known, to be backfilled
           parent_id: 'AA',
           root_tx_id: 'AA',

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -22,7 +22,6 @@ import * as config from '../config.js';
 import * as system from '../system.js';
 import * as events from '../events.js';
 import { release } from '../version.js';
-import { QueueDataItemHeaders } from '../types.js';
 
 export const arIoRouter = Router();
 
@@ -147,6 +146,19 @@ export function isDataItemHeaders(
     'target' in dataItemHeader &&
     'anchor' in dataItemHeader
   );
+}
+
+/** Accepted in queue data item route fields as normalized b64 */
+export interface QueueDataItemHeaders {
+  content_type: string;
+  data_size: number;
+  id: string;
+  owner: string; // data item signer's public key
+  owner_address: string; // normalized address
+  signature: string;
+  tags: { name: string; value: string }[];
+  target: string;
+  anchor: string;
 }
 
 // Queue a bundle for processing

--- a/src/system.ts
+++ b/src/system.ts
@@ -392,7 +392,7 @@ eventEmitter.on(events.ANS104_UNBUNDLE_COMPLETE, async (bundleEvent: any) => {
   }
 });
 
-const dataItemIndexer = new DataItemIndexer({
+export const dataItemIndexer = new DataItemIndexer({
   log,
   eventEmitter,
   indexWriter: dataItemIndexWriter,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -542,22 +542,3 @@ export interface QueueDataItemHeaders {
   target: string;
   anchor: string;
 }
-
-/** Type guard for ensuring required fields on data item headers */
-export function isDataItemHeaders(
-  dataItemHeader: unknown,
-): dataItemHeader is DataItemHeaders {
-  return (
-    typeof dataItemHeader === 'object' &&
-    dataItemHeader !== null &&
-    'content_type' in dataItemHeader &&
-    'data_size' in dataItemHeader &&
-    'id' in dataItemHeader &&
-    'owner' in dataItemHeader &&
-    'owner_address' in dataItemHeader &&
-    'signature' in dataItemHeader &&
-    'tags' in dataItemHeader &&
-    'target' in dataItemHeader &&
-    'anchor' in dataItemHeader
-  );
-}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -529,16 +529,3 @@ export type KVBufferStore = {
   del(key: string): Promise<void>;
   has(key: string): Promise<boolean>;
 };
-
-/** Accepted in queue data item route fields as normalized b64 */
-export interface QueueDataItemHeaders {
-  content_type: string;
-  data_size: number;
-  id: string;
-  owner: string; // data item signer's public key
-  owner_address: string; // normalized address
-  signature: string;
-  tags: { name: string; value: string }[];
-  target: string;
-  anchor: string;
-}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -529,3 +529,35 @@ export type KVBufferStore = {
   del(key: string): Promise<void>;
   has(key: string): Promise<boolean>;
 };
+
+/** Accepted in queue data item route fields as normalized b64 */
+export interface QueueDataItemHeaders {
+  content_type: string;
+  data_size: number;
+  id: string;
+  owner: string; // data item signer's public key
+  owner_address: string; // normalized address
+  signature: string;
+  tags: { name: string; value: string }[];
+  target: string;
+  anchor: string;
+}
+
+/** Type guard for ensuring required fields on data item headers */
+export function isDataItemHeaders(
+  dataItemHeader: unknown,
+): dataItemHeader is DataItemHeaders {
+  return (
+    typeof dataItemHeader === 'object' &&
+    dataItemHeader !== null &&
+    'content_type' in dataItemHeader &&
+    'data_size' in dataItemHeader &&
+    'id' in dataItemHeader &&
+    'owner' in dataItemHeader &&
+    'owner_address' in dataItemHeader &&
+    'signature' in dataItemHeader &&
+    'tags' in dataItemHeader &&
+    'target' in dataItemHeader &&
+    'anchor' in dataItemHeader
+  );
+}

--- a/test/end-to-end/indexing.test.ts
+++ b/test/end-to-end/indexing.test.ts
@@ -510,7 +510,7 @@ describe('Indexing', function () {
       compose = await composeUp();
       bundlesDb = new Sqlite(`${projectRootPath}/data/sqlite/bundles.db`);
 
-      const res = await axios({
+      await axios({
         method: 'post',
         url: 'http://localhost:4000/ar-io/admin/queue-data-item',
         headers: {
@@ -533,9 +533,7 @@ describe('Indexing', function () {
             ],
           },
         ],
-        validateStatus: () => true,
       });
-      console.log(res.data);
 
       await waitForIndexing();
     });


### PR DESCRIPTION
This PR adds a queue data item admin endpoint 


would still like to add E2E tests and tests around upsert


manual test example:

```sh

curl -X POST http://localhost:3000/ar-io/admin/queue-data-item \
  -H "Authorization: Bearer secret" \
  -H "Content-Type: application/json" \
  -d '[{
      "id": "cTbz16hHhGW4HF-uMJ5u8RoCg9atYmyMFWGd-kzhF_Q",
      "owner": "owner",
      "owner_address": "owner_address",
      "signature": "signature",
      "target": "target",
      "anchor": "anchor",
      "content_type": "content_type",
      "data_size": 1234,
      "tags": [
          { "name": "QnVuZGxlLUZvcm1hdA", "value": "YmluYXJ5" },
          { "name": "QnVuZGxlLVZlcnNpb24", "value": "Mi4wLjA" }
      ]
  }]'

```



