### PR TITLE
fix(sqlite): flush data items using bundle db writer PE-6872

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/ar-io/ar-io-node"
   },
   "dependencies": {
-    "@ar.io/sdk": "^2.0.0",
+    "@ar.io/sdk": "^2.2.5",
     "@aws-lite/client": "^0.21.7",
     "@aws-lite/s3": "^0.1.21",
     "@clickhouse/client": "^1.3.0",


### PR DESCRIPTION
Prior to this commit, data items were flushed via the core DB writer. Under sufficiently heavy bunde import load this lead to contention with data item writes. This change adjusts the flushing logic to use the bundle DB writer. This avoids concurrent bundle DB write attempts and eliminates the contention.