### PR TITLE
metrics: add WAL checkpoint metrics

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -130,6 +130,12 @@ export const saveMethodsDuplicateCounter = new promClient.Counter({
   labelNames: ['method'],
 });
 
+export const sqliteWalCheckpointPages = new promClient.Gauge({
+  name: 'sqlite_wal_checkpoint_pages',
+  help: 'Number of pages in the WAL',
+  labelNames: ['db', 'type'],
+});
+
 //
 // Block importer metrics
 //


### PR DESCRIPTION
Add metrics for the WAL checkpoint pages for each database.

Log output:
```
info: WAL checkpoint {"class":"StandaloneSqliteDatabase","dbName":"data","timestamp":"2024-09-24T14:22:13.957Z","walCheckpoint":{"busy":0,"checkpointed":0,"log":0}}
```

Metric output:
```
sqlite_wal_checkpoint_pages{db="data",type="busy"} 0
sqlite_wal_checkpoint_pages{db="data",type="checkpointed"} 0
sqlite_wal_checkpoint_pages{db="data",type="log"} 0
```