### PR TITLE
fix(arns): remove service default for TRUSTED_ARNS_GATEWAY_URL

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -50,7 +50,11 @@ const app = express();
 
 app.use(
   cors({
-    exposedHeaders: [headerNames.arnsResolvedId, headerNames.arnsTtlSeconds],
+    exposedHeaders: [
+      headerNames.arnsResolvedId,
+      headerNames.arnsTtlSeconds,
+      headerNames.arnsProcessId,
+    ],
   }),
 );
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -298,9 +298,8 @@ export const ARNS_ON_DEMAND_CIRCUIT_BREAKER_RESET_TIMEOUT_MS =
   );
 
 // TODO: support multiple gateway urls
-export const TRUSTED_ARNS_GATEWAY_URL = env.varOrDefault(
+export const TRUSTED_ARNS_GATEWAY_URL = env.varOrUndefined(
   'TRUSTED_ARNS_GATEWAY_URL',
-  'https://__NAME__.arweave.net',
 );
 
 //

--- a/src/init/resolvers.ts
+++ b/src/init/resolvers.ts
@@ -74,7 +74,6 @@ export const createArNSResolver = ({
   trustedGatewayUrl?: string;
   networkProcess?: AoIORead;
 }): NameResolver => {
-  log.info(`Using ${resolutionOrder} for arns name resolution`);
   const resolverMap: Record<ArNSResolverType, NameResolver | undefined> = {
     'on-demand': new OnDemandArNSResolver({
       log,
@@ -102,6 +101,10 @@ export const createArNSResolver = ({
       log.warn(`Ignoring unsupported resolver type: ${resolverType}`);
     }
   }
+
+  log.info(
+    `Using ${resolvers.map((r) => r.constructor.name).join(',')} for arns name resolution`,
+  );
 
   return new CompositeArNSResolver({
     log,


### PR DESCRIPTION
By defaulting this in the service, there is no way to disable gateway arns resolution. Instead we will leave the default in the docker-compose and set to undefined if not provided to disable always falling back to arweave.net