### PR TITLE
feat(codedeploy): add litestream profile flag to app-start

### DIFF
--- a/scripts/codedeploy/app-start
+++ b/scripts/codedeploy/app-start
@@ -8,4 +8,4 @@ if [ "$(docker ps -q)" ]; then
 fi
 
 # TODO use a pre-built image
-docker-compose up -d
+docker-compose --profile litestream up -d


### PR DESCRIPTION
I'm not able to test if the legacy `docker-compose` cli command supports `--profile` flag. I hope it does.
EDIT: it was introduced in docker-compose v2 so this should work just fine.