### PR TITLE
fix(arns): bump resolver image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -113,7 +113,7 @@ services:
       - AR_IO_NODE_RELEASE=${AR_IO_NODE_RELEASE:-14}
 
   resolver:
-    image: ghcr.io/ar-io/arns-resolver:${RESOLVER_IMAGE_TAG:-62b15e75c6524ff344a62d4fb890a619925937a9}
+    image: ghcr.io/ar-io/arns-resolver:${RESOLVER_IMAGE_TAG:-3b7ee23d111d19f58601df0d79bfea83689e3a34}
     restart: on-failure:5
     ports:
       - 6000:6000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -113,7 +113,7 @@ services:
       - AR_IO_NODE_RELEASE=${AR_IO_NODE_RELEASE:-14}
 
   resolver:
-    image: ghcr.io/ar-io/arns-resolver:${RESOLVER_IMAGE_TAG:-9b1609b4036870f1656d476172f27cd6ea3cd682}
+    image: ghcr.io/ar-io/arns-resolver:${RESOLVER_IMAGE_TAG:-62b15e75c6524ff344a62d4fb890a619925937a9}
     restart: on-failure:5
     ports:
       - 6000:6000
@@ -123,6 +123,7 @@ services:
       - IO_PROCESS_ID=${IO_PROCESS_ID:-}
       - RUN_RESOLVER=${RUN_RESOLVER:-false}
       - EVALUATION_INTERVAL_MS=${EVALUATION_INTERVAL_MS:-}
+      - ARNS_CACHE_TTL_MS=${RESOLVER_CACHE_TTL_MS:-}
       - ARNS_CACHE_PATH=${ARNS_CACHE_PATH:-./data/arns}
     volumes:
       - ${ARNS_CACHE_PATH:-./data/arns}:/app/data/arns


### PR DESCRIPTION
Resolver now supports separate env vars for the cache TTL and evaluation interval.

Ticket: [PE-6355](https://ardrive.atlassian.net/browse/PE-6355)
Related: https://github.com/ar-io/arns-resolver/commit/3b7ee23d111d19f58601df0d79bfea83689e3a34

[PE-6355]: https://ardrive.atlassian.net/browse/PE-6355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ