### PR TITLE
fix(arns): fix undername resolution, add e2e tests

### DIFF
--- a/src/resolution/on-demand-arns-resolver.ts
+++ b/src/resolution/on-demand-arns-resolver.ts
@@ -83,7 +83,7 @@ export class OnDemandArNSResolver implements NameResolver {
   async resolve(name: string): Promise<NameResolution> {
     this.log.info('Resolving name...', { name });
     try {
-      // get the base name which is the last of th array split by _
+      // get the base name which is the last of the array split by _
       const baseName = name.split('_').pop();
       if (baseName === undefined) {
         throw new Error('Invalid name');


### PR DESCRIPTION
The arns name cache only contains base names. When an undername is requested, it fails to find the full undername in the cache and results in a 404. This modifies the behavior to parse out the base name from an undername, and check the arns name cache for that base name first. Then it checks the resolution cache for the full name data of the undername. Additional e2e tests have been added to ensure this behavior does not regress in future modifications to arns handling.