### PR TITLE
feat(ao): allow AO env variables to point process evaluation against …

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -27,7 +27,7 @@ jobs:
         if: matrix.os == 'macos-latest'
 
       # Build and test TypeScript
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --ignore-engines
       - run: yarn build
       - run: yarn lint:check
       - run: yarn test:ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN yarn install --ignore-engines \
     && yarn build \
     && rm -rf node_modules \
-    && yarn install --production
+    && yarn install --production --ignore-engines
 
 # Runtime
 FROM gcr.io/distroless/nodejs${NODE_VERSION_SHORT}-debian12

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 RUN apt-get update \
     && apt-get install -y build-essential curl git python3
 COPY . .
-RUN yarn install \
+RUN yarn install --ignore-engines \
     && yarn build \
     && rm -rf node_modules \
     && yarn install --production

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@ar.io/sdk": "^2.0.0",
     "@aws-lite/client": "^0.21.7",
     "@aws-lite/s3": "^0.1.21",
+    "@permaweb/aoconnect": "^0.0.56",
     "apollo-server-express": "^3.13.0",
     "arweave": "^1.14.4",
     "axios": "^1.6.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -271,3 +271,10 @@ export const GET_DATA_CIRCUIT_BREAKER_TIMEOUT_MS = +env.varOrDefault(
   'GET_DATA_CIRCUIT_BREAKER_TIMEOUT_MS',
   '500',
 );
+
+// AO
+
+export const AO_MU_URL = env.varOrUndefined('AO_MU_URL');
+export const AO_CU_URL = env.varOrUndefined('AO_CU_URL');
+export const AO_GRAPHQL_URL = env.varOrUndefined('AO_GRAPHQL_URL');
+export const AO_GATEWAY_URL = env.varOrUndefined('AO_GATEWAY_URL');

--- a/src/system.ts
+++ b/src/system.ts
@@ -19,7 +19,7 @@ import { default as Arweave } from 'arweave';
 import EventEmitter from 'node:events';
 import { Server } from 'node:http';
 import fs from 'node:fs';
-import { IO } from '@ar.io/sdk';
+import { AOProcess, IO } from '@ar.io/sdk';
 import awsLite from '@aws-lite/client';
 import awsLiteS3 from '@aws-lite/s3';
 
@@ -72,6 +72,7 @@ import { createArNSResolver } from './init/resolvers.js';
 import { MempoolWatcher } from './workers/mempool-watcher.js';
 import { ArIODataSource } from './data/ar-io-data-source.js';
 import { S3DataSource } from './data/s3-data-source.js';
+import { connect } from '@permaweb/aoconnect';
 
 process.on('uncaughtException', (error) => {
   metrics.uncaughtExceptionCounter.inc();
@@ -80,7 +81,21 @@ process.on('uncaughtException', (error) => {
 
 const arweave = Arweave.init({});
 
-const arIO = IO.init({ processId: config.IO_PROCESS_ID });
+// IO/AO SDK
+
+const arIO = IO.init({
+  process: new AOProcess({
+    processId: config.IO_PROCESS_ID,
+    ao: connect({
+      // @permaweb/aoconnect defaults will be used if these are not provided
+      MU_URL: config.AO_MU_URL,
+      CU_URL: config.AO_CU_URL,
+      GRAPHQL_URL: config.AO_GATEWAY_URL,
+      GATEWAY_URL: config.AO_GATEWAY_URL,
+    }),
+  }),
+});
+
 export const awsClient =
   config.AWS_ACCESS_KEY_ID !== undefined &&
   config.AWS_SECRET_ACCESS_KEY !== undefined &&

--- a/src/system.ts
+++ b/src/system.ts
@@ -90,7 +90,7 @@ const arIO = IO.init({
       // @permaweb/aoconnect defaults will be used if these are not provided
       MU_URL: config.AO_MU_URL,
       CU_URL: config.AO_CU_URL,
-      GRAPHQL_URL: config.AO_GATEWAY_URL,
+      GRAPHQL_URL: config.AO_GRAPHQL_URL,
       GATEWAY_URL: config.AO_GATEWAY_URL,
     }),
   }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,6 +1575,20 @@
     warp-arbundles "^1.0.4"
     zod "^3.22.4"
 
+"@permaweb/aoconnect@^0.0.56":
+  version "0.0.56"
+  resolved "https://registry.yarnpkg.com/@permaweb/aoconnect/-/aoconnect-0.0.56.tgz#28dcf1a094a2b1c1cbaa246d63eeb08a5a0c7269"
+  integrity sha512-Eu4AC1KeX2EOIS9ihWkwPJs7rK+/+XV43QwOJ9DCQAu6EhjanlT3UfV2wSpGiFK/dT/B1YsQyTcxNrmQaXn81g==
+  dependencies:
+    "@permaweb/ao-scheduler-utils" "~0.0.16"
+    buffer "^6.0.3"
+    debug "^4.3.4"
+    hyper-async "^1.1.2"
+    mnemonist "^0.39.8"
+    ramda "^0.29.1"
+    warp-arbundles "^1.0.4"
+    zod "^3.22.4"
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -6049,12 +6063,12 @@ multistream@^4.1.0:
     once "^1.4.0"
     readable-stream "^3.6.0"
 
-nan@2.18.0:
+nan@2.18.0, nan@^2.18.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
   integrity sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==
 
-nan@^2.18.0, nan@^2.19.0:
+nan@^2.19.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.20.0.tgz#08c5ea813dd54ed16e5bd6505bf42af4f7838ca3"
   integrity sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==


### PR DESCRIPTION
…specific AO infrastrucutre

The defaults are reccomended, but this gives operators the ability to point the resolvers dryRuns to specific AO infrastructure. Useful for testing and if you are running any part of an AO stack yourself to avoid rate-limiting/network issues.