### PR TITLE
docs: removed instructions to test gateway on localhost

### DIFF
--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -191,9 +191,7 @@ To ensure your node is running correctly, follow the next two steps.
         - `-f`: Follow the logs in real time.
         - `--tail=0`: Ignore all logs from before running the command.
 
-- Make a request to your node using localhost:
-    Open your browser or use the `wget` command in the terminal to navigate to http://localhost:3000/3lyxgbgEvqNSvJrTX2J7CfRychUD5KClFhhVLyTPNCQ.
-    If you can see the image, your node is operating correctly.
+**NOTE**:  Previous versions of these instructions advised checking a gateway's ability to fetch content using `localhost`. Subsequent security updates prevent this without first unsetting `ARNS_ROOT_HOST` in your `.env`.
 
 ## Set up Networking
 

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -131,13 +131,6 @@ The hardware specifications listed below represent the minimum system requiremen
 
    - If prompted by the firewall, allow access for Docker when requested.
 
-
-## Test Localhost
-
-- Open your web browser.
-- Enter `http://localhost:3000/3lyxgbgEvqNSvJrTX2J7CfRychUD5KClFhhVLyTPNCQ` in the address bar.
-- If you can see the image, your node is operating correctly.
-
 ## Set Up Router Port Forwarding
 
 To expose your node to the internet and use a custom domain, follow these steps:


### PR DESCRIPTION
Recent security updates prevent resolving content on a gateway using localhost. As such, instructions to test a gateway at startup using localhost have been removed.