### PR TITLE
fix(db): add created_at field when blocking name

### DIFF
--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -2394,6 +2394,7 @@ export class StandaloneSqliteDatabaseWorker {
     if (source !== undefined) {
       this.stmts.moderation.insertSource.run({
         name: source,
+        created_at: currentUnixTimestamp(),
       });
       sourceId = this.stmts.moderation.getSourceByName.get({
         name: source,


### PR DESCRIPTION
This is causing and uncaught exception `Uncaught exception: Error in StandaloneSqlite worker","name":"DetailedError","stack":"RangeError: Missing named parameter \"created_at\"\n    at StandaloneSqliteDatabaseWorker.blockName (file:///app/dist/database/standalone-sqlite.js:1581:48)\n `