### PR TITLE
chore(yarn): add .yarnrc file to avoid having to pass around --ignore…

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -27,7 +27,7 @@ jobs:
         if: matrix.os == 'macos-latest'
 
       # Build and test TypeScript
-      - run: yarn --immutable --immutable-cache --ignore-engines
+      - run: yarn --immutable --immutable-cache
       - run: yarn build
       - run: yarn lint:check
       - run: yarn test:ci

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ignore-engines true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ WORKDIR /app
 RUN apt-get update \
     && apt-get install -y build-essential curl git python3
 COPY . .
-RUN yarn install --ignore-engines \
+RUN yarn install \
     && yarn build \
     && rm -rf node_modules \
-    && yarn install --production --ignore-engines
+    && yarn install --production
 
 # Runtime
 FROM gcr.io/distroless/nodejs${NODE_VERSION_SHORT}-debian12


### PR DESCRIPTION
…-engines everywhere

This is required bc aoconnect encourages the use of npm over yarn.