### PR TITLE
cache for saveNestedDataHash calls to prevent duplicate writes

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -124,6 +124,12 @@ export const methodDurationSummary = new promClient.Summary({
   labelNames: ['worker', 'role', 'method'],
 });
 
+export const saveMethodsDuplicateCounter = new promClient.Counter({
+  name: 'save_methods_duplicate_total',
+  help: 'Count of duplicate calls to save methods',
+  labelNames: ['method'],
+});
+
 //
 // Block importer metrics
 //


### PR DESCRIPTION
Add a cache for saveNestedDataHash calls to prevent duplicate writes. Add a metrics counter for the number of duplicate saveNestedDataHash calls.

In an environment with ~830 calls to saveNestedDataHash per second after 7 minutes of operation(cache entry TTL), the amount of cached keys was ~349k, with a total of ~33MB of data stored in the cache.

Total amount of duplicated calls was 1428.