### PR TITLE
ArNS ADR alignment and performance improvements

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -525,10 +525,10 @@ export const ARNS_NAME_LIST_CACHE_HIT_REFRESH_INTERVAL_SECONDS =
     `${60 * 60}`, // 1 hour
   );
 
-export const ARNS_ANT_STATE_CACHE_HIT_REFRESH_INTERVAL_SECONDS =
+export const ARNS_ANT_STATE_CACHE_HIT_REFRESH_BUFFER_SECONDS =
   +env.varOrDefault(
-    'ARNS_ANT_STATE_CACHE_HIT_REFRESH_INTERVAL_SECONDS',
-    `${60 * 10}`, // 10 minutes
+    'ARNS_ANT_STATE_CACHE_HIT_REFRESH_BUFFER_SECONDS',
+    `${60}`, // 1 minutes
   );
 
 // TODO: support multiple gateway urls

--- a/src/config.ts
+++ b/src/config.ts
@@ -525,10 +525,10 @@ export const ARNS_NAME_LIST_CACHE_HIT_REFRESH_INTERVAL_SECONDS =
     `${60 * 60}`, // 1 hour
   );
 
-export const ARNS_ANT_STATE_CACHE_HIT_REFRESH_BUFFER_SECONDS =
+export const ARNS_ANT_STATE_CACHE_HIT_REFRESH_WINDOW_SECONDS =
   +env.varOrDefault(
-    'ARNS_ANT_STATE_CACHE_HIT_REFRESH_BUFFER_SECONDS',
-    `${60}`, // 1 minutes
+    'ARNS_ANT_STATE_CACHE_HIT_REFRESH_WINDOW_SECONDS',
+    `${30}`, // 30 seconds
   );
 
 // TODO: support multiple gateway urls

--- a/src/config.ts
+++ b/src/config.ts
@@ -525,16 +525,10 @@ export const ARNS_NAME_LIST_CACHE_HIT_REFRESH_INTERVAL_SECONDS =
     `${60 * 60}`, // 1 hour
   );
 
-export const ARNS_ANT_STATE_CACHE_MISS_REFRESH_INTERVAL_SECONDS =
-  +env.varOrDefault(
-    'ARNS_ANT_STATE_CACHE_MISS_REFRESH_INTERVAL_SECONDS',
-    `${10}`, // 10 seconds
-  );
-
 export const ARNS_ANT_STATE_CACHE_HIT_REFRESH_INTERVAL_SECONDS =
   +env.varOrDefault(
     'ARNS_ANT_STATE_CACHE_HIT_REFRESH_INTERVAL_SECONDS',
-    `${60 * 5}`, // 5 minutes
+    `${60 * 10}`, // 10 minutes
   );
 
 // TODO: support multiple gateway urls

--- a/src/middleware/arns.ts
+++ b/src/middleware/arns.ts
@@ -93,7 +93,9 @@ export const createArnsMiddleware = ({
           return arnsResolutionPromise;
         }
       }
-      const arnsResolutionPromise = nameResolver.resolve(arnsSubdomain);
+      const arnsResolutionPromise = nameResolver.resolve({
+        name: arnsSubdomain,
+      });
       arnsRequestCache.set(arnsSubdomain, arnsResolutionPromise);
       return arnsResolutionPromise;
     };

--- a/src/resolution/arns-names-cache.ts
+++ b/src/resolution/arns-names-cache.ts
@@ -88,7 +88,7 @@ export class ArNSNamesCache {
        * Bind the hydrateArNSNamesCache method to the ArNSNamesCache instance
        * so that the debounceFn has access to this instance's properties and methods (e.g. this.log, this.networkProcess, etc.).
        */
-      debounceFn: this.hydrateArNSNamesCache.bind(this),
+      hydrateFn: this.hydrateArNSNamesCache.bind(this),
     });
   }
 

--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -104,7 +104,6 @@ export class CompositeArNSResolver implements NameResolver {
         for (const resolver of this.resolvers) {
           try {
             this.log.info('Attempting to resolve name with resolver', {
-              type: resolver.constructor.name,
               name,
             });
             const resolution = await resolver.resolve({
@@ -128,7 +127,6 @@ export class CompositeArNSResolver implements NameResolver {
             });
           }
         }
-
         return undefined;
       };
 

--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -147,13 +147,13 @@ export class CompositeArNSResolver implements NameResolver {
           ttlSeconds !== undefined &&
           cachedResolution.resolvedAt + ttlSeconds * 1000 > Date.now()
         ) {
-          // Resolve again in the background to refresh cache if past the ANT
-          // refresh interval
+          // Resolve again in the background to refresh cache if TTL is close
+          // to expiring
           if (
             // Ensure only one resolution is in-flight at a time
             !this.pendingResolutions[name] &&
-            Date.now() - cachedResolution.resolvedAt >
-              config.ARNS_ANT_STATE_CACHE_HIT_REFRESH_INTERVAL_SECONDS
+            cachedResolution.resolvedAt + ttlSeconds * 1000 - Date.now() <
+              config.ARNS_ANT_STATE_CACHE_HIT_REFRESH_BUFFER_SECONDS
           ) {
             this.pendingResolutions[name] = resolveName();
           }

--- a/src/resolution/trusted-gateway-arns-resolver.ts
+++ b/src/resolution/trusted-gateway-arns-resolver.ts
@@ -39,7 +39,7 @@ export class TrustedGatewayArNSResolver implements NameResolver {
     this.trustedGatewayUrl = trustedGatewayUrl;
   }
 
-  async resolve(name: string): Promise<NameResolution> {
+  async resolve({ name }: { name: string }): Promise<NameResolution> {
     this.log.info('Resolving name...', { name });
     try {
       const nameUrl = this.trustedGatewayUrl.replace('__NAME__', name);

--- a/src/routes/arns.ts
+++ b/src/routes/arns.ts
@@ -46,7 +46,7 @@ if (config.ARNS_ROOT_HOST !== undefined) {
 arnsRouter.get('/ar-io/resolver/:name', async (req, res) => {
   const { name } = req.params;
   // TODO: replace this with the same request cache used in arns middleware
-  const resolved = await system.nameResolver.resolve(name);
+  const resolved = await system.nameResolver.resolve({ name });
   if (resolved === undefined) {
     sendNotFound(res);
     return;

--- a/src/store/kv-debounce-store.test.ts
+++ b/src/store/kv-debounce-store.test.ts
@@ -32,7 +32,7 @@ describe('KvDebounceCache', () => {
     }),
     cacheMissDebounceTtl: 100,
     cacheHitDebounceTtl: 100,
-    debounceFn: async () => {
+    hydrateFn: async () => {
       // noop
     },
   });
@@ -71,7 +71,7 @@ describe('KvDebounceCache', () => {
         cacheHitDebounceTtl: 100,
         cacheMissDebounceTtl: 10,
         debounceImmediately: true,
-        debounceFn: async () => {
+        hydrateFn: async () => {
           callCount++;
           kvBufferStore.set(key, Buffer.from('test'));
         },
@@ -94,7 +94,7 @@ describe('KvDebounceCache', () => {
         cacheHitDebounceTtl: 100,
         cacheMissDebounceTtl: 10,
         debounceImmediately: false,
-        debounceFn: async () => {
+        hydrateFn: async () => {
           lastCallTimestamp = Date.now();
           callCount++;
           kvBufferStore.set(key, Buffer.from('test'));
@@ -118,7 +118,7 @@ describe('KvDebounceCache', () => {
         cacheHitDebounceTtl: 100,
         cacheMissDebounceTtl: 10,
         debounceImmediately: true,
-        debounceFn: async () => {
+        hydrateFn: async () => {
           lastCallTimestamp = Date.now();
           // return undefined on first call
           if (callCount === 0) {
@@ -154,7 +154,7 @@ describe('KvDebounceCache', () => {
         cacheHitDebounceTtl: 100,
         cacheMissDebounceTtl: 10,
         debounceImmediately: true,
-        debounceFn: async () => {
+        hydrateFn: async () => {
           lastCallTimestamp = Date.now();
           kvBufferStore.set(key, Buffer.from(`test${callCount}`));
           callCount++;
@@ -187,7 +187,7 @@ describe('KvDebounceCache', () => {
           cacheMissDebounceTtl: 10,
           cacheHitDebounceTtl: 100,
           // synchronously throw for testing purposes
-          debounceFn: () => {
+          hydrateFn: () => {
             throw new Error('Test error');
           },
         });

--- a/src/store/kv-debounce-store.ts
+++ b/src/store/kv-debounce-store.ts
@@ -48,7 +48,7 @@ export class KvDebounceStore implements KVBufferStore {
         return this.pendingHydrate;
       }
 
-      this.pendingHydrate = hydrateFn().then(() => {
+      this.pendingHydrate = hydrateFn().finally(() => {
         this.pendingHydrate = undefined;
       });
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { Readable, Writable } from 'node:stream';
+import { AoArNSNameDataWithName } from '@ar.io/sdk';
 
 export interface B64uTag {
   name: string;
@@ -645,7 +646,13 @@ type NameResolution =
   | FailedNameResolution;
 
 export interface NameResolver {
-  resolve(name: string): Promise<NameResolution>;
+  resolve({
+    name,
+    baseArNSRecord,
+  }: {
+    name: string;
+    baseArNSRecord?: AoArNSNameDataWithName;
+  }): Promise<NameResolution>;
 }
 
 export interface MatchableItem {


### PR DESCRIPTION
- Don't make unnecessary requests to get base names.
- Don't unnecessarily wait on request to refresh the base name list.
- Ensure only one base name request in flight at once.
- Refresh ANTs in the background only when the cache is about to expire.
- Ensure only one ANT refresh at a time is in flight.