### PR TITLE
feat(arns): allow operator to override arns ttls and force refreshes …

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -268,6 +268,15 @@ export const ARNS_CACHE_TTL_SECONDS = +env.varOrDefault(
   `${60 * 60}`, // 1 hour
 );
 
+export const ARNS_RESOLVER_OVERRIDE_TTL_SECONDS_STRING = env.varOrUndefined(
+  'ARNS_RESOLVER_OVERRIDE_TTL_SECONDS',
+);
+
+export const ARNS_RESOLVER_OVERRIDE_TTL_SECONDS =
+  ARNS_RESOLVER_OVERRIDE_TTL_SECONDS_STRING !== undefined
+    ? +ARNS_RESOLVER_OVERRIDE_TTL_SECONDS_STRING
+    : undefined;
+
 export const ARNS_CACHE_MAX_KEYS = +env.varOrDefault(
   'ARNS_CACHE_MAX_KEYS',
   '10000',

--- a/src/init/resolvers.ts
+++ b/src/init/resolvers.ts
@@ -70,12 +70,16 @@ export const createArNSResolver = ({
   resolutionOrder,
   trustedGatewayUrl,
   networkProcess,
+  overrides,
 }: {
   log: Logger;
   cache: KvArnsStore;
   resolutionOrder: (ArNSResolverType | string)[];
   trustedGatewayUrl?: string;
   networkProcess?: AoIORead;
+  overrides?: {
+    ttlSeconds?: number;
+  };
 }): NameResolver => {
   const resolverMap: Record<ArNSResolverType, NameResolver | undefined> = {
     'on-demand': new OnDemandArNSResolver({
@@ -113,5 +117,6 @@ export const createArNSResolver = ({
     log,
     resolvers,
     cache,
+    overrides,
   });
 };

--- a/src/system.ts
+++ b/src/system.ts
@@ -568,6 +568,10 @@ export const nameResolver = createArNSResolver({
   resolutionOrder: config.ARNS_RESOLVER_PRIORITY_ORDER,
   networkProcess: arIO,
   cache: arnsResolverCache,
+  overrides: {
+    ttlSeconds: config.ARNS_RESOLVER_OVERRIDE_TTL_SECONDS,
+    // TODO: other overrides like fallback txId if not found in resolution
+  },
 });
 
 const webhookEmitter = new WebhookEmitter({


### PR DESCRIPTION
…based on env variable

Introduces `ARNS_RESOLVER_OVERRIDE_TTL_SECONDS` env variable which can be used to override when to refresh arns names. If set to `0` the resolver will always attempt to fetch the latest resolution data from the resolvers. If it fails to refretch, it will fallback to what it has cached.

### Testing
```bash
ARNS_RESOLVER_OVERRIDE_TTL_SECONDS=0
```
First resolved at: **1727378491422**
Second resolved at: **1727378509536** (18s later)

Logs
```
info: Resolving name... {"class":"CompositeArNSResolver","name":"dtf","overrides":{"ttlSeconds":0},"timestamp":"2024-09-26T19:21:29.144Z"}
info: Cache miss for arns name {"class":"CompositeArNSResolver","name":"dtf","timestamp":"2024-09-26T19:21:29.145Z"}
info: Attempting to resolve name with resolver {"class":"CompositeArNSResolver","name":"dtf","timestamp":"2024-09-26T19:21:29.145Z","type":"OnDemandArNSResolver"}
info: Resolving name... {"class":"OnDemandArNSResolver","name":"dtf","timestamp":"2024-09-26T19:21:29.145Z"}
info: Resolved name {"class":"CompositeArNSResolver","name":"dtf","resolution":{"name":"dtf","processId":"j2CetgCJlRhiuoqtxEWkXjaaar-KvxqI3i8d0K7Grqo","resolvedAt":1727378491422,"resolvedId":"TzeIML94iFdoQKc6rz0JP74FLSXNscWc52q_uvXtC34","ttl":3600},"timestamp":"2024-09-26T19:21:31.423Z"}
info: Resolving name... {"class":"CompositeArNSResolver","name":"dtf","overrides":{"ttlSeconds":0},"timestamp":"2024-09-26T19:21:47.201Z"}
info: Cache miss for arns name {"class":"CompositeArNSResolver","name":"dtf","timestamp":"2024-09-26T19:21:47.201Z"}
info: Attempting to resolve name with resolver {"class":"CompositeArNSResolver","name":"dtf","timestamp":"2024-09-26T19:21:47.201Z","type":"OnDemandArNSResolver"}
info: Resolving name... {"class":"OnDemandArNSResolver","name":"dtf","timestamp":"2024-09-26T19:21:47.201Z"}
info: Resolved name {"class":"CompositeArNSResolver","name":"dtf","resolution":{"name":"dtf","processId":"j2CetgCJlRhiuoqtxEWkXjaaar-KvxqI3i8d0K7Grqo","resolvedAt":1727378509536,"resolvedId":"TzeIML94iFdoQKc6rz0JP74FLSXNscWc52q_uvXtC34","ttl":3600},"timestamp":"2024-09-26T19:21:49.536Z"}
```