### PR TITLE
fix(db): getVerifiableDataIds

### DIFF
--- a/src/database/sql/data/contiguous-data-ids.sql
+++ b/src/database/sql/data/contiguous-data-ids.sql
@@ -1,7 +1,8 @@
--- selectUnverifiedContiguousDataIds
-SELECT id
-FROM contiguous_data_ids
-WHERE verified = FALSE
+-- selectVerifiableContiguousDataIds
+SELECT cd.id
+FROM contiguous_data_ids cd
+JOIN bundles.bundle_data_items bdi ON bdi.id = cd.id
+WHERE cd.verified = FALSE AND bdi.root_transaction_id IS NOT NULL
 LIMIT 1000;
 
 -- updateDataItemVerificationStatus

--- a/src/database/standalone-sqlite.test.ts
+++ b/src/database/standalone-sqlite.test.ts
@@ -54,6 +54,36 @@ const CURSOR =
   'WzExMzgsNDIsInpvbGpJUnl6RzVocC1SNEVaVjJxOGtGSTQ5T0FveTIzX0I5WUpfeUVFd3MiLDE2MzAwMDAwMDAsInpvbGpJUnl6RzVocC1SNEVaVjJxOGtGSTQ5T0FveTIzX0I5WUpfeUVFd3MiXQ';
 const INDEXED_AT = 1630000000;
 
+const dataItemRootTxId = '0000000000000000000000000000000000000000000';
+const dataItem = {
+  anchor: 'a',
+  dataOffset: 10,
+  dataSize: 1,
+  id: DATA_ITEM_ID,
+  offset: 10,
+  owner: 'a',
+  ownerOffset: 1,
+  ownerSize: 1,
+  sigName: 'a',
+  signature: 'a',
+  signatureOffset: 1,
+  signatureSize: 1,
+  signatureType: 1,
+  size: 1,
+  tags: [],
+  target: 'a',
+};
+const normalizedDataItem = normalizeAns104DataItem({
+  rootTxId: dataItemRootTxId,
+  parentId: dataItemRootTxId,
+  parentIndex: -1,
+  index: 0,
+  ans104DataItem: dataItem,
+  filter: '',
+  dataHash: '',
+  rootParentOffset: 0,
+});
+
 describe('SQLite helper functions', () => {
   describe('toSqliteParams', () => {
     it('should convert SQL Bricks param values to better-sqlite3 params', () => {
@@ -1173,9 +1203,9 @@ describe('StandaloneSqliteDatabase', () => {
     });
   });
 
-  describe('getUnverifiedDataIds', () => {
-    it("should return an empty list if there's no unverified data ids", async () => {
-      const emptyDbIds = await db.getUnverifiedDataIds();
+  describe('getVerifiableDataIds', () => {
+    it("should return an empty list if there's no verifiable data ids", async () => {
+      const emptyDbIds = await db.getVerifiableDataIds();
       assert.equal(emptyDbIds.length, 0);
 
       // inserting a verified data id
@@ -1186,11 +1216,11 @@ describe('StandaloneSqliteDatabase', () => {
         verified: true,
       });
 
-      const unverifiedIds = await db.getUnverifiedDataIds();
-      assert.equal(unverifiedIds.length, 0);
+      const verifiableIds = await db.getVerifiableDataIds();
+      assert.equal(verifiableIds.length, 0);
     });
 
-    it('should return a list of ids if unverified data ids exists', async () => {
+    it('should return a list of ids if verifiable data ids exists', async () => {
       // inserting a verified data id
       await db.saveDataContentAttributes({
         id: '0000000000000000000000000000000000000000000',
@@ -1201,51 +1231,21 @@ describe('StandaloneSqliteDatabase', () => {
 
       // inserting an unverified data id
       await db.saveDataContentAttributes({
-        id: 'fLxHz2WbpNFL7x1HrOyUlsAVHYaKSyj6IqgCJlFuv9g',
+        id: DATA_ITEM_ID,
         hash: 'hash',
         dataSize: 10,
         verified: false,
       });
 
-      const unverifiedIds = await db.getUnverifiedDataIds();
-      assert.equal(unverifiedIds.length, 1);
-      assert.deepEqual(unverifiedIds, [
-        'fLxHz2WbpNFL7x1HrOyUlsAVHYaKSyj6IqgCJlFuv9g',
-      ]);
+      await db.saveDataItem(normalizedDataItem);
+
+      const verifiableIds = await db.getVerifiableDataIds();
+      assert.equal(verifiableIds.length, 1);
+      assert.deepEqual(verifiableIds, [DATA_ITEM_ID]);
     });
   });
 
   describe('getRootTxId', () => {
-    const dataItemRootTxId = '0000000000000000000000000000000000000000000';
-    const dataItem = {
-      anchor: 'a',
-      dataOffset: 10,
-      dataSize: 1,
-      id: DATA_ITEM_ID,
-      offset: 10,
-      owner: 'a',
-      ownerOffset: 1,
-      ownerSize: 1,
-      sigName: 'a',
-      signature: 'a',
-      signatureOffset: 1,
-      signatureSize: 1,
-      signatureType: 1,
-      size: 1,
-      tags: [],
-      target: 'a',
-    };
-    const normalizedDataItem = normalizeAns104DataItem({
-      rootTxId: dataItemRootTxId,
-      parentId: dataItemRootTxId,
-      parentIndex: -1,
-      index: 0,
-      ans104DataItem: dataItem,
-      filter: '',
-      dataHash: '',
-      rootParentOffset: 0,
-    });
-
     it('should return undefined if id is not found', async () => {
       const rootTxId = await db.getRootTxId(DATA_ITEM_ID);
       assert.equal(rootTxId, undefined);

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -2472,8 +2472,8 @@ export class StandaloneSqliteDatabaseWorker {
     });
   }
 
-  getUnverifiedDataIds() {
-    const dataIds = this.stmts.data.selectUnverifiedContiguousDataIds.all();
+  getVerifiableDataIds() {
+    const dataIds = this.stmts.data.selectVerifiableContiguousDataIds.all();
     return dataIds.map((row) => toB64Url(row.id));
   }
 
@@ -3237,8 +3237,8 @@ export class StandaloneSqliteDatabase
     ]);
   }
 
-  async getUnverifiedDataIds() {
-    return this.queueRead('data', 'getUnverifiedDataIds', undefined);
+  async getVerifiableDataIds() {
+    return this.queueRead('data', 'getVerifiableDataIds', undefined);
   }
 
   async getRootTxId(id: string) {
@@ -3450,9 +3450,9 @@ if (!isMainThread) {
           worker.saveNestedDataHash(args[0]);
           parentPort?.postMessage(null);
           break;
-        case 'getUnverifiedDataIds':
-          const unverifiedIds = worker.getUnverifiedDataIds();
-          parentPort?.postMessage(unverifiedIds);
+        case 'getVerifiableDataIds':
+          const ids = worker.getVerifiableDataIds();
+          parentPort?.postMessage(ids);
           break;
         case 'getRootTxId':
           const rootTxId = worker.getRootTxId(args[0]);

--- a/src/routes/data/handlers.test.ts
+++ b/src/routes/data/handlers.test.ts
@@ -46,7 +46,7 @@ describe('Data routes', () => {
         getTransactionAttributes: () => Promise.resolve(undefined),
         getDataParent: () => Promise.resolve(undefined),
         saveDataContentAttributes: () => Promise.resolve(undefined),
-        getUnverifiedDataIds: () => Promise.resolve([]),
+        getVerifiableDataIds: () => Promise.resolve([]),
         getRootTxId: () => Promise.resolve(undefined),
         saveVerificationStatus: () => Promise.resolve(undefined),
       };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -576,7 +576,7 @@ export interface ContiguousDataIndex {
     cachedAt?: number;
     verified?: boolean;
   }): Promise<void>;
-  getUnverifiedDataIds(): Promise<string[]>;
+  getVerifiableDataIds(): Promise<string[]>;
   getRootTxId(id: string): Promise<string | undefined>;
   saveVerificationStatus(id: string): Promise<void>;
 }

--- a/src/workers/data-verification.ts
+++ b/src/workers/data-verification.ts
@@ -90,7 +90,7 @@ export class DataVerificationWorker {
       return;
     }
 
-    const dataIds = await this.contiguousDataIndex.getUnverifiedDataIds();
+    const dataIds = await this.contiguousDataIndex.getVerifiableDataIds();
     const rootTxIds: string[] = [];
 
     for (const dataId of dataIds) {


### PR DESCRIPTION
Change `getUnverifiedDataIds` to `getVerifiableDataIds`. It will now only select contiguous data ids associated with root transactions