### PR TITLE
chore(logs): updating error messages to only log the message and stack

### DIFF
--- a/src/data/ar-io-data-source.ts
+++ b/src/data/ar-io-data-source.ts
@@ -99,8 +99,11 @@ export class ArIODataSource implements ContiguousDataSource {
 
       this.peers = peers;
       log.info('Updated peer list from ArIO contract');
-    } catch (error) {
-      log.error('Failed to update peer list', { error });
+    } catch (error: any) {
+      log.error('Failed to update peer list', {
+        message: error.message,
+        stack: error.stack,
+      });
     }
   }
 
@@ -187,9 +190,10 @@ export class ArIODataSource implements ContiguousDataSource {
       });
 
       return this.parseResponse(response, hops, origin);
-    } catch (error) {
+    } catch (error: any) {
       log.error('Failed to fetch contiguous data from first random ArIO peer', {
-        error,
+        message: error.message,
+        stack: error.stack,
       });
 
       try {
@@ -201,10 +205,13 @@ export class ArIODataSource implements ContiguousDataSource {
         });
 
         return this.parseResponse(response, hops, origin);
-      } catch (error) {
+      } catch (error: any) {
         log.error(
           'Failed to fetch contiguous data from second random ArIO peer',
-          { error },
+          {
+            message: error.message,
+            stack: error.stack,
+          },
         );
         throw new Error('Failed to fetch contiguous data from ArIO peers');
       }

--- a/src/data/s3-data-source.ts
+++ b/src/data/s3-data-source.ts
@@ -158,7 +158,8 @@ export class S3DataSource implements ContiguousDataSource {
     } catch (error: any) {
       log.error('Failed to fetch contiguous data from S3', {
         id,
-        error,
+        message: error.message,
+        stack: error.stack,
       });
       throw error;
     }

--- a/src/store/redis-kv-store.ts
+++ b/src/store/redis-kv-store.ts
@@ -40,12 +40,18 @@ export class RedisKvStore implements KVBufferStore {
     this.client = createClient({
       url: redisUrl,
     });
-    this.client.on('error', (err) => {
-      this.log.error(`Redis error: ${err}`);
+    this.client.on('error', (error: any) => {
+      this.log.error(`Redis error`, {
+        message: error.message,
+        stack: error.stack,
+      });
       metrics.redisErrorCounter.inc();
     });
-    this.client.connect().catch((err) => {
-      this.log.error(`Redis connection error: ${err}`);
+    this.client.connect().catch((error: any) => {
+      this.log.error(`Redis connection error`, {
+        message: error.message,
+        stack: error.stack,
+      });
       metrics.redisConnectionErrorsCounter.inc();
     });
   }

--- a/src/system.ts
+++ b/src/system.ts
@@ -419,8 +419,12 @@ eventEmitter.on(events.ANS104_UNBUNDLE_COMPLETE, async (bundleEvent: any) => {
       matchedDataItemCount: bundleEvent.matchedItemCount,
       unbundledAt: currentUnixTimestamp(),
     });
-  } catch (error) {
-    log.error('Error saving unbundle completion', error);
+  } catch (error: any) {
+    log.error('Error saving unbundle completion', {
+      parentId: bundleEvent.parentId,
+      message: error.message,
+      stack: error.stack,
+    });
   }
 });
 

--- a/src/workers/ans104-data-indexer.ts
+++ b/src/workers/ans104-data-indexer.ts
@@ -114,8 +114,12 @@ export class Ans104DataIndexer {
       } else {
         this.log.warn('Data item data is missing data offset or size.');
       }
-    } catch (error) {
-      log.error('Failed to index data item data:', error);
+    } catch (error: any) {
+      log.error('Failed to index data item data:', {
+        message: error.message,
+        stack: error.stack,
+        id: item.id,
+      });
     }
   }
 


### PR DESCRIPTION
Following a general policy to minimize the logs of error messages to only relevant information. This does not address all error messages, but ones in critical paths.