### PR TITLE
feat(parquet-exporter): add status endpoint for parquet export

### DIFF
--- a/src/workers/parquet-exporter.ts
+++ b/src/workers/parquet-exporter.ts
@@ -97,8 +97,9 @@ export class ParquetExporter {
     maxFileRows: number;
   }): Promise<void> {
     if (this.exportStatus.status === RUNNING) {
-      this.log.error('An export is already in progress');
-      return;
+      const error = new Error('An export is already in progress');
+      this.log.error(error.message);
+      return Promise.reject(error);
     }
 
     this.exportStatus.status = RUNNING;

--- a/src/workers/parquet-exporter.ts
+++ b/src/workers/parquet-exporter.ts
@@ -53,6 +53,8 @@ type ExportData = {
   endHeight?: number;
   maxFileRows?: number;
   durationInSeconds?: number;
+  endTime?: string;
+  endTimestamp?: number;
   error?: string;
 };
 
@@ -132,8 +134,8 @@ export class ParquetExporter {
 
       this.worker.on('message', (message: Message) => {
         if (message.eventName === EXPORT_COMPLETE) {
-          const endTime = Date.now();
-          const durationInSeconds = (endTime - startTime) / 1000; // Convert to seconds
+          const endTime = new Date();
+          const durationInSeconds = (endTime.getTime() - startTime) / 1000; // Convert to seconds
 
           this.log.info(`Parquet export completed`, {
             outputDir,
@@ -149,19 +151,28 @@ export class ParquetExporter {
             startHeight,
             endHeight,
             maxFileRows,
+            endTime: endTime.toISOString(),
+            endTimestamp: endTime.getTime(),
             durationInSeconds,
           };
 
           resolve();
         } else if (message.eventName === EXPORT_ERROR) {
+          const endTime = new Date();
+          const durationInSeconds = (endTime.getTime() - startTime) / 1000; // Convert to seconds
+
           this.exportStatus = {
             status: ERRORED,
             error: message.error,
+            endTime: endTime.toISOString(),
+            endTimestamp: endTime.getTime(),
+            durationInSeconds,
           };
 
           this.log.error('Parquet export error', {
             error: message.error,
             stack: message.stack,
+            durationInSeconds,
           });
 
           reject(new Error(message.error));


### PR DESCRIPTION
The new `/ar-io/admin/export-parquet/status` endpoint will return a json message with the following structure:
```
{
  pending: boolean;
  outputDir?: string;
  startHeight?: number;
  endHeight?: number;
  maxFileRows?: number;
  durationInSeconds?: number;
  error?: string;
}
```

`pending` is always present and the other attributes are present when needed.