### PR TITLE
feat(PE-6738): introduce arns resolver GET endpoint

### DIFF
--- a/src/routes/arns.ts
+++ b/src/routes/arns.ts
@@ -24,6 +24,7 @@ import * as system from '../system.js';
 import { dataHandler } from './data/index.js';
 import { headerNames } from '../constants.js';
 import { sendNotFound } from './data/handlers.js';
+import { DEFAULT_ARNS_TTL_SECONDS } from '../resolution/trusted-gateway-arns-resolver.js';
 
 export const arnsRouter = Router();
 
@@ -53,18 +54,16 @@ arnsRouter.get('/ar-io/resolver/:name', async (req, res) => {
 
   const { resolvedId, ttl, processId, resolvedAt } = resolved;
 
-  // check if they are undefined
-  if (
-    resolvedId === undefined ||
-    ttl === undefined ||
-    processId === undefined
-  ) {
+  if (resolvedId === undefined) {
     sendNotFound(res);
     return;
   }
 
   res.header(headerNames.arnsResolvedId, resolvedId);
-  res.header(headerNames.arnsTtlSeconds, ttl.toString());
+  res.header(
+    headerNames.arnsTtlSeconds,
+    ttl.toString() || DEFAULT_ARNS_TTL_SECONDS.toString(),
+  );
   res.header(headerNames.arnsProcessId, processId);
 
   // add arns headers

--- a/src/routes/arns.ts
+++ b/src/routes/arns.ts
@@ -22,6 +22,8 @@ import { createArnsMiddleware } from '../middleware/arns.js';
 import { createSandboxMiddleware } from '../middleware/sandbox.js';
 import * as system from '../system.js';
 import { dataHandler } from './data/index.js';
+import { headerNames } from '../constants.js';
+import { sendNotFound } from './data/handlers.js';
 
 export const arnsRouter = Router();
 
@@ -39,3 +41,37 @@ if (config.ARNS_ROOT_HOST !== undefined) {
     }),
   );
 }
+
+arnsRouter.get('/ar-io/resolver/:name', async (req, res) => {
+  const { name } = req.params;
+  // TODO: replace this with the same request cache used in arns middleware
+  const resolved = await system.nameResolver.resolve(name);
+  if (resolved === undefined) {
+    sendNotFound(res);
+    return;
+  }
+
+  const { resolvedId, ttl, processId, resolvedAt } = resolved;
+
+  // check if they are undefined
+  if (
+    resolvedId === undefined ||
+    ttl === undefined ||
+    processId === undefined
+  ) {
+    sendNotFound(res);
+    return;
+  }
+
+  res.header(headerNames.arnsResolvedId, resolvedId);
+  res.header(headerNames.arnsTtlSeconds, ttl.toString());
+  res.header(headerNames.arnsProcessId, processId);
+
+  // add arns headers
+  res.json({
+    txId: resolvedId,
+    ttlSeconds: ttl,
+    processId,
+    resolvedAt,
+  });
+});

--- a/test/end-to-end/arns.test.ts
+++ b/test/end-to-end/arns.test.ts
@@ -113,13 +113,8 @@ describe('ArNS', function () {
 
   // verify the /ar-io/resolver/:name endpoint
   it('Verifying that /ar-io/resolver/:name returns 200 and resolution data', async function () {
-    const txId = 'TB2wJyKrPnkAW79DAwlJYwpgdHKpijEJWQfcwX715Co';
-    const res = await axios.get(
-      'http://localhost:4000/ar-io/resolver/ardrive',
-      {
-        headers: { Host: 'ardrive.ar-io.localhost' },
-      },
-    );
+    const txId = '7czHwMqgYHC3eJrPagyFA03UT4YXIN1um__tpHUXAHE';
+    const res = await axios.get('http://localhost:4000/ar-io/resolver/ardrive');
 
     assert.strictEqual(res.status, 200);
     assert.strictEqual(res.data.txId, txId);
@@ -129,15 +124,10 @@ describe('ArNS', function () {
 
   // verify the headers are set correctly on the response
   it('Verifying that /ar-io/resolver/:name returns 200 and sets the correct headers', async function () {
-    const txId = 'TB2wJyKrPnkAW79DAwlJYwpgdHKpijEJWQfcwX715Co';
-    const res = await axios.get(
-      'http://localhost:4000/ar-io/resolver/ardrive',
-      {
-        headers: { Host: 'ardrive.ar-io.localhost' },
-      },
-    );
+    const txId = '7czHwMqgYHC3eJrPagyFA03UT4YXIN1um__tpHUXAHE';
+    const res = await axios.get('http://localhost:4000/ar-io/resolver/ardrive');
 
-    assert.strictEqual(typeof res.headers['x-arns-resolved-id'], txId);
+    assert.strictEqual(res.headers['x-arns-resolved-id'], txId);
     assert.strictEqual(typeof res.headers['x-arns-ttl-seconds'], 'string');
     assert.strictEqual(typeof res.headers['x-arns-process-id'], 'string');
   });
@@ -146,7 +136,7 @@ describe('ArNS', function () {
     const res = await axios.get(
       'http://localhost:4000/ar-io/resolver/nonexistent',
       {
-        headers: { Host: 'ardrive.ar-io.localhost' },
+        validateStatus: (status) => status === 404, // only accept 404 status
       },
     );
 

--- a/test/end-to-end/arns.test.ts
+++ b/test/end-to-end/arns.test.ts
@@ -110,4 +110,46 @@ describe('ArNS', function () {
     // Assert that the Location header matches the expected URL
     assert.strictEqual(res.headers['location'], expectedRedirect);
   });
+
+  // verify the /ar-io/resolver/:name endpoint
+  it('Verifying that /ar-io/resolver/:name returns 200 and resolution data', async function () {
+    const txId = 'TB2wJyKrPnkAW79DAwlJYwpgdHKpijEJWQfcwX715Co';
+    const res = await axios.get(
+      'http://localhost:4000/ar-io/resolver/ardrive',
+      {
+        headers: { Host: 'ardrive.ar-io.localhost' },
+      },
+    );
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.data.txId, txId);
+    assert.strictEqual(typeof res.data.ttlSeconds, 'number');
+    assert.strictEqual(typeof res.data.processId, 'string');
+  });
+
+  // verify the headers are set correctly on the response
+  it('Verifying that /ar-io/resolver/:name returns 200 and sets the correct headers', async function () {
+    const txId = 'TB2wJyKrPnkAW79DAwlJYwpgdHKpijEJWQfcwX715Co';
+    const res = await axios.get(
+      'http://localhost:4000/ar-io/resolver/ardrive',
+      {
+        headers: { Host: 'ardrive.ar-io.localhost' },
+      },
+    );
+
+    assert.strictEqual(typeof res.headers['x-arns-resolved-id'], txId);
+    assert.strictEqual(typeof res.headers['x-arns-ttl-seconds'], 'string');
+    assert.strictEqual(typeof res.headers['x-arns-process-id'], 'string');
+  });
+
+  it('Verifying that /ar-io/resolver/:name returns 404 for nonexistent name', async function () {
+    const res = await axios.get(
+      'http://localhost:4000/ar-io/resolver/nonexistent',
+      {
+        headers: { Host: 'ardrive.ar-io.localhost' },
+      },
+    );
+
+    assert.strictEqual(res.status, 404);
+  });
 });


### PR DESCRIPTION
This is the same behavior in the middleware, but does not fetch the data. Useful for those that just want resolution info for a name.