### PR TITLE
fix(arns): introduce cache miss/hit debouncing for arns name cache

### DIFF
--- a/docs/madr/002-arns-cache-timing.md
+++ b/docs/madr/002-arns-cache-timing.md
@@ -62,14 +62,20 @@ flowchart TD
 
 - **Name list TTL** - The maximum interval between name list cache refreshes
   for names already in the cached name list. Suggested default: 1 hour.
-- **Name list miss debounce interval** - The miminum amount of time between
+- **Name list miss debounce interval** - The minimum amount of time between
   name list cache refreshes triggered by names not found in the cache.
   Suggested default: 10 seconds.
+- **Name list hit debounce interval** - The maximum amount of time between
+  name list cache refreshes triggered by names found in the cache. Suggested
+  default: 1 hour.
 - **ANT state TTL** - The maximum interval between individual ANT state cache
   refreshes when the ANT state is already cached. Suggested default: 1 hour.
-- **ANT state debounce interval** - The minimum amount of time between ANT
+- **ANT state miss debounce interval** - The minimum amount of time between ANT
   state cache refreshes triggered by missing ANT state. Suggested default: 10
   seconds.
+- **ANT state hit debounce interval** - The maximum amount of time between ANT
+  state cache refreshes triggered by names found in the ANT state cache.
+  Suggested default: 5 minutes.
 - **ANT state concurrency limit** - The maximum number of parallel in-flight
   ANT state requests to the CU. Suggested default: 10.
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "node-cache": "^5.1.2",
     "opossum": "^8.1.3",
     "opossum-prometheus": "^0.3.0",
+    "p-debounce": "^4.0.0",
     "p-limit": "^6.2.0",
     "prom-client": "^14.0.1",
     "ramda": "^0.28.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -469,6 +469,30 @@ export const ARNS_NAMES_CACHE_TTL_SECONDS = +env.varOrDefault(
   `${5 * 60}`, // 5 minutes
 );
 
+export const ARNS_NAME_LIST_CACHE_MISS_REFRESH_INTERVAL_SECONDS =
+  +env.varOrDefault(
+    'ARNS_NAME_LIST_CACHE_MISS_REFRESH_INTERVAL_SECONDS',
+    `${10}`, // 10 seconds
+  );
+
+export const ARNS_NAME_LIST_CACHE_HIT_REFRESH_INTERVAL_SECONDS =
+  +env.varOrDefault(
+    'ARNS_NAME_LIST_CACHE_HIT_REFRESH_INTERVAL_SECONDS',
+    `${60 * 60}`, // 1 hour
+  );
+
+export const ARNS_ANT_STATE_CACHE_MISS_REFRESH_INTERVAL_SECONDS =
+  +env.varOrDefault(
+    'ARNS_ANT_STATE_CACHE_MISS_REFRESH_INTERVAL_SECONDS',
+    `${10}`, // 10 seconds
+  );
+
+export const ARNS_ANT_STATE_CACHE_HIT_REFRESH_INTERVAL_SECONDS =
+  +env.varOrDefault(
+    'ARNS_ANT_STATE_CACHE_HIT_REFRESH_INTERVAL_SECONDS',
+    `${60 * 5}`, // 5 minutes
+  );
+
 // TODO: support multiple gateway urls
 export const TRUSTED_ARNS_GATEWAY_URL = env.varOrUndefined(
   'TRUSTED_ARNS_GATEWAY_URL',

--- a/src/init/resolvers.ts
+++ b/src/init/resolvers.ts
@@ -116,7 +116,7 @@ export const createArNSResolver = ({
   return new CompositeArNSResolver({
     log,
     resolvers,
-    cache,
+    resolutionCache: cache,
     overrides,
   });
 };

--- a/src/init/resolvers.ts
+++ b/src/init/resolvers.ts
@@ -23,7 +23,8 @@ import { AoARIORead } from '@ar.io/sdk';
 import { CompositeArNSResolver } from '../resolution/composite-arns-resolver.js';
 import { RedisKvStore } from '../store/redis-kv-store.js';
 import { NodeKvStore } from '../store/node-kv-store.js';
-import { KvArnsStore } from '../store/kv-arns-store.js';
+import { KvArNSRegistryStore } from '../store/kv-arns-base-name-store.js';
+import { KvArNSResolutionStore } from '../store/kv-arns-name-resolution-store.js';
 
 const supportedResolvers = ['on-demand', 'gateway'] as const;
 export type ArNSResolverType = (typeof supportedResolvers)[number];
@@ -66,15 +67,17 @@ export const createArNSKvStore = ({
 
 export const createArNSResolver = ({
   log,
-  cache,
+  resolutionCache,
   resolutionOrder,
+  registryCache,
   trustedGatewayUrl,
   networkProcess,
   overrides,
 }: {
   log: Logger;
-  cache: KvArnsStore;
+  resolutionCache: KvArNSResolutionStore;
   resolutionOrder: (ArNSResolverType | string)[];
+  registryCache: KvArNSRegistryStore;
   trustedGatewayUrl?: string;
   networkProcess?: AoARIORead;
   overrides?: {
@@ -116,7 +119,9 @@ export const createArNSResolver = ({
   return new CompositeArNSResolver({
     log,
     resolvers,
-    resolutionCache: cache,
+    resolutionCache,
+    registryCache,
+    networkProcess,
     overrides,
   });
 };

--- a/src/resolution/arns-names-cache.test.ts
+++ b/src/resolution/arns-names-cache.test.ts
@@ -33,12 +33,15 @@ const createMockNetworkProcess = () => {
         items: [
           {
             name: `name-${callCount}-1`,
+            processId: 'process-1',
           },
           {
             name: `name-${callCount}-2`,
+            processId: 'process-2',
           },
           {
             name: `name-${callCount}-3`,
+            processId: 'process-3',
           },
         ],
         nextCursor: undefined,
@@ -64,7 +67,14 @@ describe('ArNSNamesCache', () => {
     });
 
     const names = await cache.getNames();
-    assert.deepEqual(names, new Set(['name-1-1', 'name-1-2', 'name-1-3']));
+    assert.deepEqual(
+      names,
+      new Map([
+        ['name-1-1', { processId: 'process-1' }],
+        ['name-1-2', { processId: 'process-2' }],
+        ['name-1-3', { processId: 'process-3' }],
+      ]),
+    );
     assert.equal(await cache.getCacheSize(), 3);
   });
 
@@ -77,11 +87,25 @@ describe('ArNSNamesCache', () => {
     });
 
     const names1 = await cache.getNames();
-    assert.deepEqual(names1, new Set(['name-1-1', 'name-1-2', 'name-1-3']));
+    assert.deepEqual(
+      names1,
+      new Map([
+        ['name-1-1', { processId: 'process-1' }],
+        ['name-1-2', { processId: 'process-2' }],
+        ['name-1-3', { processId: 'process-3' }],
+      ]),
+    );
     assert.equal(await cache.getCacheSize(), 3);
 
     const names2 = await cache.getNames();
-    assert.deepEqual(names2, new Set(['name-1-1', 'name-1-2', 'name-1-3']));
+    assert.deepEqual(
+      names2,
+      new Map([
+        ['name-1-1', { processId: 'process-1' }],
+        ['name-1-2', { processId: 'process-2' }],
+        ['name-1-3', { processId: 'process-3' }],
+      ]),
+    );
     assert.equal(await cache.getCacheSize(), 3);
   });
 
@@ -92,11 +116,25 @@ describe('ArNSNamesCache', () => {
     });
 
     const names1 = await cache.getNames();
-    assert.deepEqual(names1, new Set(['name-1-1', 'name-1-2', 'name-1-3']));
+    assert.deepEqual(
+      names1,
+      new Map([
+        ['name-1-1', { processId: 'process-1' }],
+        ['name-1-2', { processId: 'process-2' }],
+        ['name-1-3', { processId: 'process-3' }],
+      ]),
+    );
     assert.equal(await cache.getCacheSize(), 3);
 
     const names2 = await cache.getNames({ forceCacheUpdate: true });
-    assert.deepEqual(names2, new Set(['name-2-1', 'name-2-2', 'name-2-3']));
+    assert.deepEqual(
+      names2,
+      new Map([
+        ['name-2-1', { processId: 'process-1' }],
+        ['name-2-2', { processId: 'process-2' }],
+        ['name-2-3', { processId: 'process-3' }],
+      ]),
+    );
     assert.equal(await cache.getCacheSize(), 3);
   });
 
@@ -109,14 +147,28 @@ describe('ArNSNamesCache', () => {
     });
 
     const names1 = await cache.getNames();
-    assert.deepEqual(names1, new Set(['name-1-1', 'name-1-2', 'name-1-3']));
+    assert.deepEqual(
+      names1,
+      new Map([
+        ['name-1-1', { processId: 'process-1' }],
+        ['name-1-2', { processId: 'process-2' }],
+        ['name-1-3', { processId: 'process-3' }],
+      ]),
+    );
     assert.equal(await cache.getCacheSize(), 3);
 
     // Wait for cache to expire
     await new Promise((resolve) => setTimeout(resolve, cacheTtl + 10));
 
     const names2 = await cache.getNames();
-    assert.deepEqual(names2, new Set(['name-2-1', 'name-2-2', 'name-2-3']));
+    assert.deepEqual(
+      names2,
+      new Map([
+        ['name-2-1', { processId: 'process-1' }],
+        ['name-2-2', { processId: 'process-2' }],
+        ['name-2-3', { processId: 'process-3' }],
+      ]),
+    );
     assert.equal(await cache.getCacheSize(), 3);
   });
 
@@ -129,7 +181,7 @@ describe('ArNSNamesCache', () => {
           throw new Error('Temporary failure');
         }
         return {
-          items: [{ name: 'success-after-retry' }],
+          items: [{ name: 'success-after-retry', processId: 'process-1' }],
           nextCursor: undefined,
         };
       },
@@ -143,7 +195,10 @@ describe('ArNSNamesCache', () => {
     });
 
     const names = await cache.getNames();
-    assert.deepEqual(names, new Set(['success-after-retry']));
+    assert.deepEqual(
+      names,
+      new Map([['success-after-retry', { processId: 'process-1' }]]),
+    );
     assert.equal(callCount, 3);
   });
 
@@ -211,7 +266,7 @@ describe('ArNSNamesCache', () => {
           return { items: [], nextCursor: undefined };
         }
         return {
-          items: [{ name: 'success' }],
+          items: [{ name: 'success', processId: 'process-1' }],
           nextCursor: undefined,
         };
       },
@@ -225,7 +280,7 @@ describe('ArNSNamesCache', () => {
     });
 
     const names = await cache.getNames();
-    assert.deepEqual(names, new Set(['success']));
+    assert.deepEqual(names, new Map([['success', { processId: 'process-1' }]]));
     assert.equal(callCount, 2);
   });
 
@@ -236,7 +291,7 @@ describe('ArNSNamesCache', () => {
         callCount++;
         if (callCount === 1) {
           return {
-            items: [{ name: 'initial-success' }],
+            items: [{ name: 'initial-success', processId: 'process-1' }],
             nextCursor: undefined,
           };
         }
@@ -252,10 +307,16 @@ describe('ArNSNamesCache', () => {
     });
 
     const initialNames = await cache.getNames();
-    assert.deepEqual(initialNames, new Set(['initial-success']));
+    assert.deepEqual(
+      initialNames,
+      new Map([['initial-success', { processId: 'process-1' }]]),
+    );
 
     const updatedNames = await cache.getNames({ forceCacheUpdate: true });
-    assert.deepEqual(updatedNames, new Set(['initial-success']));
+    assert.deepEqual(
+      updatedNames,
+      new Map([['initial-success', { processId: 'process-1' }]]),
+    );
     assert.equal(callCount, 4); // 1 initial + 3 retry attempts
   });
 
@@ -291,19 +352,20 @@ describe('ArNSNamesCache', () => {
         if (callCount === 0) {
           callCount++;
           return {
-            items: [{ name: 'name-0' }],
+            items: [{ name: 'name-0', processId: 'process-0' }],
             nextCursor: undefined,
           };
         }
         callCount++;
         return {
-          items: [{ name: 'name-0' }, { name: 'name-1' }],
+          items: [
+            { name: 'name-0', processId: 'process-0' },
+            { name: 'name-1', processId: 'process-1' },
+          ],
           nextCursor: undefined,
         };
       },
     } as unknown as AoARIORead;
-
-    log.level = 'debug';
 
     const cache = new ArNSNamesCache({
       log,
@@ -316,13 +378,13 @@ describe('ArNSNamesCache', () => {
     assert.equal(callCount, 1);
 
     // check a missing name, this should instantiate the debounce timeout to refresh the cache in 1 second
-    const missingName = await cache.has('name-1');
-    assert.equal(missingName, false, 'Name should not be cached');
+    const missingName = await cache.getName('name-1');
+    assert.equal(missingName, undefined, 'Name should not be cached');
     assert.equal(callCount, 1);
 
     // it should not trigger a refresh if the name is requested again within the ttl
-    const missingName2 = await cache.has('name-1');
-    assert.equal(missingName2, false, 'Name should not be cached');
+    const missingName2 = await cache.getName('name-1');
+    assert.equal(missingName2, undefined, 'Name should not be cached');
     assert.equal(callCount, 1);
 
     // wait the ttl + 5ms and assert that it does trigger a refresh and getArNSRecords is called again
@@ -335,7 +397,13 @@ describe('ArNSNamesCache', () => {
 
     // assert that the names are refreshed and the cache size is updated
     const names = await cache.getNames();
-    assert.deepEqual(names, new Set(['name-0', 'name-1']));
+    assert.deepEqual(
+      names,
+      new Map([
+        ['name-0', { processId: 'process-0' }],
+        ['name-1', { processId: 'process-1' }],
+      ]),
+    );
     assert.equal(await cache.getCacheSize(), 2);
   });
 
@@ -344,7 +412,10 @@ describe('ArNSNamesCache', () => {
     const mockNetworkProcess = {
       async getArNSRecords() {
         callCount++;
-        return { items: [{ name: 'name-1' }], nextCursor: undefined };
+        return {
+          items: [{ name: 'name-1', processId: 'process-1' }],
+          nextCursor: undefined,
+        };
       },
     } as unknown as AoARIORead;
 
@@ -361,19 +432,19 @@ describe('ArNSNamesCache', () => {
     await new Promise((resolve) => setTimeout(resolve, 5));
 
     // request a hit
-    const hitName = await cache.has('name-1');
-    assert.equal(hitName, true);
+    const hitName = await cache.getName('name-1');
+    assert.deepEqual(hitName, { processId: 'process-1' });
     assert.equal(callCount, 1);
 
     // assert that getArNS records is not called again if name is requested between cache hit cache and ttl
-    const hitName2 = await cache.has('name-1');
-    assert.equal(hitName2, true);
+    const hitName2 = await cache.getName('name-1');
+    assert.deepEqual(hitName2, { processId: 'process-1' });
     assert.equal(callCount, 1);
 
     // wait the ttl and assert that it does trigger a refresh
     await new Promise((resolve) => setTimeout(resolve, 15));
-    const debouncedName = await cache.has('name-1');
-    assert.equal(debouncedName, true);
+    const debouncedName = await cache.getName('name-1');
+    assert.deepEqual(debouncedName, { processId: 'process-1' });
     assert.equal(callCount, 2);
   });
 });

--- a/src/resolution/arns-names-cache.test.ts
+++ b/src/resolution/arns-names-cache.test.ts
@@ -28,7 +28,7 @@ ARIOLogger.default.setLogLevel('none');
 describe('ArNSNamesCache', () => {
   const log = winston.createLogger({
     // when debugging, set silent to false
-    transports: [new winston.transports.Console({ silent: false })],
+    transports: [new winston.transports.Console({ silent: true })],
     format: winston.format.combine(
       winston.format.timestamp(),
       winston.format.json(),

--- a/src/resolution/arns-names-cache.test.ts
+++ b/src/resolution/arns-names-cache.test.ts
@@ -302,7 +302,7 @@ describe('ArNSNamesCache', () => {
     assert.equal(missingName2, undefined, 'Name should not be cached');
     assert.equal(callCount, 1);
 
-    // wait cache miss ttl and assert that the hydrateFn was triggered and names were cached
+    // wait cache miss ttl and assert that the debounceFn was triggered and names were cached
     await new Promise((resolve) => setTimeout(resolve, 100));
     assert.equal(callCount, 2);
 

--- a/src/resolution/arns-names-cache.test.ts
+++ b/src/resolution/arns-names-cache.test.ts
@@ -16,414 +16,319 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'node:test';
+import { after, beforeEach, describe, it } from 'node:test';
 import winston from 'winston';
 import { ArNSNamesCache } from './arns-names-cache.js';
 import { AoARIORead, Logger as ARIOLogger } from '@ar.io/sdk';
+import { NodeKvStore } from '../store/node-kv-store.js';
 
 // disable sdk logging to reduce noise
 ARIOLogger.default.setLogLevel('none');
 
-const createMockNetworkProcess = () => {
-  let callCount = 0;
-  return {
-    async getArNSRecords() {
-      callCount++;
-      return {
-        items: [
-          {
-            name: `name-${callCount}-1`,
-            processId: 'process-1',
-          },
-          {
-            name: `name-${callCount}-2`,
-            processId: 'process-2',
-          },
-          {
-            name: `name-${callCount}-3`,
-            processId: 'process-3',
-          },
-        ],
-        nextCursor: undefined,
-      };
-    },
-  } as unknown as AoARIORead;
-};
-
 describe('ArNSNamesCache', () => {
   const log = winston.createLogger({
     // when debugging, set silent to false
-    transports: [new winston.transports.Console({ silent: true })],
+    transports: [new winston.transports.Console({ silent: false })],
     format: winston.format.combine(
       winston.format.timestamp(),
       winston.format.json(),
     ),
   });
 
-  it('should fetch and cache names on initialization', async () => {
-    const cache = new ArNSNamesCache({
-      log,
-      networkProcess: createMockNetworkProcess(),
-    });
+  let registryCache: NodeKvStore;
 
-    const names = await cache.getNames();
-    assert.deepEqual(
-      names,
-      new Map([
-        ['name-1-1', { processId: 'process-1' }],
-        ['name-1-2', { processId: 'process-2' }],
-        ['name-1-3', { processId: 'process-3' }],
-      ]),
-    );
-    assert.equal(await cache.getCacheSize(), 3);
+  beforeEach(async () => {
+    // new cache for each test
+    registryCache = new NodeKvStore({
+      ttlSeconds: 1,
+      maxKeys: 100,
+    });
   });
 
-  it('should use cached names within TTL period', async () => {
-    const cacheTtl = 1000;
-    const cache = new ArNSNamesCache({
+  after(async () => {
+    // exit forcefully due to intentional non-awaited promises in ArNSNamesCache
+    process.exit(0);
+  });
+
+  it('should fetch and cache names on initialization', async () => {
+    let callCount = 0;
+    const debounceCache = new ArNSNamesCache({
       log,
-      networkProcess: createMockNetworkProcess(),
-      cacheTtl,
+      registryCache,
+      networkProcess: {
+        getArNSRecords: async () => {
+          callCount++;
+          return {
+            items: [
+              {
+                name: `name-${callCount}-1`,
+                processId: `process-${callCount}`,
+              },
+            ],
+            nextCursor: undefined,
+          };
+        },
+      } as unknown as AoARIORead,
     });
 
-    const names1 = await cache.getNames();
-    assert.deepEqual(
-      names1,
-      new Map([
-        ['name-1-1', { processId: 'process-1' }],
-        ['name-1-2', { processId: 'process-2' }],
-        ['name-1-3', { processId: 'process-3' }],
-      ]),
-    );
-    assert.equal(await cache.getCacheSize(), 3);
+    // let the cache hydrate
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
-    const names2 = await cache.getNames();
-    assert.deepEqual(
-      names2,
-      new Map([
-        ['name-1-1', { processId: 'process-1' }],
-        ['name-1-2', { processId: 'process-2' }],
-        ['name-1-3', { processId: 'process-3' }],
-      ]),
-    );
-    assert.equal(await cache.getCacheSize(), 3);
+    // assert names were loaded right away
+    assert.equal(callCount, 1);
+
+    // assert the name was cached
+    const name = await debounceCache.getCachedArNSBaseName('name-1-1');
+    assert.deepEqual(name, { name: 'name-1-1', processId: 'process-1' });
+  });
+
+  it('should use cached names within TTL period', async (done) => {
+    let callCount = 0;
+    const debounceCache = new ArNSNamesCache({
+      log,
+      registryCache,
+      networkProcess: {
+        getArNSRecords: async () => {
+          callCount++;
+          return {
+            items: [
+              {
+                name: `name-${callCount}-1`,
+                processId: `process-${callCount}`,
+              },
+            ],
+            nextCursor: undefined,
+          };
+        },
+      } as unknown as AoARIORead,
+    });
+
+    // let the cache hydrate
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // assert the name was cached
+    const name = await debounceCache.getCachedArNSBaseName('name-1-1');
+    assert.deepEqual(name, { name: 'name-1-1', processId: 'process-1' });
+
+    // call it again and assert it's still cached and call count is still 1
+    const name2 = await debounceCache.getCachedArNSBaseName('name-1-1');
+    assert.deepEqual(name2, { name: 'name-1-1', processId: 'process-1' });
+    assert.equal(callCount, 1);
   });
 
   it('should refresh cache when forced', async () => {
-    const cache = new ArNSNamesCache({
-      log,
-      networkProcess: createMockNetworkProcess(),
-    });
-
-    const names1 = await cache.getNames();
-    assert.deepEqual(
-      names1,
-      new Map([
-        ['name-1-1', { processId: 'process-1' }],
-        ['name-1-2', { processId: 'process-2' }],
-        ['name-1-3', { processId: 'process-3' }],
-      ]),
-    );
-    assert.equal(await cache.getCacheSize(), 3);
-
-    const names2 = await cache.getNames({ forceCacheUpdate: true });
-    assert.deepEqual(
-      names2,
-      new Map([
-        ['name-2-1', { processId: 'process-1' }],
-        ['name-2-2', { processId: 'process-2' }],
-        ['name-2-3', { processId: 'process-3' }],
-      ]),
-    );
-    assert.equal(await cache.getCacheSize(), 3);
-  });
-
-  it('should refresh cache after TTL expires', async () => {
-    const cacheTtl = 100;
-    const cache = new ArNSNamesCache({
-      log,
-      networkProcess: createMockNetworkProcess(),
-      cacheTtl,
-    });
-
-    const names1 = await cache.getNames();
-    assert.deepEqual(
-      names1,
-      new Map([
-        ['name-1-1', { processId: 'process-1' }],
-        ['name-1-2', { processId: 'process-2' }],
-        ['name-1-3', { processId: 'process-3' }],
-      ]),
-    );
-    assert.equal(await cache.getCacheSize(), 3);
-
-    // Wait for cache to expire
-    await new Promise((resolve) => setTimeout(resolve, cacheTtl + 10));
-
-    const names2 = await cache.getNames();
-    assert.deepEqual(
-      names2,
-      new Map([
-        ['name-2-1', { processId: 'process-1' }],
-        ['name-2-2', { processId: 'process-2' }],
-        ['name-2-3', { processId: 'process-3' }],
-      ]),
-    );
-    assert.equal(await cache.getCacheSize(), 3);
-  });
-
-  it('should retry on failure and succeed within max retries', async () => {
     let callCount = 0;
-    const mockNetworkProcess = {
-      async getArNSRecords() {
-        callCount++;
-        if (callCount <= 2) {
-          throw new Error('Temporary failure');
-        }
-        return {
-          items: [{ name: 'success-after-retry', processId: 'process-1' }],
-          nextCursor: undefined,
-        };
-      },
-    } as unknown as AoARIORead;
-
-    const cache = new ArNSNamesCache({
+    const debounceCache = new ArNSNamesCache({
       log,
-      networkProcess: mockNetworkProcess,
-      maxRetries: 3,
-      retryDelay: 0,
-    });
-
-    const names = await cache.getNames();
-    assert.deepEqual(
-      names,
-      new Map([['success-after-retry', { processId: 'process-1' }]]),
-    );
-    assert.equal(callCount, 3);
-  });
-
-  it('should fail after exhausting all retry attempts', async () => {
-    let callCount = 0;
-    const mockNetworkProcess = {
-      async getArNSRecords() {
-        callCount++;
-        throw new Error(`Attempt ${callCount} failed`);
-      },
-    } as unknown as AoARIORead;
-
-    const cache = new ArNSNamesCache({
-      log,
-      networkProcess: mockNetworkProcess,
-      maxRetries: 3,
-      retryDelay: 0,
-    });
-
-    await assert.rejects(
-      () => cache.getNames(),
-      /Failed to fetch ArNS records after 3 attempts/,
-    );
-    assert.equal(callCount, 3);
-  });
-
-  it('should respect the retry delay between attempts', async () => {
-    let callCount = 0;
-    const timestamps: number[] = [];
-
-    const mockNetworkProcess = {
-      async getArNSRecords() {
-        callCount++;
-        timestamps.push(Date.now());
-        if (callCount < 3) {
-          throw new Error('Temporary failure');
-        }
-        return {
-          items: [{ name: 'success' }],
-          nextCursor: undefined,
-        };
-      },
-    } as unknown as AoARIORead;
-
-    const retryDelay = 100;
-    const cache = new ArNSNamesCache({
-      log,
-      networkProcess: mockNetworkProcess,
-      maxRetries: 3,
-      retryDelay,
-    });
-
-    await cache.getNames();
-
-    assert.ok(timestamps[1] - timestamps[0] >= retryDelay);
-    assert.ok(timestamps[2] - timestamps[1] >= retryDelay);
-  });
-
-  it('should handle empty results as failures and retry', async () => {
-    let callCount = 0;
-    const mockNetworkProcess = {
-      async getArNSRecords() {
-        callCount++;
-        if (callCount < 2) {
-          return { items: [], nextCursor: undefined };
-        }
-        return {
-          items: [{ name: 'success', processId: 'process-1' }],
-          nextCursor: undefined,
-        };
-      },
-    } as unknown as AoARIORead;
-
-    const cache = new ArNSNamesCache({
-      log,
-      networkProcess: mockNetworkProcess,
-      maxRetries: 3,
-      retryDelay: 0,
-    });
-
-    const names = await cache.getNames();
-    assert.deepEqual(names, new Map([['success', { processId: 'process-1' }]]));
-    assert.equal(callCount, 2);
-  });
-
-  it('should return last successful names if all retry attempts fail', async () => {
-    let callCount = 0;
-    const mockNetworkProcess = {
-      async getArNSRecords() {
-        callCount++;
-        if (callCount === 1) {
-          return {
-            items: [{ name: 'initial-success', processId: 'process-1' }],
-            nextCursor: undefined,
-          };
-        }
-        throw new Error('Network error');
-      },
-    } as unknown as AoARIORead;
-
-    const cache = new ArNSNamesCache({
-      log,
-      networkProcess: mockNetworkProcess,
-      maxRetries: 3,
-      retryDelay: 0,
-    });
-
-    const initialNames = await cache.getNames();
-    assert.deepEqual(
-      initialNames,
-      new Map([['initial-success', { processId: 'process-1' }]]),
-    );
-
-    const updatedNames = await cache.getNames({ forceCacheUpdate: true });
-    assert.deepEqual(
-      updatedNames,
-      new Map([['initial-success', { processId: 'process-1' }]]),
-    );
-    assert.equal(callCount, 4); // 1 initial + 3 retry attempts
-  });
-
-  it('should throw error if all retries fail and no previous successful cache exists', async () => {
-    let callCount = 0;
-    const mockNetworkProcess = {
-      async getArNSRecords() {
-        callCount++;
-        throw new Error(`Attempt ${callCount} failed`);
-      },
-    } as unknown as AoARIORead;
-
-    const cache = new ArNSNamesCache({
-      log,
-      networkProcess: mockNetworkProcess,
-      maxRetries: 3,
-      retryDelay: 0,
-    });
-
-    await assert.rejects(
-      () => cache.getNames(),
-      /Failed to fetch ArNS records after 3 attempts/,
-    );
-    assert.equal(callCount, 3);
-  });
-
-  it('should debounce after provided ttl on a cache miss', async () => {
-    let callCount = 0;
-    const mockNetworkProcess = {
-      // on first call, return empty, then return success
-      async getArNSRecords() {
-        // on first two calls, return empty, then return success
-        if (callCount === 0) {
+      registryCache,
+      networkProcess: {
+        getArNSRecords: async () => {
           callCount++;
           return {
-            items: [{ name: 'name-0', processId: 'process-0' }],
+            items: [
+              {
+                name: `name-${callCount}-1`,
+                processId: `process-${callCount}`,
+              },
+            ],
             nextCursor: undefined,
           };
-        }
-        callCount++;
-        return {
-          items: [
-            { name: 'name-0', processId: 'process-0' },
-            { name: 'name-1', processId: 'process-1' },
-          ],
-          nextCursor: undefined,
-        };
-      },
-    } as unknown as AoARIORead;
-
-    const cache = new ArNSNamesCache({
-      log,
-      networkProcess: mockNetworkProcess,
-      cacheTtl: 10000, // cache the names list for 10s
-      cacheMissDebounceTtl: 10, // cache miss should trigger a refresh within 10ms
+        },
+      } as unknown as AoARIORead,
     });
+
+    // let the cache hydrate
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // assert the name was cached
+    const name = await debounceCache.getCachedArNSBaseName('name-1-1');
+    assert.deepEqual(name, { name: 'name-1-1', processId: 'process-1' });
+
+    // force refresh the cache
+    await debounceCache.forceRefresh();
+
+    // let the cache hydrate finish
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // assert call count is 2
+    assert.equal(callCount, 2);
+
+    // assert the cache was refreshed, but bc of the underlying buffer cache the previous name should is still returned
+    const previousCachedName =
+      await debounceCache.getCachedArNSBaseName('name-1-1');
+    assert.deepEqual(previousCachedName, {
+      name: 'name-1-1',
+      processId: 'process-1',
+    });
+
+    // assert the cache size is updated with the new name
+    const newCachedName = await debounceCache.getCachedArNSBaseName('name-2-1');
+    assert.deepEqual(newCachedName, {
+      name: 'name-2-1',
+      processId: 'process-2',
+    });
+  });
+
+  it('should return undefined if the name expires from the underlying kv cache and hydrating fails', async () => {
+    let callCount = 0;
+    const debounceCache = new ArNSNamesCache({
+      log,
+      registryCache,
+      networkProcess: {
+        getArNSRecords: async () => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              items: [
+                {
+                  name: `name-${callCount}`,
+                  processId: `process-${callCount}`,
+                },
+              ],
+              nextCursor: undefined,
+            };
+          }
+          throw new Error('Network error');
+        },
+      } as unknown as AoARIORead,
+    });
+
+    // let the cache hydrate
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // on first call, the name is returned from the kv cache but the underlying kv cache expires it
+    const name = await debounceCache.getCachedArNSBaseName('name-1');
+    assert.deepEqual(name, {
+      name: 'name-1',
+      processId: 'process-1',
+    });
+
+    // let the underlying kv cache expire
+    await new Promise((resolve) => setTimeout(resolve, 1000)); // wait the 1 second ttl for the name to expire from the kv cache
+
+    // on second call, the name is not in the kv cache and hydrating fails
+    const name2 = await debounceCache.getCachedArNSBaseName('name-1');
+    assert.equal(name2, undefined);
+  });
+
+  it('should return last successful cached name from kv cache if hydrating fails and within the underlying kv cache ttl', async () => {
+    let callCount = 0;
+    const debounceCache = new ArNSNamesCache({
+      log,
+      registryCache,
+      networkProcess: {
+        getArNSRecords: async () => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              items: [
+                {
+                  name: `name-${callCount}`,
+                  processId: `process-${callCount}`,
+                },
+              ],
+              nextCursor: undefined,
+            };
+          }
+          throw new Error('Network error');
+        },
+      } as unknown as AoARIORead,
+    });
+
+    // let the cache hydrate
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const name = await debounceCache.getCachedArNSBaseName('name-1');
+    assert.deepEqual(name, { name: 'name-1', processId: 'process-1' });
+
+    // force refresh the cache
+    await debounceCache.forceRefresh();
+
+    // let the cache hydrate finish
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // assert the name was refreshed
+    const previousCachedName =
+      await debounceCache.getCachedArNSBaseName('name-1');
+    // should be undefined, but process-2 is cached
+    assert.deepEqual(previousCachedName, {
+      name: 'name-1',
+      processId: 'process-1',
+    });
+  });
+
+  it('should debounce after provided cache miss ttl on a cache miss', async () => {
+    let callCount = 0;
+    const debounceCache = new ArNSNamesCache({
+      log,
+      cacheHitDebounceTtl: 10000, // don't refresh the cache on a hit
+      cacheMissDebounceTtl: 100, // cache miss should trigger a refresh within 100ms
+      registryCache,
+      networkProcess: {
+        // on first call, return empty, then return success
+        async getArNSRecords() {
+          callCount++;
+          // on first two calls, return empty, then return success
+          if (callCount === 1) {
+            return {
+              items: [],
+              nextCursor: undefined,
+            };
+          }
+          return {
+            items: [
+              { name: `name-${callCount}`, processId: `process-${callCount}` },
+            ],
+            nextCursor: undefined,
+          };
+        },
+      } as unknown as AoARIORead,
+    });
+
+    // let the cache hydrate
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
     // call count will get incremented on instantiation of the cache
     assert.equal(callCount, 1);
+    // assert nothing in the underlying kv cache
 
-    // check a missing name, this should instantiate the debounce timeout to refresh the cache in 1 second
-    const missingName = await cache.getName('name-1');
+    // check a missing name, this should instantiate the debounce timeout to refresh the cache in 100ms
+    const missingName = await debounceCache.getCachedArNSBaseName('name-1');
     assert.equal(missingName, undefined, 'Name should not be cached');
     assert.equal(callCount, 1);
 
     // it should not trigger a refresh if the name is requested again within the ttl
-    const missingName2 = await cache.getName('name-1');
+    const missingName2 = await debounceCache.getCachedArNSBaseName('name-1');
     assert.equal(missingName2, undefined, 'Name should not be cached');
     assert.equal(callCount, 1);
 
-    // wait the ttl + 5ms and assert that it does trigger a refresh and getArNSRecords is called again
-    await new Promise((resolve) => setTimeout(resolve, 15)); // wait 15ms to ensure the debounce is triggered
-    assert.equal(
-      callCount,
-      2,
-      'getArNSRecords should be called again after debounce is triggered',
-    );
+    // wait cache miss ttl and assert that the hydrateFn was triggered and names were cached
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(callCount, 2);
 
-    // assert that the names are refreshed and the cache size is updated
-    const names = await cache.getNames();
-    assert.deepEqual(
-      names,
-      new Map([
-        ['name-0', { processId: 'process-0' }],
-        ['name-1', { processId: 'process-1' }],
-      ]),
-    );
-    assert.equal(await cache.getCacheSize(), 2);
+    // assert that the new names are cached in the underlying kv cache
+    const names = await debounceCache.getCachedArNSBaseName('name-2');
+    assert.deepEqual(names, { name: 'name-2', processId: 'process-2' });
   });
 
-  it('should debounce after provided ttl on a cache hit', async () => {
+  it('should debounce after provided cache hit ttl on a cache hit', async () => {
     let callCount = 0;
-    const mockNetworkProcess = {
-      async getArNSRecords() {
-        callCount++;
-        return {
-          items: [{ name: 'name-1', processId: 'process-1' }],
-          nextCursor: undefined,
-        };
-      },
-    } as unknown as AoARIORead;
-
-    const cache = new ArNSNamesCache({
+    const debounceCache = new ArNSNamesCache({
       log,
-      networkProcess: mockNetworkProcess,
-      cacheTtl: 10000, // cache the names list for 10s
-      cacheHitDebounceTtl: 10, // cache hit should trigger a refresh within 10ms
+      cacheHitDebounceTtl: 100, // don't refresh the cache on a hit
+      cacheMissDebounceTtl: 1000, // longer cache miss to avoid refreshing on misses and validate cache hit refreshes
+      registryCache,
+      networkProcess: {
+        async getArNSRecords() {
+          callCount++;
+          return {
+            items: [
+              { name: `name-${callCount}`, processId: `process-${callCount}` },
+            ],
+            nextCursor: undefined,
+          };
+        },
+      } as unknown as AoARIORead,
     });
 
     // call count will get incremented on instantiation of the cache
@@ -432,19 +337,24 @@ describe('ArNSNamesCache', () => {
     await new Promise((resolve) => setTimeout(resolve, 5));
 
     // request a hit
-    const hitName = await cache.getName('name-1');
-    assert.deepEqual(hitName, { processId: 'process-1' });
+    const cachedName = await debounceCache.getCachedArNSBaseName('name-1');
+    assert.deepEqual(cachedName, { name: 'name-1', processId: 'process-1' });
     assert.equal(callCount, 1);
 
-    // assert that getArNS records is not called again if name is requested between cache hit cache and ttl
-    const hitName2 = await cache.getName('name-1');
-    assert.deepEqual(hitName2, { processId: 'process-1' });
+    // assert that cached name is returned if requested again within ttl
+    const cachedName2 = await debounceCache.getCachedArNSBaseName('name-1');
+    assert.deepEqual(cachedName2, cachedName);
     assert.equal(callCount, 1);
 
-    // wait the ttl and assert that it does trigger a refresh
-    await new Promise((resolve) => setTimeout(resolve, 15));
-    const debouncedName = await cache.getName('name-1');
-    assert.deepEqual(debouncedName, { processId: 'process-1' });
+    // assert that a missing name is not cached yet
+    const cachedName3 = await debounceCache.getCachedArNSBaseName('name-2');
+    assert.deepEqual(cachedName3, undefined);
+    assert.equal(callCount, 1);
+
+    // wait the remainder of the original cache hit ttl and assert that the cache is refreshed with latest names
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const newName = await debounceCache.getCachedArNSBaseName('name-2');
+    assert.deepEqual(newName, { name: 'name-2', processId: 'process-2' });
     assert.equal(callCount, 2);
   });
 });

--- a/src/resolution/arns-names-cache.ts
+++ b/src/resolution/arns-names-cache.ts
@@ -82,9 +82,9 @@ export class ArNSNamesCache {
       hydrateImmediately: true,
       /**
        * Bind the hydrateArNSNamesCache method to the ArNSNamesCache instance
-       * so that the hydrateFn has access to this instance's properties and methods (e.g. this.log, this.networkProcess, etc.).
+       * so that the debounceFn has access to this instance's properties and methods (e.g. this.log, this.networkProcess, etc.).
        */
-      hydrateFn: this.hydrateArNSNamesCache.bind(this),
+      debounceFn: this.hydrateArNSNamesCache.bind(this),
     });
   }
 

--- a/src/resolution/arns-names-cache.ts
+++ b/src/resolution/arns-names-cache.ts
@@ -22,37 +22,32 @@ import {
   AoARIORead,
   AOProcess,
   ARIO,
-  fetchAllArNSRecords,
-  AoArNSNameData,
+  AoArNSNameDataWithName,
+  PaginationResult,
 } from '@ar.io/sdk';
 import * as config from '../config.js';
 import { connect } from '@permaweb/aoconnect';
-
-const DEFAULT_CACHE_TTL = config.ARNS_NAMES_CACHE_TTL_SECONDS * 1000;
-const DEFAULT_MAX_RETRIES = 3;
-const DEFAULT_RETRY_DELAY = 5 * 1000; // 5 seconds
+import { KvDebounceStore } from '../store/kv-debounce-store.js';
+import { KVBufferStore } from '../types.js';
 
 const DEFAULT_CACHE_MISS_DEBOUNCE_TTL =
   config.ARNS_NAME_LIST_CACHE_MISS_REFRESH_INTERVAL_SECONDS * 1000;
 const DEFAULT_CACHE_HIT_DEBOUNCE_TTL =
   config.ARNS_NAME_LIST_CACHE_HIT_REFRESH_INTERVAL_SECONDS * 1000;
 
+/**
+ * Wraps an ArNS registry cache in a debounce cache that automatically refreshes
+ * the cache after the debounce ttl has expired.
+ */
 export class ArNSNamesCache {
   private log: winston.Logger;
   private networkProcess: AoARIORead;
-  private namesCache: Promise<Map<string, AoArNSNameData>>;
-  private lastSuccessfulNames: Map<string, AoArNSNameData> | null = null;
-  private lastCacheTime = 0;
-  private cacheTtl: number;
-  private maxRetries: number;
-  private retryDelay: number;
-  private cacheMissDebounceTtl: number;
-  private cacheHitDebounceTtl: number;
-  private debounceTimeout: NodeJS.Timeout | null = null;
-  private isDebouncing = false;
+  private arnsRegistryKvCache: KVBufferStore;
+  private arnsDebounceCache: KvDebounceStore;
 
   constructor({
     log,
+    registryCache,
     ao = connect({
       MU_URL: config.AO_MU_URL,
       CU_URL: config.AO_CU_URL,
@@ -65,18 +60,13 @@ export class ArNSNamesCache {
         ao: ao,
       }),
     }),
-    cacheTtl = DEFAULT_CACHE_TTL,
-    maxRetries = DEFAULT_MAX_RETRIES,
-    retryDelay = DEFAULT_RETRY_DELAY,
     cacheMissDebounceTtl = DEFAULT_CACHE_MISS_DEBOUNCE_TTL,
     cacheHitDebounceTtl = DEFAULT_CACHE_HIT_DEBOUNCE_TTL,
   }: {
     log: winston.Logger;
+    registryCache: KVBufferStore;
     ao?: AoClient;
     networkProcess?: AoARIORead;
-    cacheTtl?: number;
-    maxRetries?: number;
-    retryDelay?: number;
     cacheMissDebounceTtl?: number;
     cacheHitDebounceTtl?: number;
   }) {
@@ -84,139 +74,79 @@ export class ArNSNamesCache {
       class: 'ArNSNamesCache',
     });
     this.networkProcess = networkProcess;
-    this.cacheTtl = cacheTtl;
-    this.maxRetries = maxRetries;
-    this.retryDelay = retryDelay;
-    this.cacheMissDebounceTtl = cacheMissDebounceTtl;
-    this.cacheHitDebounceTtl = cacheHitDebounceTtl;
-    this.log.info('Initiating cache load');
-    this.namesCache = this.getNames({ forceCacheUpdate: true });
+    this.arnsRegistryKvCache = registryCache;
+    this.arnsDebounceCache = new KvDebounceStore({
+      kvBufferStore: registryCache,
+      cacheMissDebounceTtl,
+      cacheHitDebounceTtl,
+      hydrateImmediately: true,
+      /**
+       * Bind the hydrateArNSNamesCache method to the ArNSNamesCache instance
+       * so that the hydrateFn has access to this instance's properties and methods (e.g. this.log, this.networkProcess, etc.).
+       */
+      hydrateFn: this.hydrateArNSNamesCache.bind(this),
+    });
   }
 
-  async getNames({
-    forceCacheUpdate = false,
-  }: {
-    forceCacheUpdate?: boolean;
-  } = {}): Promise<Map<string, AoArNSNameData>> {
-    const log = this.log.child({ method: 'getNames' });
-
-    const expiredTtl = Date.now() - this.lastCacheTime > this.cacheTtl;
-    const shouldRefresh = forceCacheUpdate || expiredTtl;
-
-    if (shouldRefresh) {
-      this.log.debug('Refreshing names cache promise', {
-        forced: forceCacheUpdate,
-      });
-      this.namesCache = this.getNamesFromContract();
-      this.lastCacheTime = Date.now();
-    } else {
-      log.debug('Using cached names promise', {
-        expiration: this.lastCacheTime + this.cacheTtl,
-      });
-    }
-
-    return this.namesCache;
-  }
-
-  async getName(name: string): Promise<AoArNSNameData | undefined> {
-    const names = await this.getNames();
-    const nameData = names.get(name);
-    // schedule the next debounce based on the cache hit or miss
-    await this.scheduleCacheRefresh(
-      nameData !== undefined
-        ? this.cacheHitDebounceTtl
-        : this.cacheMissDebounceTtl,
-    );
-    return nameData;
-  }
-
-  private async scheduleCacheRefresh(ttl: number): Promise<void> {
-    if (this.isDebouncing) {
-      this.log.debug('Already debouncing, skipping...');
-      return;
-    }
-    if (this.debounceTimeout) {
-      clearTimeout(this.debounceTimeout);
-      this.debounceTimeout = null;
-    }
-    this.log.debug(
-      `Setting cache debounce timeout to refresh cache in ${ttl}ms`,
-    );
-    // set the new timeout to refresh the cache after the debounce interval
-    this.debounceTimeout = setTimeout(async () => {
-      this.log.debug('Debounce timeout triggered, refreshing cache...');
-      this.getNames({ forceCacheUpdate: true });
-      this.debounceTimeout = null;
-      this.isDebouncing = false;
-    }, ttl);
-    this.isDebouncing = true; // set the debouncing flag to true to prevent multiple debounces
-  }
-
-  async getCacheSize(): Promise<number> {
-    const names = await this.namesCache;
-    return names.size;
-  }
-
-  private async getNamesFromContract(): Promise<Map<string, AoArNSNameData>> {
-    const log = this.log.child({ method: 'getNamesFromContract' });
-    log.info('Starting to fetch names from contract');
-
-    let lastError: Error | null = null;
-
-    for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
-      try {
-        const records = await fetchAllArNSRecords({
-          contract: this.networkProcess,
-        });
-
-        // to be safe, we will throw here to force a retry if no names returned
-        if (Object.keys(records).length === 0) {
-          throw new Error('Failed to fetch ArNS names');
-        }
-
-        log.info(
-          `Successfully fetched ${Object.keys(records).length} names from contract on attempt ${attempt}`,
-        );
-
-        this.lastSuccessfulNames = new Map(Object.entries(records));
-
-        return this.lastSuccessfulNames;
-      } catch (error) {
-        lastError = error as Error;
-
-        if (attempt === this.maxRetries) {
-          if (this.lastSuccessfulNames) {
-            log.warn(
-              `Failed to fetch names after ${this.maxRetries} attempts, falling back to last successful cache of ${this.lastSuccessfulNames.size} names`,
-              {
-                error: lastError.message,
-              },
-            );
-            return this.lastSuccessfulNames;
-          }
-
-          log.error(
-            `Failed to fetch names after ${this.maxRetries} attempts and no previous successful cache exists`,
-            {
-              error: lastError.message,
-            },
-          );
-          throw new Error(
-            `Failed to fetch ArNS records after ${this.maxRetries} attempts: ${lastError.message}`,
+  /**
+   * Paginate through all the names in the registry and hydrate the cache
+   * with the names and their associated processId and undernameLimits. The ar-io-sdk
+   * retries requests 3 times with exponential backoff by default.
+   */
+  private async hydrateArNSNamesCache() {
+    try {
+      this.log.info('Hydrating ArNS names cache...');
+      let cursor: string | undefined = undefined;
+      // TODO: add timing metrics
+      do {
+        const {
+          items: records,
+          nextCursor,
+        }: PaginationResult<AoArNSNameDataWithName> =
+          await this.networkProcess.getArNSRecords({ cursor, limit: 1000 });
+        for (const record of records) {
+          // do not await, avoid blocking the event loop
+          this.arnsRegistryKvCache.set(
+            record.name,
+            Buffer.from(JSON.stringify(record)),
           );
         }
-
-        log.warn(
-          `Attempt ${attempt}/${this.maxRetries} failed, retrying in ${this.retryDelay}ms`,
-          {
-            error: lastError.message,
-          },
-        );
-
-        await new Promise((resolve) => setTimeout(resolve, this.retryDelay));
-      }
+        cursor = nextCursor;
+      } while (cursor !== undefined);
+      this.log.info('Successfully hydrated ArNS names cache');
+    } catch (error: any) {
+      this.log.error('Error hydrating ArNS names cache', {
+        error: error.message,
+        stack: error.stack,
+      });
     }
+  }
 
-    throw lastError || new Error('Unexpected error in getNamesFromContract');
+  /**
+   * Ignore debounce and hydrate the cache immediately
+   */
+  public async forceRefresh() {
+    // TODO: could add clear() to KvBufferStore to clear out all cached items before hydrating
+    return this.hydrateArNSNamesCache();
+  }
+
+  /**
+   * Get the ArNS name data for a given name. The debounce cache will
+   * automatically refresh the cache after the debounce ttl has expired.
+   * @param name - The name to get the ArNS name data for.
+   * @returns The ArNS name data for the given name, or undefined if the name is not found.
+   */
+  async getCachedArNSBaseName(
+    name: string,
+  ): Promise<AoArNSNameDataWithName | undefined> {
+    const record = await this.arnsDebounceCache.get(name);
+    if (record) {
+      return JSON.parse(record.toString()) as AoArNSNameDataWithName;
+    }
+    return undefined;
+  }
+
+  async close() {
+    await this.arnsDebounceCache.close();
   }
 }

--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -55,10 +55,9 @@ export class CompositeArNSResolver implements NameResolver {
 
   async resolve(name: string): Promise<NameResolution> {
     this.log.info('Resolving name...', { name, overrides: this.overrides });
-    const arnsBaseNamesCache = await this.arnsBaseNamesCache.getNames();
     let resolution: NameResolution | undefined;
 
-    if (arnsBaseNamesCache.size === 0) {
+    if ((await this.arnsBaseNamesCache.getCacheSize()) === 0) {
       this.log.debug('Cached ArNS names list is empty');
     }
 
@@ -74,7 +73,7 @@ export class CompositeArNSResolver implements NameResolver {
       };
     }
 
-    if (arnsBaseNamesCache.has(baseName)) {
+    if (await this.arnsBaseNamesCache.has(baseName)) {
       try {
         // check if our resolution cache contains the FULL name
         const cachedResolutionBuffer = await this.cache.get(name);

--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -85,7 +85,14 @@ export class CompositeArNSResolver implements NameResolver {
         await this.arnsNamesCache.getCachedArNSBaseName(baseName);
 
       if (!baseNameInCache) {
-        throw new Error('Base name not found in ArNS names cache');
+        this.log.warn('Base name not found in ArNS names cache', { name });
+        return {
+          name,
+          resolvedId: undefined,
+          resolvedAt: undefined,
+          ttl: undefined,
+          processId: undefined,
+        };
       }
 
       // check if our resolution cache contains the FULL name

--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -24,7 +24,7 @@ import { ArNSNamesCache } from './arns-names-cache.js';
 export class CompositeArNSResolver implements NameResolver {
   private log: winston.Logger;
   private resolvers: NameResolver[];
-  private cache: KvArnsStore;
+  private resolutionCache: KvArnsStore;
   private overrides:
     | {
         ttlSeconds?: number;
@@ -36,19 +36,19 @@ export class CompositeArNSResolver implements NameResolver {
   constructor({
     log,
     resolvers,
-    cache,
+    resolutionCache,
     overrides,
   }: {
     log: winston.Logger;
     resolvers: NameResolver[];
-    cache: KvArnsStore;
+    resolutionCache: KvArnsStore;
     overrides?: {
       ttlSeconds?: number;
     };
   }) {
     this.log = log.child({ class: this.constructor.name });
     this.resolvers = resolvers;
-    this.cache = cache;
+    this.resolutionCache = resolutionCache;
     this.overrides = overrides;
     this.arnsBaseNamesCache = new ArNSNamesCache({ log });
   }
@@ -73,61 +73,67 @@ export class CompositeArNSResolver implements NameResolver {
       };
     }
 
-    if (await this.arnsBaseNamesCache.has(baseName)) {
-      try {
-        // check if our resolution cache contains the FULL name
-        const cachedResolutionBuffer = await this.cache.get(name);
-        if (cachedResolutionBuffer) {
-          const cachedResolution: NameResolution = JSON.parse(
-            cachedResolutionBuffer.toString(),
-          );
-          resolution = cachedResolution; // hold on to this in case we need it
-          // use the override ttl if it exists, otherwise use the cached resolution ttl
-          const ttlSeconds = this.overrides?.ttlSeconds ?? cachedResolution.ttl;
-          if (
-            cachedResolution !== undefined &&
-            cachedResolution.resolvedAt !== undefined &&
-            ttlSeconds !== undefined &&
-            cachedResolution.resolvedAt + ttlSeconds * 1000 > Date.now()
-          ) {
-            metrics.arnsCacheHitCounter.inc();
-            this.log.info('Cache hit for arns name', { name });
-            return cachedResolution;
-          }
-        }
-        metrics.arnsCacheMissCounter.inc();
-        this.log.info('Cache miss for arns name', { name });
+    try {
+      // check if our base name is in our arns names cache, this triggers a debounce with a ttl dependent on if it's in the cache or not
+      const baseNameInCache = await this.arnsBaseNamesCache.getName(baseName);
 
-        for (const resolver of this.resolvers) {
-          try {
-            this.log.info('Attempting to resolve name with resolver', {
-              type: resolver.constructor.name,
-              name,
-            });
-            const resolution = await resolver.resolve(name);
-            if (resolution.resolvedAt !== undefined) {
-              this.cache.set(name, Buffer.from(JSON.stringify(resolution)));
-              this.log.info('Resolved name', { name, resolution });
-              return resolution;
-            }
-          } catch (error: any) {
-            this.log.error('Error resolving name with resolver', {
-              resolver,
-              message: error.message,
-              stack: error.stack,
-            });
-          }
-        }
-        this.log.warn('Unable to resolve name against all resolvers', { name });
-      } catch (error: any) {
-        this.log.error('Error resolving name:', {
-          name,
-          message: error.message,
-          stack: error.stack,
-        });
+      if (!baseNameInCache) {
+        throw new Error('Base name not found in ArNS names cache');
       }
-    } else {
-      this.log.error(`${name} not included in the cached ArNS names list`);
+
+      // check if our resolution cache contains the FULL name
+      const cachedResolutionBuffer = await this.resolutionCache.get(name);
+      if (cachedResolutionBuffer) {
+        const cachedResolution: NameResolution = JSON.parse(
+          cachedResolutionBuffer.toString(),
+        );
+        resolution = cachedResolution; // hold on to this in case we need it
+        // use the override ttl if it exists, otherwise use the cached resolution ttl
+        const ttlSeconds = this.overrides?.ttlSeconds ?? cachedResolution.ttl;
+        if (
+          cachedResolution !== undefined &&
+          cachedResolution.resolvedAt !== undefined &&
+          ttlSeconds !== undefined &&
+          cachedResolution.resolvedAt + ttlSeconds * 1000 > Date.now()
+        ) {
+          metrics.arnsCacheHitCounter.inc();
+          this.log.info('Cache hit for arns name', { name });
+          return cachedResolution;
+        }
+      }
+      metrics.arnsCacheMissCounter.inc();
+      this.log.info('Cache miss for arns name', { name });
+
+      for (const resolver of this.resolvers) {
+        try {
+          this.log.info('Attempting to resolve name with resolver', {
+            type: resolver.constructor.name,
+            name,
+          });
+          const resolution = await resolver.resolve(name);
+          if (resolution.resolvedAt !== undefined) {
+            this.resolutionCache.set(
+              name,
+              Buffer.from(JSON.stringify(resolution)),
+            );
+            this.log.info('Resolved name', { name, resolution });
+            return resolution;
+          }
+        } catch (error: any) {
+          this.log.error('Error resolving name with resolver', {
+            resolver,
+            message: error.message,
+            stack: error.stack,
+          });
+        }
+      }
+      this.log.warn('Unable to resolve name against all resolvers', { name });
+    } catch (error: any) {
+      this.log.error('Error resolving name:', {
+        name,
+        message: error.message,
+        stack: error.stack,
+      });
     }
 
     // return the resolution if it exists, otherwise return an empty resolution

--- a/src/store/kv-arns-base-name-store.ts
+++ b/src/store/kv-arns-base-name-store.ts
@@ -18,15 +18,38 @@
 
 import { KVBufferStore } from '../types.js';
 
-export class KvArnsStore implements KVBufferStore {
+/**
+ * Key-Value stored intended to hold ArNS Name Registry data.
+ *
+ * Example data:
+ *
+ * {
+ *   key: 'ardrive',
+ *   value: {
+ *      processId: AO_PROCESS_ID,
+ *      undernameLimit: UNDERNAME_LIMIT,
+ *      type: 'permabuy' | 'lease',
+ *      startTimestamp: TIMESTAMP,
+ *      endTimestamp?: TIMESTAMP
+ *   }
+ * }
+ */
+export class KvArNSRegistryStore implements KVBufferStore {
   private kvBufferStore: KVBufferStore;
-
-  constructor({ kvBufferStore }: { kvBufferStore: KVBufferStore }) {
+  private hashKeyPrefix: string;
+  constructor({
+    hashKeyPrefix,
+    kvBufferStore,
+  }: {
+    hashKeyPrefix: string;
+    kvBufferStore: KVBufferStore;
+  }) {
     this.kvBufferStore = kvBufferStore;
+    this.hashKeyPrefix = hashKeyPrefix;
   }
 
   private hashKey(key: string): string {
-    return `arns|${key}`;
+    return `${this.hashKeyPrefix}|${key}`;
   }
 
   async get(key: string): Promise<Buffer | undefined> {

--- a/src/store/kv-arns-name-resolution-store.ts
+++ b/src/store/kv-arns-name-resolution-store.ts
@@ -1,0 +1,73 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { KVBufferStore } from '../types.js';
+
+/**
+ * Key-Value Store for storing ArNS Name resolution data as a Buffer.
+ *
+ * Example data:
+ *
+ * {
+ *   key: 'ardrive',
+ *   value: Buffer.from({
+ *      txId: <ARWEAVE-TX-ID>,
+ *      processId: <AO-PROCESS-ID>,
+ *      owner: <OWNING_ANT_ADDRESS>,
+ *      ttl: <TTL_SECONDS>
+ *   })
+ * }
+ */
+export class KvArNSResolutionStore implements KVBufferStore {
+  private kvBufferStore: KVBufferStore;
+  private hashKeyPrefix: string;
+  constructor({
+    hashKeyPrefix,
+    kvBufferStore,
+  }: {
+    hashKeyPrefix: string;
+    kvBufferStore: KVBufferStore;
+  }) {
+    this.kvBufferStore = kvBufferStore;
+    this.hashKeyPrefix = hashKeyPrefix;
+  }
+
+  private hashKey(key: string): string {
+    return `${this.hashKeyPrefix}|${key}`;
+  }
+
+  async get(key: string): Promise<Buffer | undefined> {
+    return this.kvBufferStore.get(this.hashKey(key));
+  }
+
+  async set(key: string, value: Buffer): Promise<void> {
+    return this.kvBufferStore.set(this.hashKey(key), value);
+  }
+
+  async has(key: string): Promise<boolean> {
+    return this.kvBufferStore.has(this.hashKey(key));
+  }
+
+  async del(key: string): Promise<void> {
+    return this.kvBufferStore.del(this.hashKey(key));
+  }
+
+  async close(): Promise<void> {
+    return this.kvBufferStore.close();
+  }
+}

--- a/src/store/kv-debounce-store.ts
+++ b/src/store/kv-debounce-store.ts
@@ -33,20 +33,20 @@ export class KvDebounceStore implements KVBufferStore {
     cacheMissDebounceTtl,
     cacheHitDebounceTtl,
     hydrateImmediately = true,
-    hydrateFn,
+    debounceFn,
   }: {
     kvBufferStore: KVBufferStore;
     cacheMissDebounceTtl: number;
     cacheHitDebounceTtl: number;
     hydrateImmediately?: boolean;
-    hydrateFn: () => Promise<void>; // caller is responsible for handling errors from hydrateFn, this class will bubble up errors on instantiation if hydrateFn throws
+    debounceFn: () => Promise<void>; // caller is responsible for handling errors from debounceFn, this class will bubble up errors on instantiation if debounceFn throws
   }) {
     this.kvBufferStore = kvBufferStore;
-    this.debounceHydrateOnMiss = pDebounce(hydrateFn, cacheMissDebounceTtl);
-    this.debounceHydrateOnHit = pDebounce(hydrateFn, cacheHitDebounceTtl);
+    this.debounceHydrateOnMiss = pDebounce(debounceFn, cacheMissDebounceTtl);
+    this.debounceHydrateOnHit = pDebounce(debounceFn, cacheHitDebounceTtl);
     // hydrate the cache immediately when the cache is created
     if (hydrateImmediately) {
-      hydrateFn();
+      debounceFn();
     }
   }
 

--- a/src/store/kv-debounce-store.ts
+++ b/src/store/kv-debounce-store.ts
@@ -18,7 +18,6 @@
 
 import { KVBufferStore } from '../types';
 import pDebounce from 'p-debounce';
-import winston from 'winston';
 
 /**
  * A wrapper around a KVBufferStore that debounces the hydrate function

--- a/src/store/kv-debounce-store.ts
+++ b/src/store/kv-debounce-store.ts
@@ -1,0 +1,79 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { KVBufferStore } from '../types';
+import pDebounce from 'p-debounce';
+import winston from 'winston';
+
+/**
+ * A wrapper around a KVBufferStore that debounces the hydrate function
+ * on cache miss and cache hit.
+ */
+export class KvDebounceStore implements KVBufferStore {
+  private kvBufferStore: KVBufferStore;
+  private debounceHydrateOnMiss: (...args: any[]) => Promise<void>;
+  private debounceHydrateOnHit: (...args: any[]) => Promise<void>;
+
+  constructor({
+    kvBufferStore,
+    hydrateFn,
+    cacheMissDebounceTtl,
+    cacheHitDebounceTtl,
+    hydrateImmediately = true,
+  }: {
+    kvBufferStore: KVBufferStore;
+    hydrateFn: () => Promise<void>;
+    cacheMissDebounceTtl: number;
+    cacheHitDebounceTtl: number;
+    hydrateImmediately?: boolean;
+  }) {
+    this.kvBufferStore = kvBufferStore;
+    this.debounceHydrateOnMiss = pDebounce(hydrateFn, cacheMissDebounceTtl);
+    this.debounceHydrateOnHit = pDebounce(hydrateFn, cacheHitDebounceTtl);
+    // hydrate the cache immediately when the cache is created
+    if (hydrateImmediately) {
+      hydrateFn();
+    }
+  }
+
+  async get(key: string): Promise<Buffer | undefined> {
+    const value = await this.kvBufferStore.get(key);
+    if (value === undefined) {
+      this.debounceHydrateOnMiss();
+      return undefined;
+    }
+    this.debounceHydrateOnHit();
+    return value;
+  }
+
+  async set(key: string, value: Buffer): Promise<void> {
+    await this.kvBufferStore.set(key, value);
+  }
+
+  async del(key: string): Promise<void> {
+    await this.kvBufferStore.del(key);
+  }
+
+  async has(key: string): Promise<boolean> {
+    return this.kvBufferStore.has(key);
+  }
+
+  async close(): Promise<void> {
+    await this.kvBufferStore.close();
+  }
+}

--- a/src/store/kv-debounce-store.ts
+++ b/src/store/kv-debounce-store.ts
@@ -39,7 +39,7 @@ export class KvDebounceStore implements KVBufferStore {
     cacheMissDebounceTtl: number;
     cacheHitDebounceTtl: number;
     hydrateImmediately?: boolean;
-    hydrateFn: () => Promise<void>;
+    hydrateFn: () => Promise<void>; // caller is responsible for handling errors from hydrateFn, this class will bubble up errors on instantiation if hydrateFn throws
   }) {
     this.kvBufferStore = kvBufferStore;
     this.debounceHydrateOnMiss = pDebounce(hydrateFn, cacheMissDebounceTtl);

--- a/src/store/kv-debounce-store.ts
+++ b/src/store/kv-debounce-store.ts
@@ -30,16 +30,16 @@ export class KvDebounceStore implements KVBufferStore {
 
   constructor({
     kvBufferStore,
-    hydrateFn,
     cacheMissDebounceTtl,
     cacheHitDebounceTtl,
     hydrateImmediately = true,
+    hydrateFn,
   }: {
     kvBufferStore: KVBufferStore;
-    hydrateFn: () => Promise<void>;
     cacheMissDebounceTtl: number;
     cacheHitDebounceTtl: number;
     hydrateImmediately?: boolean;
+    hydrateFn: () => Promise<void>;
   }) {
     this.kvBufferStore = kvBufferStore;
     this.debounceHydrateOnMiss = pDebounce(hydrateFn, cacheMissDebounceTtl);

--- a/src/system.ts
+++ b/src/system.ts
@@ -82,11 +82,12 @@ import { connect } from '@permaweb/aoconnect';
 import { DataContentAttributeImporter } from './workers/data-content-attribute-importer.js';
 import { SignatureFetcher } from './data/signature-fetcher.js';
 import { SQLiteWalCleanupWorker } from './workers/sqlite-wal-cleanup-worker.js';
-import { KvArnsStore } from './store/kv-arns-store.js';
+import { KvArNSResolutionStore } from './store/kv-arns-name-resolution-store.js';
 import { parquetExporter } from './routes/ar-io.js';
 import { server } from './app.js';
 import { S3DataStore } from './store/s3-data-store.js';
 import { BlockedNamesCache } from './blocked-names-cache.js';
+import { KvArNSRegistryStore } from './store/kv-arns-base-name-store.js';
 
 process.on('uncaughtException', (error) => {
   metrics.uncaughtExceptionCounter.inc();
@@ -598,7 +599,20 @@ export const manifestPathResolver = new StreamingManifestPathResolver({
   log,
 });
 
-export const arnsResolverCache = new KvArnsStore({
+export const arnsResolutionCache = new KvArNSResolutionStore({
+  hashKeyPrefix: 'arns', // all arns resolution cache keys start with 'arns'
+  kvBufferStore: createArNSKvStore({
+    log,
+    type: config.ARNS_CACHE_TYPE,
+    redisUrl: config.REDIS_CACHE_URL,
+    ttlSeconds: config.ARNS_CACHE_TTL_SECONDS,
+    maxKeys: config.ARNS_CACHE_MAX_KEYS,
+    useTls: config.REDIS_USE_TLS,
+  }),
+});
+
+export const arnsRegistryCache = new KvArNSRegistryStore({
+  hashKeyPrefix: 'registry', // all arns registry cache keys start with 'registry'
   kvBufferStore: createArNSKvStore({
     log,
     type: config.ARNS_CACHE_TYPE,
@@ -614,7 +628,8 @@ export const nameResolver = createArNSResolver({
   trustedGatewayUrl: config.TRUSTED_ARNS_GATEWAY_URL,
   resolutionOrder: config.ARNS_RESOLVER_PRIORITY_ORDER,
   networkProcess: arIO,
-  cache: arnsResolverCache,
+  resolutionCache: arnsResolutionCache,
+  registryCache: arnsRegistryCache,
   overrides: {
     ttlSeconds: config.ARNS_RESOLVER_OVERRIDE_TTL_SECONDS,
     // TODO: other overrides like fallback txId if not found in resolution
@@ -695,7 +710,8 @@ export const shutdown = async (exitCode = 0) => {
       arIODataSource.stopUpdatingPeers();
       dataSqliteWalCleanupWorker?.stop();
       parquetExporter?.stop();
-      await arnsResolverCache.close();
+      await arnsResolutionCache.close();
+      await arnsRegistryCache.close();
       await mempoolWatcher?.stop();
       await blockImporter.stop();
       await dataItemIndexer.stop();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6564,6 +6564,11 @@ p-cancelable@^3.0.0:
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-3.0.0.tgz#63826694b54d61ca1c20ebcb6d3ecf5e14cd8050"
   integrity sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==
 
+p-debounce@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-debounce/-/p-debounce-4.0.0.tgz#348e3f44489baa9435cc7d807f17b3bb2fb16b24"
+  integrity sha512-4Ispi9I9qYGO4lueiLDhe4q4iK5ERK8reLsuzH6BPaXn53EGaua8H66PXIFGrW897hwjXp+pVLrm/DLxN0RF0A==
+
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"


### PR DESCRIPTION
Adds debouncing to the arns name list on cache hit/misses based on newly exposed variables. These should help alleviate name resolution delays for new names, as the cache will be refreshed within 10 seconds on misses (by default). Additionally, operators can choose to set cache hit debounce interval separate from the cache TTL, allowing tighter control of how often to refresh the cache - but always preserving it for at least the TTL if it fails to request an updated list from the CU. Refer to the updated ADR for specifics on how these caching mechanisms are architected.

Update:

Introducing a new `Kv-Debounce-Store` which accepts any existing `KvStore` implementation and a `hydrateFn` that is called after the provided debounce intervals. 