### PR TITLE
fix(sqlite): selectFailedBundleIds order

### DIFF
--- a/migrations/2024.06.06T16.04.48.bundles.import-attempt-count-last-queued-at-indexes.sql
+++ b/migrations/2024.06.06T16.04.48.bundles.import-attempt-count-last-queued-at-indexes.sql
@@ -1,0 +1,3 @@
+-- up migration
+CREATE INDEX IF NOT EXISTS import_attempt_last_queued_idx ON bundles (import_attempt_count, last_queued_at);
+

--- a/migrations/down/2024.06.06T16.04.48.bundles.import-attempt-count-last-queued-at-indexes.sql
+++ b/migrations/down/2024.06.06T16.04.48.bundles.import-attempt-count-last-queued-at-indexes.sql
@@ -1,0 +1,2 @@
+-- down migration
+DROP INDEX IF EXISTS import_attempt_last_queued_idx;

--- a/src/database/sql/bundles/repair.sql
+++ b/src/database/sql/bundles/repair.sql
@@ -19,7 +19,7 @@ FROM (
       b.matched_data_item_count IS NULL
       OR b.matched_data_item_count > 0
     )
-  ORDER BY b.last_queued_at ASC
+  ORDER BY b.import_attempt_count, b.last_queued_at ASC
   LIMIT @limit
 )
 ORDER BY RANDOM()

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -72,7 +72,7 @@ const MAX_WORKER_ERRORS = 100;
 const STABLE_FLUSH_INTERVAL = 5;
 const NEW_TX_CLEANUP_WAIT_SECS = 60 * 60 * 2;
 const NEW_DATA_ITEM_CLEANUP_WAIT_SECS = 60 * 60 * 2;
-const BUNDLE_REPROCESS_WAIT_SECS = 60 * 60 * 4;
+const BUNDLE_REPROCESS_WAIT_SECS = 60 * 1;
 const LOW_SELECTIVITY_TAG_NAMES = new Set(['App-Name', 'Content-Type']);
 
 function tagJoinSortPriority(tag: { name: string; values: string[] }) {

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -72,7 +72,7 @@ const MAX_WORKER_ERRORS = 100;
 const STABLE_FLUSH_INTERVAL = 5;
 const NEW_TX_CLEANUP_WAIT_SECS = 60 * 60 * 2;
 const NEW_DATA_ITEM_CLEANUP_WAIT_SECS = 60 * 60 * 2;
-const BUNDLE_REPROCESS_WAIT_SECS = 60 * 1;
+const BUNDLE_REPROCESS_WAIT_SECS = 60 * 15;
 const LOW_SELECTIVITY_TAG_NAMES = new Set(['App-Name', 'Content-Type']);
 
 function tagJoinSortPriority(tag: { name: string; values: string[] }) {

--- a/test/bundles-schema.sql
+++ b/test/bundles-schema.sql
@@ -138,6 +138,7 @@ CREATE INDEX bundles_index_filter_id_idx
   ON bundles (index_filter_id);
 CREATE INDEX bundle_data_items_parent_id_filter_id_idx
   ON bundle_data_items (parent_id, filter_id);
+CREATE INDEX import_attempt_last_queued_idx ON bundles (import_attempt_count, last_queued_at);
 PRAGMA foreign_keys=OFF;
 BEGIN TRANSACTION;
 CREATE TABLE bundle_formats (


### PR DESCRIPTION
Changed order for selectFailedBundleIds query. Now order combine `import_attempt_count` and `last_queued_at`.
Added an indexed for `import_attempt_count` and `last_queued_at`.