### PR TITLE
feat(arns): allow for on-demand name resolution, introduce composite arns resolver with fallbacks

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -244,6 +244,14 @@ export const WEBHOOK_BLOCK_FILTER = createFilter(
 // ArNS Resolution
 //
 
+export const ARNS_CACHE_TTL_SECONDS = +env.varOrDefault(
+  'ARNS_CACHE_TTL_SECONDS',
+  '60 * 60  ', // 1 hour
+);
+export const ARNS_CACHE_MAX_KEYS = +env.varOrDefault(
+  'ARNS_CACHE_MAX_KEYS',
+  '10000',
+);
 export const TRUSTED_ARNS_GATEWAY_URL = env.varOrDefault(
   'TRUSTED_ARNS_GATEWAY_URL',
   'https://__NAME__.arweave.dev',

--- a/src/config.ts
+++ b/src/config.ts
@@ -246,12 +246,14 @@ export const WEBHOOK_BLOCK_FILTER = createFilter(
 
 export const ARNS_CACHE_TTL_SECONDS = +env.varOrDefault(
   'ARNS_CACHE_TTL_SECONDS',
-  '60 * 60  ', // 1 hour
+  '3600', // 1 hour
 );
+
 export const ARNS_CACHE_MAX_KEYS = +env.varOrDefault(
   'ARNS_CACHE_MAX_KEYS',
   '10000',
 );
+
 export const TRUSTED_ARNS_GATEWAY_URL = env.varOrDefault(
   'TRUSTED_ARNS_GATEWAY_URL',
   'https://__NAME__.arweave.dev',

--- a/src/config.ts
+++ b/src/config.ts
@@ -246,7 +246,7 @@ export const WEBHOOK_BLOCK_FILTER = createFilter(
 
 export const ARNS_CACHE_TTL_SECONDS = +env.varOrDefault(
   'ARNS_CACHE_TTL_SECONDS',
-  '3600', // 1 hour
+  `${60 * 60}`, // 1 hour
 );
 
 export const ARNS_CACHE_MAX_KEYS = +env.varOrDefault(
@@ -254,11 +254,17 @@ export const ARNS_CACHE_MAX_KEYS = +env.varOrDefault(
   '10000',
 );
 
+export const ARNS_RESOLVER_PRIORITY_ORDER = env
+  .varOrDefault('ARNS_RESOLVER_PRIORITY_ORDER', 'resolver,on-demand,gateway')
+  .split(',');
+
 export const TRUSTED_ARNS_GATEWAY_URL = env.varOrDefault(
   'TRUSTED_ARNS_GATEWAY_URL',
   'https://__NAME__.arweave.dev',
 );
 
+// @deprecated - use ARNS_RESOLVER_PRIORITY_ORDER instead to specify the order
+// of resolvers to try if the first one is not available.
 export const TRUSTED_ARNS_RESOLVER_TYPE = env.varOrDefault(
   'TRUSTED_ARNS_RESOLVER_TYPE',
   'gateway',

--- a/src/init/resolvers.ts
+++ b/src/init/resolvers.ts
@@ -17,20 +17,30 @@
  */
 import { Logger } from 'winston';
 import { StandaloneArNSResolver } from '../resolution/standalone-arns-resolver.js';
+import { OnDemandArNSResolver } from '../resolution/on-demand-arns-resolver.js';
 import { TrustedGatewayArNSResolver } from '../resolution/trusted-gateway-arns-resolver.js';
 import { NameResolver } from '../types.js';
+import { AoIORead } from '@ar.io/sdk';
 
 export const createArNSResolver = ({
   log,
   type,
   url,
+  networkProcess,
 }: {
   log: Logger;
   type: string;
   url: string;
+  networkProcess?: AoIORead;
 }): NameResolver => {
   log.info(`Using ${type} for arns name resolution`);
   switch (type) {
+    case 'on-demand': {
+      return new OnDemandArNSResolver({
+        log,
+        networkProcess,
+      });
+    }
     case 'resolver': {
       return new StandaloneArNSResolver({
         log,

--- a/src/init/resolvers.ts
+++ b/src/init/resolvers.ts
@@ -67,15 +67,15 @@ export const createArNSResolver = ({
 
   const resolvers: NameResolver[] = [];
 
-  // Add resolvers in the order specified by resolutionOrder
+  // add resolvers in the order specified by resolutionOrder
   for (const resolverType of resolutionOrder) {
-    // ignore invalid resolver types
     if (isArNSResolverType(resolverType)) {
       const resolver = resolverMap[resolverType];
       if (resolver !== undefined) {
         resolvers.push(resolver);
       }
     }
+    log.warn(`Ignoring unsupported resolver type: ${resolverType}`);
   }
 
   return new CompositeArNSResolver({

--- a/src/init/resolvers.ts
+++ b/src/init/resolvers.ts
@@ -74,8 +74,9 @@ export const createArNSResolver = ({
       if (resolver !== undefined) {
         resolvers.push(resolver);
       }
+    } else {
+      log.warn(`Ignoring unsupported resolver type: ${resolverType}`);
     }
-    log.warn(`Ignoring unsupported resolver type: ${resolverType}`);
   }
 
   return new CompositeArNSResolver({

--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -38,6 +38,9 @@ export class CompositeArNSResolver implements NameResolver {
 
     try {
       for (const resolver of this.resolvers) {
+        this.log.debug('Attempting to resolve name with resolver', {
+          resolver,
+        });
         const resolution = await resolver.resolve(name);
         if (resolution.resolvedId !== undefined) {
           return resolution;

--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -1,0 +1,69 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import winston from 'winston';
+import { NameResolution, NameResolver } from '../types.js';
+
+export class CompositeArNSResolver implements NameResolver {
+  private log: winston.Logger;
+  private resolvers: NameResolver[];
+
+  constructor({
+    log,
+    resolvers,
+  }: {
+    log: winston.Logger;
+    resolvers: NameResolver[];
+  }) {
+    this.log = log.child({ class: 'CompositeArNSResolver' });
+    this.resolvers = resolvers;
+  }
+
+  async resolve(name: string): Promise<NameResolution> {
+    this.log.info('Resolving name...', { name });
+
+    try {
+      for (const resolver of this.resolvers) {
+        const resolution = await resolver.resolve(name);
+        if (resolution.resolvedId !== undefined) {
+          return resolution;
+        }
+      }
+      this.log.warn('Unable to resolve name against all resolvers', { name });
+      return {
+        name,
+        resolvedId: undefined,
+        resolvedAt: undefined,
+        processId: undefined,
+        ttl: undefined,
+      };
+    } catch (error: any) {
+      this.log.error('Error resolving name:', {
+        name,
+        message: error.message,
+        stack: error.stack,
+      });
+      return {
+        name,
+        resolvedId: undefined,
+        resolvedAt: undefined,
+        ttl: undefined,
+        processId: undefined,
+      };
+    }
+  }
+}

--- a/src/resolution/memory-cache-arns-resolver.ts
+++ b/src/resolution/memory-cache-arns-resolver.ts
@@ -19,15 +19,16 @@ import { default as NodeCache } from 'node-cache';
 import winston from 'winston';
 
 import { NameResolution, NameResolver } from '../types.js';
+import * as config from '../config.js';
 
 export class MemoryCacheArNSResolver implements NameResolver {
   private log: winston.Logger;
   private resolver: NameResolver;
   private requestCache = new NodeCache({
-    checkperiod: 60 * 5, // 5 minutes
-    stdTTL: 60 * 60 * 2, // 2 hours
+    checkperiod: Math.min(60 * 5, config.ARNS_CACHE_TTL_SECONDS), // 5 minutes or less
+    stdTTL: config.ARNS_CACHE_TTL_SECONDS,
     useClones: false, // cloning promises is unsafe
-    maxKeys: 10000,
+    maxKeys: config.ARNS_CACHE_MAX_KEYS,
   });
 
   constructor({

--- a/src/resolution/on-demand-arns-resolver.ts
+++ b/src/resolution/on-demand-arns-resolver.ts
@@ -56,7 +56,7 @@ export class OnDemandArNSResolver implements NameResolver {
         name: baseName,
       });
 
-      if (arnsRecord === undefined) {
+      if (arnsRecord === undefined || arnsRecord.processId === undefined) {
         throw new Error('Invalid name, arns record not found');
       }
 

--- a/src/resolution/on-demand-arns-resolver.ts
+++ b/src/resolution/on-demand-arns-resolver.ts
@@ -1,0 +1,127 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import winston from 'winston';
+
+import { isValidDataId } from '../lib/validation.js';
+import { NameResolution, NameResolver } from '../types.js';
+import { ANT, AoIORead, AOProcess, IO } from '@ar.io/sdk';
+import * as config from '../config.js';
+import { connect } from '@permaweb/aoconnect';
+
+export class OnDemandArNSResolver implements NameResolver {
+  private log: winston.Logger;
+  private networkProcess: AoIORead;
+
+  constructor({
+    log,
+    networkProcess = IO.init({
+      processId: config.IO_PROCESS_ID,
+    }),
+  }: {
+    log: winston.Logger;
+    networkProcess?: AoIORead;
+  }) {
+    this.log = log.child({
+      class: 'OnDemandArNSResolver',
+    });
+    this.networkProcess = networkProcess;
+  }
+
+  async resolve(name: string): Promise<NameResolution> {
+    this.log.info('Resolving name...', { name });
+    try {
+      // get the base name which is the last of th array split by _
+      const baseName = name.split('_').pop();
+      if (baseName === undefined) {
+        throw new Error('Invalid name');
+      }
+      // find that name in the network process
+      const arnsRecord = await this.networkProcess.getArNSRecord({
+        name: baseName,
+      });
+
+      if (arnsRecord === undefined) {
+        throw new Error('Invalid name, arns record not found');
+      }
+
+      const processId = arnsRecord.processId;
+
+      // now get the ant process from the process id
+      const ant = ANT.init({
+        process: new AOProcess({
+          processId: processId,
+          ao: connect({
+            MU_URL: config.AO_MU_URL,
+            CU_URL: config.AO_CU_URL,
+            GRAPHQL_URL: config.AO_GRAPHQL_URL,
+            GATEWAY_URL: config.AO_GATEWAY_URL,
+          }),
+        }),
+      });
+
+      const undername = name.replace(`_${baseName}`, '');
+
+      const antRecord = await ant.getRecord({
+        undername,
+      });
+
+      if (antRecord === undefined) {
+        throw new Error('Invalid name, ant record for name not found');
+      }
+
+      const resolvedId = antRecord.transactionId;
+      const ttl = antRecord.ttlSeconds;
+
+      if (isValidDataId(resolvedId)) {
+        this.log.info('Resolved name', {
+          name,
+          resolvedId,
+          ttl,
+        });
+        return {
+          name,
+          resolvedId,
+          resolvedAt: Date.now(),
+          processId: processId,
+          ttl,
+        };
+      } else {
+        this.log.warn('Invalid resolved data ID', {
+          name,
+          resolvedId,
+          processId,
+          ttl,
+        });
+      }
+    } catch (error: any) {
+      this.log.warn('Unable to resolve name:', {
+        name,
+        message: error.message,
+        stack: error.stack,
+      });
+    }
+
+    return {
+      name,
+      resolvedId: undefined,
+      resolvedAt: undefined,
+      ttl: undefined,
+      processId: undefined,
+    };
+  }
+}

--- a/src/resolution/on-demand-arns-resolver.ts
+++ b/src/resolution/on-demand-arns-resolver.ts
@@ -43,10 +43,11 @@ export class OnDemandArNSResolver implements NameResolver {
   }
 
   async resolve(name: string): Promise<NameResolution> {
-    this.log.info('Resolving name...', { name });
+    this.log.info('Resolving name...', { name }).profile('Resolver', {
+      name,
+    });
     try {
       // start profiling
-      this.log.profile('resolve', { name });
       // get the base name which is the last of th array split by _
       const baseName = name.split('_').pop();
       if (baseName === undefined) {
@@ -76,7 +77,9 @@ export class OnDemandArNSResolver implements NameResolver {
         }),
       });
 
-      const undername = name.replace(`_${baseName}`, '');
+      // if it is the root name, then it should point to '@'
+      const undername =
+        name === baseName ? '@' : name.replace(`_${baseName}`, '');
 
       const antRecord = await ant.getRecord({
         undername,
@@ -93,13 +96,15 @@ export class OnDemandArNSResolver implements NameResolver {
         throw new Error('Invalid resolved data ID');
       }
 
-      this.log.info('Resolved name', {
-        name,
-        resolvedId,
-        ttl,
-      });
-      // end profiling
-      this.log.profile('resolve', { name });
+      this.log
+        .info('Resolved name', {
+          name,
+          resolvedId,
+          ttl,
+        })
+        .profile('Resolver', {
+          name,
+        });
       return {
         name,
         resolvedId,

--- a/src/resolution/on-demand-arns-resolver.ts
+++ b/src/resolution/on-demand-arns-resolver.ts
@@ -45,6 +45,8 @@ export class OnDemandArNSResolver implements NameResolver {
   async resolve(name: string): Promise<NameResolution> {
     this.log.info('Resolving name...', { name });
     try {
+      // start profiling
+      this.log.profile('resolve', { name });
       // get the base name which is the last of th array split by _
       const baseName = name.split('_').pop();
       if (baseName === undefined) {
@@ -87,27 +89,24 @@ export class OnDemandArNSResolver implements NameResolver {
       const resolvedId = antRecord.transactionId;
       const ttl = antRecord.ttlSeconds;
 
-      if (isValidDataId(resolvedId)) {
-        this.log.info('Resolved name', {
-          name,
-          resolvedId,
-          ttl,
-        });
-        return {
-          name,
-          resolvedId,
-          resolvedAt: Date.now(),
-          processId: processId,
-          ttl,
-        };
-      } else {
-        this.log.warn('Invalid resolved data ID', {
-          name,
-          resolvedId,
-          processId,
-          ttl,
-        });
+      if (!isValidDataId(resolvedId)) {
+        throw new Error('Invalid resolved data ID');
       }
+
+      this.log.info('Resolved name', {
+        name,
+        resolvedId,
+        ttl,
+      });
+      // end profiling
+      this.log.profile('resolve', { name });
+      return {
+        name,
+        resolvedId,
+        resolvedAt: Date.now(),
+        processId: processId,
+        ttl,
+      };
     } catch (error: any) {
       this.log.warn('Unable to resolve name:', {
         name,

--- a/src/resolution/on-demand-arns-resolver.ts
+++ b/src/resolution/on-demand-arns-resolver.ts
@@ -43,11 +43,9 @@ export class OnDemandArNSResolver implements NameResolver {
   }
 
   async resolve(name: string): Promise<NameResolution> {
-    this.log.info('Resolving name...', { name }).profile('Resolver', {
-      name,
-    });
+    this.log.info('Resolving name...', { name });
     try {
-      // start profiling
+      const start = Date.now();
       // get the base name which is the last of th array split by _
       const baseName = name.split('_').pop();
       if (baseName === undefined) {
@@ -96,15 +94,12 @@ export class OnDemandArNSResolver implements NameResolver {
         throw new Error('Invalid resolved data ID');
       }
 
-      this.log
-        .info('Resolved name', {
-          name,
-          resolvedId,
-          ttl,
-        })
-        .profile('Resolver', {
-          name,
-        });
+      this.log.info('Resolved name', {
+        name,
+        resolvedId,
+        ttl,
+        durationMs: Date.now() - start,
+      });
       return {
         name,
         resolvedId,

--- a/src/resolution/standalone-arns-resolver.ts
+++ b/src/resolution/standalone-arns-resolver.ts
@@ -57,27 +57,23 @@ export class StandaloneArNSResolver implements NameResolver {
       const resolvedId = data.txId;
       const ttl = data.ttlSeconds || DEFAULT_ARNS_TTL_SECONDS;
       const processId = data.processId;
-      if (isValidDataId(resolvedId)) {
-        this.log.info('Resolved name', {
-          name,
-          resolvedId,
-          ttl,
-        });
-        return {
-          name,
-          resolvedId,
-          resolvedAt: Date.now(),
-          processId: processId,
-          ttl,
-        };
-      } else {
-        this.log.warn('Invalid resolved data ID', {
-          name,
-          resolvedId,
-          processId,
-          ttl,
-        });
+
+      if (!isValidDataId(resolvedId)) {
+        throw new Error('Invalid resolved data ID');
       }
+
+      this.log.info('Resolved name', {
+        name,
+        resolvedId,
+        ttl,
+      });
+      return {
+        name,
+        resolvedId,
+        resolvedAt: Date.now(),
+        processId: processId,
+        ttl,
+      };
     } catch (error: any) {
       this.log.warn('Unable to resolve name:', {
         name,

--- a/src/system.ts
+++ b/src/system.ts
@@ -494,6 +494,7 @@ export const nameResolver = new MemoryCacheArNSResolver({
     log,
     type: config.TRUSTED_ARNS_RESOLVER_TYPE,
     url: config.TRUSTED_ARNS_RESOLVER_URL,
+    networkProcess: arIO,
   }),
 });
 

--- a/src/system.ts
+++ b/src/system.ts
@@ -493,7 +493,8 @@ export const nameResolver = new MemoryCacheArNSResolver({
   resolver: createArNSResolver({
     log,
     type: config.TRUSTED_ARNS_RESOLVER_TYPE,
-    url: config.TRUSTED_ARNS_RESOLVER_URL,
+    trustedGatewayUrl: config.TRUSTED_GATEWAY_URL,
+    standaloneArnResolverUrl: config.TRUSTED_ARNS_RESOLVER_URL,
     networkProcess: arIO,
   }),
 });

--- a/src/system.ts
+++ b/src/system.ts
@@ -492,9 +492,9 @@ export const nameResolver = new MemoryCacheArNSResolver({
   log,
   resolver: createArNSResolver({
     log,
-    type: config.TRUSTED_ARNS_RESOLVER_TYPE,
     trustedGatewayUrl: config.TRUSTED_GATEWAY_URL,
     standaloneArnResolverUrl: config.TRUSTED_ARNS_RESOLVER_URL,
+    resolutionOrder: config.ARNS_RESOLVER_PRIORITY_ORDER,
     networkProcess: arIO,
   }),
 });

--- a/test/end-to-end/data.test.ts
+++ b/test/end-to-end/data.test.ts
@@ -595,7 +595,7 @@ describe('X-AR-IO headers', function () {
       );
 
       assert.equal(reqWithHeaders.headers['x-ar-io-hops'], '7');
-      assert.equal(reqWithHeaders.headers['x-ar-io-origin'], 'another-host');
+      assert.equal(reqWithHeadefrs.headers['x-ar-io-origin'], 'another-host');
       assert.equal(reqWithHeaders.headers['x-ar-io-origin-node-release'], '10');
     });
 

--- a/test/end-to-end/data.test.ts
+++ b/test/end-to-end/data.test.ts
@@ -595,7 +595,7 @@ describe('X-AR-IO headers', function () {
       );
 
       assert.equal(reqWithHeaders.headers['x-ar-io-hops'], '7');
-      assert.equal(reqWithHeadefrs.headers['x-ar-io-origin'], 'another-host');
+      assert.equal(reqWithHeaders.headers['x-ar-io-origin'], 'another-host');
       assert.equal(reqWithHeaders.headers['x-ar-io-origin-node-release'], '10');
     });
 


### PR DESCRIPTION
### Update
Also introduces a `CompositeArNSResolver` that attempts to resolve a name against each provided resolver in order. By default, if `on-demand` is set and other URLs are provided, it will attempt to fallback to those. If `resolver` or `trustedGatewayUrl` is set, it will fallback to AO. Welcome any feedback on these "defaults" fallbacks.

### Details
This is experimental way to allow name resolution directly through AO infrastructure rather than relying on the resolver or other gateways. We may want to fallback to those if this experiences a high rate of errors, potentially using a circuit breaker or some sort. For now, it is an opt-in feature that is useful when testing arns workflows.

Logs: OnDemandArNSResolver
```bash
ar-io-node-core-1  | info: Resolved name {"class":"OnDemandArNSResolver","name":"satyvm","resolvedId":"dbyBbjrtUxyvoPFroVxoH-Idg6RVK3YWMi5BzsoMWjU","timestamp":"2024-08-26T20:30:20.649Z","ttl":900}
ar-io-node-core-1  | info: Resolved name from resolver {"class":"MemoryCacheArNSResolver","name":"satyvm","processId":"zefaHse_NCCzsa_hW41xkpnaYuk0RRexpCv06UYXkwI","resolvedAt":1724704220650,"resolvedId":"dbyBbjrtUxyvoPFroVxoH-Idg6RVK3YWMi5BzsoMWjU","timestamp":"2024-08-26T20:30:20.650Z","ttl":900}
ar-io-node-core-1  | info: Successfully cached data {"class":"ReadThroughDataCache","hash":"-pFEhQA99nBU8iCc41bgS4HnLAZpEiQrGuvVSHQmX-g","id":"dbyBbjrtUxyvoPFroVxoH-Idg6RVK3YWMi5BzsoMWjU","timestamp":"2024-08-26T20:30:20.676Z"}
ar-io-node-core-1  | info: Resolved name {"class":"OnDemandArNSResolver","name":"osmosis","resolvedId":"z-0EDHh_bqRY6AJFpoSJcNF3gtR_B7R3vpLjFMSxVbg","timestamp":"2024-08-26T20:30:20.820Z","ttl":3600}
ar-io-node-core-1  | info: Resolved name from resolver {"class":"MemoryCacheArNSResolver","name":"osmosis","processId":"irU6r49IUUe40NpK7hgYHbgUb66pjseT35hmmRjCH08","resolvedAt":1724704220820,"resolvedId":"z-0EDHh_bqRY6AJFpoSJcNF3gtR_B7R3vpLjFMSxVbg","timestamp":"2024-08-26T20:30:20.820Z","ttl":3600}
```

Logs: Fallback logic in CompositeArNSResolver - for a name that does not exist
```bash
 warn: Unable to resolve name {"class":"MemoryCacheArNSResolver","name":"totalitems","timestamp":"2024-08-29T12:56:40.645Z"}
ar-io-node-core-1  | warn: Unable to resolve name: Cannot read properties of null (reading 'processId') {"class":"OnDemandArNSResolver","name":"items","timestamp":"2024-08-29T12:56:40.694Z"}
ar-io-node-core-1  | info: Resolving name... {"class":"StandaloneArNSResolver","name":"items","resolverUrl":"http://resolver:6000","timestamp":"2024-08-29T12:56:40.694Z"}
ar-io-node-core-1  | warn: Unable to resolve name: Request failed with status code 404 {"class":"StandaloneArNSResolver","name":"items","resolverUrl":"http://resolver:6000","timestamp":"2024-08-29T12:56:40.697Z"}
ar-io-node-core-1  | info: Resolving name... {"class":"TrustedGatewayArNSResolver","name":"items","timestamp":"2024-08-29T12:56:40.697Z"}
ar-io-node-core-1  | warn: Unable to resolve name: Cannot read properties of undefined (reading 'match') {"class":"TrustedGatewayArNSResolver","name":"items","timestamp":"2024-08-29T12:56:40.701Z"}
ar-io-node-core-1  | warn: Unable to resolve name against all resolvers {"class":"CompositeArNSResolver","name":"items","timestamp":"2024-08-29T12:56:40.702Z"}
ar-io-node-core-1  | warn: Unable to resolve name {"class":"MemoryCacheArNSResolver","name":"items","timestamp":"2024-08-29T12:56:40.702Z"}
```