### PR TITLE
perf(arns): cache resolution for non-existent name

### DIFF
--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -49,7 +49,7 @@ export class CompositeArNSResolver implements NameResolver {
         const cachedResolution: NameResolution = JSON.parse(
           cachedResolutionBuffer.toString(),
         );
-        resolution = cachedResolution; // hold on tho this in case we need it
+        resolution = cachedResolution; // hold on to this in case we need it
         if (
           cachedResolution !== undefined &&
           cachedResolution.resolvedAt !== undefined &&
@@ -71,7 +71,7 @@ export class CompositeArNSResolver implements NameResolver {
             name,
           });
           const resolution = await resolver.resolve(name);
-          if (resolution.resolvedId !== undefined) {
+          if (resolution.resolvedAt !== undefined) {
             this.cache.set(name, Buffer.from(JSON.stringify(resolution)));
             this.log.info('Resolved name', { name, resolution });
             return resolution;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -596,7 +596,17 @@ export interface ValidNameResolution {
   processId: string;
 }
 
+// Name resolved, but is missing
 export interface MissingNameResolution {
+  name: string;
+  resolvedId: undefined;
+  resolvedAt: number;
+  ttl: number;
+  processId: undefined;
+}
+
+// An error occured while resolving the name
+export interface FailedNameResolution {
   name: string;
   resolvedId: undefined;
   resolvedAt: undefined;
@@ -604,7 +614,10 @@ export interface MissingNameResolution {
   processId: undefined;
 }
 
-type NameResolution = ValidNameResolution | MissingNameResolution;
+type NameResolution =
+  | ValidNameResolution
+  | MissingNameResolution
+  | FailedNameResolution;
 
 export interface NameResolver {
   resolve(name: string): Promise<NameResolution>;


### PR DESCRIPTION
Without this it's easy for non-existent names to DOS the CUs we're using to resolve names. This change caches non-existent name resolutions for 5 minutes in the in-memory/Redis cache.