### PR TITLE
chore(deps): update ar-io-sdk to v3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/ar-io/ar-io-node"
   },
   "dependencies": {
-    "@ar.io/sdk": "^3.1.0-alpha.11",
+    "@ar.io/sdk": "^3.1.0",
     "@aws-lite/client": "^0.22.4",
     "@aws-lite/s3": "^0.2.6",
     "@clickhouse/client": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/ar-io/ar-io-node"
   },
   "dependencies": {
-    "@ar.io/sdk": "^2.2.5",
+    "@ar.io/sdk": "^3.1.0-alpha.11",
     "@aws-lite/client": "^0.22.4",
     "@aws-lite/s3": "^0.2.6",
     "@clickhouse/client": "^1.3.0",

--- a/src/data/ar-io-data-source.test.ts
+++ b/src/data/ar-io-data-source.test.ts
@@ -19,7 +19,7 @@ import { strict as assert } from 'node:assert';
 import { afterEach, before, beforeEach, describe, it, mock } from 'node:test';
 import * as winston from 'winston';
 import axios from 'axios';
-import { AoIORead, IO } from '@ar.io/sdk';
+import { AoARIORead, ARIO } from '@ar.io/sdk';
 import { Readable } from 'node:stream';
 import { RequestAttributes } from '../types.js';
 import { ArIODataSource } from './ar-io-data-source.js';
@@ -29,7 +29,7 @@ import { TestDestroyedReadable, axiosStreamData } from './test-utils.js';
 let log: winston.Logger;
 let dataSource: ArIODataSource;
 let requestAttributes: RequestAttributes;
-let mockedArIOInstance: AoIORead;
+let mockedArIOInstance: AoARIORead;
 let mockedAxiosGet: any;
 
 before(async () => {
@@ -70,7 +70,7 @@ beforeEach(async () => {
     },
   });
 
-  mock.method(IO, 'init', () => mockedArIOInstance);
+  mock.method(ARIO, 'init', () => mockedArIOInstance);
 
   mock.method(axios, 'get', mockedAxiosGet);
 
@@ -80,7 +80,7 @@ beforeEach(async () => {
 
   dataSource = new ArIODataSource({
     log,
-    arIO: IO.init(),
+    arIO: ARIO.init(),
     nodeWallet: 'localNode',
   });
 

--- a/src/data/ar-io-data-source.ts
+++ b/src/data/ar-io-data-source.ts
@@ -17,7 +17,7 @@
  */
 import { default as axios, AxiosResponse } from 'axios';
 import winston from 'winston';
-import { AoIORead } from '@ar.io/sdk';
+import { AoARIORead } from '@ar.io/sdk';
 import { randomInt } from 'node:crypto';
 
 import {
@@ -43,7 +43,7 @@ export class ArIODataSource implements ContiguousDataSource {
   private requestTimeoutMs: number;
   private updatePeersRefreshIntervalMs: number;
 
-  private arIO: AoIORead;
+  private arIO: AoARIORead;
   peers: Record<string, string> = {};
   private intervalId?: NodeJS.Timeout;
 
@@ -56,7 +56,7 @@ export class ArIODataSource implements ContiguousDataSource {
     updatePeersRefreshIntervalMs = DEFAULT_UPDATE_PEERS_REFRESH_INTERVAL_MS,
   }: {
     log: winston.Logger;
-    arIO: AoIORead;
+    arIO: AoARIORead;
     nodeWallet?: string;
     maxHopsAllowed?: number;
     requestTimeoutMs?: number;
@@ -108,7 +108,7 @@ export class ArIODataSource implements ContiguousDataSource {
         cursor = nextCursor;
       } catch (error: any) {
         log.error(
-          'Failed to fetch gateways from IO. Returning current peer list.',
+          'Failed to fetch gateways from ARIO Returning current peer list.',
           {
             message: error.message,
             stack: error.stack,

--- a/src/init/resolvers.ts
+++ b/src/init/resolvers.ts
@@ -19,7 +19,7 @@ import { Logger } from 'winston';
 import { OnDemandArNSResolver } from '../resolution/on-demand-arns-resolver.js';
 import { TrustedGatewayArNSResolver } from '../resolution/trusted-gateway-arns-resolver.js';
 import { KVBufferStore, NameResolver } from '../types.js';
-import { AoIORead } from '@ar.io/sdk';
+import { AoARIORead } from '@ar.io/sdk';
 import { CompositeArNSResolver } from '../resolution/composite-arns-resolver.js';
 import { RedisKvStore } from '../store/redis-kv-store.js';
 import { NodeKvStore } from '../store/node-kv-store.js';
@@ -76,7 +76,7 @@ export const createArNSResolver = ({
   cache: KvArnsStore;
   resolutionOrder: (ArNSResolverType | string)[];
   trustedGatewayUrl?: string;
-  networkProcess?: AoIORead;
+  networkProcess?: AoARIORead;
   overrides?: {
     ttlSeconds?: number;
   };

--- a/src/resolution/arns-names-cache.test.ts
+++ b/src/resolution/arns-names-cache.test.ts
@@ -19,7 +19,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import winston from 'winston';
 import { ArNSNamesCache } from './arns-names-cache.js';
-import { AoIORead } from '@ar.io/sdk';
+import { AoARIORead } from '@ar.io/sdk';
 
 const createMockNetworkProcess = () => {
   let callCount = 0;
@@ -41,7 +41,7 @@ const createMockNetworkProcess = () => {
         nextCursor: undefined,
       };
     },
-  } as unknown as AoIORead;
+  } as unknown as AoARIORead;
 };
 
 describe('ArNSNamesCache', () => {
@@ -125,7 +125,7 @@ describe('ArNSNamesCache', () => {
           nextCursor: undefined,
         };
       },
-    } as unknown as AoIORead;
+    } as unknown as AoARIORead;
 
     const cache = new ArNSNamesCache({
       log,
@@ -146,7 +146,7 @@ describe('ArNSNamesCache', () => {
         callCount++;
         throw new Error(`Attempt ${callCount} failed`);
       },
-    } as unknown as AoIORead;
+    } as unknown as AoARIORead;
 
     const cache = new ArNSNamesCache({
       log,
@@ -178,7 +178,7 @@ describe('ArNSNamesCache', () => {
           nextCursor: undefined,
         };
       },
-    } as unknown as AoIORead;
+    } as unknown as AoARIORead;
 
     const retryDelay = 100;
     const cache = new ArNSNamesCache({
@@ -207,7 +207,7 @@ describe('ArNSNamesCache', () => {
           nextCursor: undefined,
         };
       },
-    } as unknown as AoIORead;
+    } as unknown as AoARIORead;
 
     const cache = new ArNSNamesCache({
       log,
@@ -234,7 +234,7 @@ describe('ArNSNamesCache', () => {
         }
         throw new Error('Network error');
       },
-    } as unknown as AoIORead;
+    } as unknown as AoARIORead;
 
     const cache = new ArNSNamesCache({
       log,
@@ -258,7 +258,7 @@ describe('ArNSNamesCache', () => {
         callCount++;
         throw new Error(`Attempt ${callCount} failed`);
       },
-    } as unknown as AoIORead;
+    } as unknown as AoARIORead;
 
     const cache = new ArNSNamesCache({
       log,

--- a/src/resolution/arns-names-cache.ts
+++ b/src/resolution/arns-names-cache.ts
@@ -19,9 +19,9 @@ import winston from 'winston';
 
 import {
   AoClient,
-  AoIORead,
+  AoARIORead,
   AOProcess,
-  IO,
+  ARIO,
   fetchAllArNSRecords,
 } from '@ar.io/sdk';
 import * as config from '../config.js';
@@ -33,7 +33,7 @@ const DEFAULT_RETRY_DELAY = 5 * 1000; // 5 seconds
 
 export class ArNSNamesCache {
   private log: winston.Logger;
-  private networkProcess: AoIORead;
+  private networkProcess: AoARIORead;
   private namesCache: Promise<Set<string>>;
   private lastSuccessfulNames: Set<string> | null = null;
   private lastCacheTime = 0;
@@ -49,7 +49,7 @@ export class ArNSNamesCache {
       GRAPHQL_URL: config.AO_GRAPHQL_URL,
       GATEWAY_URL: config.AO_GATEWAY_URL,
     }),
-    networkProcess = IO.init({
+    networkProcess = ARIO.init({
       process: new AOProcess({
         processId: config.IO_PROCESS_ID,
         ao: ao,
@@ -61,7 +61,7 @@ export class ArNSNamesCache {
   }: {
     log: winston.Logger;
     ao?: AoClient;
-    networkProcess?: AoIORead;
+    networkProcess?: AoARIORead;
     cacheTtl?: number;
     maxRetries?: number;
     retryDelay?: number;

--- a/src/resolution/on-demand-arns-resolver.ts
+++ b/src/resolution/on-demand-arns-resolver.ts
@@ -19,7 +19,7 @@ import winston from 'winston';
 
 import { isValidDataId } from '../lib/validation.js';
 import { NameResolution, NameResolver } from '../types.js';
-import { ANT, AoClient, AoIORead, AOProcess, IO } from '@ar.io/sdk';
+import { ANT, AoClient, AoARIORead, AOProcess, ARIO } from '@ar.io/sdk';
 import * as config from '../config.js';
 import { connect } from '@permaweb/aoconnect';
 import CircuitBreaker from 'opossum';
@@ -27,11 +27,11 @@ import * as metrics from '../metrics.js';
 
 export class OnDemandArNSResolver implements NameResolver {
   private log: winston.Logger;
-  private networkProcess: AoIORead;
+  private networkProcess: AoARIORead;
   private ao: AoClient;
   private aoCircuitBreaker: CircuitBreaker<
-    Parameters<AoIORead['getArNSRecord']>,
-    Awaited<ReturnType<AoIORead['getArNSRecord']>>
+    Parameters<AoARIORead['getArNSRecord']>,
+    Awaited<ReturnType<AoARIORead['getArNSRecord']>>
   >;
 
   constructor({
@@ -42,7 +42,7 @@ export class OnDemandArNSResolver implements NameResolver {
       GRAPHQL_URL: config.AO_GRAPHQL_URL,
       GATEWAY_URL: config.AO_GATEWAY_URL,
     }),
-    networkProcess = IO.init({
+    networkProcess = ARIO.init({
       process: new AOProcess({
         processId: config.IO_PROCESS_ID,
         ao: ao,
@@ -58,7 +58,7 @@ export class OnDemandArNSResolver implements NameResolver {
     },
   }: {
     log: winston.Logger;
-    networkProcess?: AoIORead;
+    networkProcess?: AoARIORead;
     ao?: AoClient;
     circuitBreakerOptions?: CircuitBreaker.Options;
   }) {

--- a/src/system.ts
+++ b/src/system.ts
@@ -18,7 +18,7 @@
 import { default as Arweave } from 'arweave';
 import EventEmitter from 'node:events';
 import fs from 'node:fs';
-import { AOProcess, IO } from '@ar.io/sdk';
+import { AOProcess, ARIO } from '@ar.io/sdk';
 import awsLite from '@aws-lite/client';
 import awsLiteS3 from '@aws-lite/s3';
 
@@ -97,7 +97,7 @@ const arweave = Arweave.init({});
 
 // IO/AO SDK
 
-const arIO = IO.init({
+const arIO = ARIO.init({
   process: new AOProcess({
     processId: config.IO_PROCESS_ID,
     ao: connect({

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,18 +119,20 @@
   dependencies:
     xss "^1.0.8"
 
-"@ar.io/sdk@^2.2.5":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-2.3.2.tgz#afac6c5cb38f517f53af6c9d70eeea9175fc70c4"
-  integrity sha512-O1BX951DzwRB3/9hc8O8PulxE84qe6wSN3ADqlJT4W0k9RcWLN/rbGMdSPaoN8dMgnxwtnIkXkHw6CG9Fu+V3g==
+"@ar.io/sdk@^3.1.0-alpha.11":
+  version "3.1.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.1.0-alpha.11.tgz#ef66226c4e4fbdf61856a07712f591b36849bb5a"
+  integrity sha512-E40PPBIQ9nob59/4pSghiay+VuSuaIby39O5iLnC9w1gO76UTCUaGJDszKDozuvG6xFkHQkzWqKC8F/FqT/ZeA==
   dependencies:
     "@dha-team/arbundles" "^1.0.1"
     "@permaweb/aoconnect" "^0.0.57"
     arweave "1.14.4"
-    axios "1.7.7"
+    axios "1.7.9"
     axios-retry "^4.3.0"
+    commander "^12.1.0"
     eventemitter3 "^5.0.1"
     plimit-lit "^3.0.1"
+    prompts "^2.4.2"
     winston "^3.13.0"
     zod "^3.23.8"
 
@@ -3384,10 +3386,10 @@ axios-retry@^4.3.0:
   dependencies:
     is-retry-allowed "^2.2.0"
 
-axios@1.7.7:
-  version "1.7.7"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
-  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
+axios@1.7.9:
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
+  integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
@@ -3916,6 +3918,11 @@ commander@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
+commander@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
 
 commander@^2.20.3:
   version "2.20.3"
@@ -5652,6 +5659,11 @@ keyv@^4.5.3:
   dependencies:
     json-buffer "3.0.1"
 
+kleur@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+  integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
 kleur@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
@@ -6820,6 +6832,14 @@ prompts-ncu@^3.0.0:
   integrity sha512-qyz9UxZ5MlPKWVhWrCmSZ1ahm2GVYdjLb8og2sg0IPth1KRuhcggHGuijz0e41dkx35p1t1q3GRISGH7QGALFA==
   dependencies:
     kleur "^4.0.1"
+    sisteransi "^1.0.5"
+
+prompts@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
+  integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
+  dependencies:
+    kleur "^3.0.3"
     sisteransi "^1.0.5"
 
 proper-lockfile@^4.1.2:

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,10 +119,10 @@
   dependencies:
     xss "^1.0.8"
 
-"@ar.io/sdk@^3.1.0-alpha.11":
-  version "3.1.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.1.0-alpha.11.tgz#ef66226c4e4fbdf61856a07712f591b36849bb5a"
-  integrity sha512-E40PPBIQ9nob59/4pSghiay+VuSuaIby39O5iLnC9w1gO76UTCUaGJDszKDozuvG6xFkHQkzWqKC8F/FqT/ZeA==
+"@ar.io/sdk@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.1.0.tgz#adb95ec64627f73c2b7c76db5e0afbc34ac18361"
+  integrity sha512-ePtvVcffzJcU+LoHqjL0RwJeS/3dCgEolWw7/ywIWwXvzYbbhASdNdBEb6/Liz8baMO/GYsaUGVSpnjmVKC0aw==
   dependencies:
     "@dha-team/arbundles" "^1.0.1"
     "@permaweb/aoconnect" "^0.0.57"


### PR DESCRIPTION
The newest version of the SDK leverages newest handlers and updated types. It also includes the modifications to align with the ARIO token branding.

Related: https://github.com/ar-io/ar-io-observer/pull/54