### PR TITLE
chore(metrics): add arns name cache hit/miss prometheus counters

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -236,6 +236,16 @@ export const arnsCacheMissCounter = new promClient.Counter({
   help: 'Number of misses in the arns cache',
 });
 
+export const arnsNameCacheHitCounter = new promClient.Counter({
+  name: 'arns_name_cache_hit_total',
+  help: 'Number of hits in the arns name cache',
+});
+
+export const arnsNameCacheMissCounter = new promClient.Counter({
+  name: 'arns_name_cache_miss_total',
+  help: 'Number of misses in the arns name cache',
+});
+
 export const arnsResolutionTime = new promClient.Summary({
   name: 'arns_resolution_time_ms',
   help: 'Time in ms it takes to resolve an arns name',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -236,6 +236,11 @@ export const arnsCacheMissCounter = new promClient.Counter({
   help: 'Number of misses in the arns cache',
 });
 
+export const arnsNameCacheDurationSummary = new promClient.Summary({
+  name: 'arns_name_cache_duration_ms',
+  help: 'Time in ms it takes to fetch and cache arns base names',
+});
+
 export const arnsNameCacheHitCounter = new promClient.Counter({
   name: 'arns_name_cache_hit_total',
   help: 'Number of hits in the arns name cache',

--- a/src/resolution/arns-names-cache.ts
+++ b/src/resolution/arns-names-cache.ts
@@ -143,8 +143,10 @@ export class ArNSNamesCache {
   ): Promise<AoArNSNameDataWithName | undefined> {
     const record = await this.arnsDebounceCache.get(name);
     if (record) {
+      metrics.arnsNameCacheHitCounter.inc();
       return <AoArNSNameDataWithName>JSON.parse(record.toString());
     }
+    metrics.arnsNameCacheMissCounter.inc();
     return undefined;
   }
 

--- a/src/resolution/arns-names-cache.ts
+++ b/src/resolution/arns-names-cache.ts
@@ -29,7 +29,7 @@ import * as config from '../config.js';
 import { connect } from '@permaweb/aoconnect';
 import { KvDebounceStore } from '../store/kv-debounce-store.js';
 import { KVBufferStore } from '../types.js';
-
+import * as metrics from '../metrics.js';
 const DEFAULT_CACHE_MISS_DEBOUNCE_TTL =
   config.ARNS_NAME_LIST_CACHE_MISS_REFRESH_INTERVAL_SECONDS * 1000;
 const DEFAULT_CACHE_HIT_DEBOUNCE_TTL =
@@ -101,7 +101,7 @@ export class ArNSNamesCache {
     try {
       this.log.info('Hydrating ArNS names cache...');
       let cursor: string | undefined = undefined;
-      // TODO: add timing metrics
+      const start = Date.now();
       do {
         const {
           items: records,
@@ -114,6 +114,7 @@ export class ArNSNamesCache {
         }
         cursor = nextCursor;
       } while (cursor !== undefined);
+      metrics.arnsNameCacheDurationSummary.observe(Date.now() - start);
       this.log.info('Successfully hydrated ArNS names cache');
     } catch (error: any) {
       this.log.error('Error hydrating ArNS names cache', {

--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -80,7 +80,6 @@ export class CompositeArNSResolver implements NameResolver {
     }
 
     try {
-      // check if our base name is in our arns names cache, this triggers a debounce with a ttl dependent on if it's in the cache or not
       const baseNameInCache =
         await this.arnsNamesCache.getCachedArNSBaseName(baseName);
 
@@ -95,9 +94,6 @@ export class CompositeArNSResolver implements NameResolver {
           processId: undefined,
         };
       }
-
-      // increment name cache hit counter
-      metrics.arnsNameCacheHitCounter.inc();
 
       // check if our resolution cache contains the FULL name
       const cachedResolutionBuffer = await this.resolutionCache.get(name);

--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -86,6 +86,7 @@ export class CompositeArNSResolver implements NameResolver {
 
       if (!baseNameInCache) {
         this.log.warn('Base name not found in ArNS names cache', { name });
+        metrics.arnsNameCacheMissCounter.inc();
         return {
           name,
           resolvedId: undefined,
@@ -94,6 +95,9 @@ export class CompositeArNSResolver implements NameResolver {
           processId: undefined,
         };
       }
+
+      // increment name cache hit counter
+      metrics.arnsNameCacheHitCounter.inc();
 
       // check if our resolution cache contains the FULL name
       const cachedResolutionBuffer = await this.resolutionCache.get(name);


### PR DESCRIPTION
Example:
```
# HELP arns_name_cache_duration_ms Time in ms it takes to fetch and cache arns base names
# TYPE arns_name_cache_duration_ms summary
arns_name_cache_duration_ms{quantile="0.01"} 4614
arns_name_cache_duration_ms{quantile="0.05"} 4614
arns_name_cache_duration_ms{quantile="0.5"} 5371.5
arns_name_cache_duration_ms{quantile="0.9"} 6129
arns_name_cache_duration_ms{quantile="0.95"} 6129
arns_name_cache_duration_ms{quantile="0.99"} 6129
arns_name_cache_duration_ms{quantile="0.999"} 6129
arns_name_cache_duration_ms_sum 10743
arns_name_cache_duration_ms_count 2

# HELP arns_name_cache_hit_total Number of hits in the arns name cache
# TYPE arns_name_cache_hit_total counter
arns_name_cache_hit_total 1

# HELP arns_name_cache_miss_total Number of misses in the arns name cache
# TYPE arns_name_cache_miss_total counter
arns_name_cache_miss_total 1
```