### PR TITLE
feat(filters): log the matching status of each filter

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { createFilter } from './filters.js';
 import * as env from './lib/env.js';
 import { release } from './version.js';
+import logger from './log.js';
 
 //
 // HTTP server
@@ -202,6 +203,7 @@ export const ANS104_UNBUNDLE_FILTER_STRING = canonicalize(
 );
 export const ANS104_UNBUNDLE_FILTER = createFilter(
   JSON.parse(ANS104_UNBUNDLE_FILTER_STRING),
+  logger,
 );
 
 // Filter determining which ANS-104 data items to index
@@ -213,6 +215,7 @@ export const ANS104_INDEX_FILTER_STRING = canonicalize(
 );
 export const ANS104_INDEX_FILTER = createFilter(
   JSON.parse(ANS104_INDEX_FILTER_STRING),
+  logger,
 );
 
 // The number of ANS-104 worker threads to run
@@ -449,6 +452,7 @@ export const WEBHOOK_INDEX_FILTER_STRING = canonicalize(
 );
 export const WEBHOOK_INDEX_FILTER = createFilter(
   JSON.parse(WEBHOOK_INDEX_FILTER_STRING),
+  logger,
 );
 
 // Block filter to use for webhooks
@@ -457,6 +461,7 @@ export const WEBHOOK_BLOCK_FILTER_STRING = canonicalize(
 );
 export const WEBHOOK_BLOCK_FILTER = createFilter(
   JSON.parse(WEBHOOK_BLOCK_FILTER_STRING),
+  logger,
 );
 
 //

--- a/src/lib/ans-104.ts
+++ b/src/lib/ans-104.ts
@@ -410,7 +410,10 @@ if (!isMainThread) {
     });
   };
 
-  const filter = createFilter(JSON.parse(workerData.dataItemIndexFilterString));
+  const filter = createFilter(
+    JSON.parse(workerData.dataItemIndexFilterString),
+    log.child({ function: 'ans104IndexFilter' }),
+  );
 
   parentPort?.on('message', async (message: any) => {
     if (message === 'terminate') {

--- a/src/system.ts
+++ b/src/system.ts
@@ -33,7 +33,7 @@ import { DataImporter } from './workers/data-importer.js';
 import { CompositeClickHouseDatabase } from './database/composite-clickhouse.js';
 import { StandaloneSqliteDatabase } from './database/standalone-sqlite.js';
 import * as events from './events.js';
-import { MatchTags } from './filters.js';
+import { MatchTags, TagMatch } from './filters.js';
 import { UniformFailureSimulator } from './lib/chaos.js';
 import {
   makeBlockStore,
@@ -233,10 +233,15 @@ export const contiguousDataFsCacheCleanupWorker = !isNaN(
     })
   : undefined;
 
-const ans104TxMatcher = new MatchTags([
+const ans104BundleTagMatch: TagMatch[] = [
   { name: 'Bundle-Format', value: 'binary' },
   { name: 'Bundle-Version', valueStartsWith: '2.' },
-]);
+];
+
+const ans104TxMatcher = new MatchTags(
+  ans104BundleTagMatch,
+  log.child({ itemFilter: JSON.stringify({ tags: ans104BundleTagMatch }) }),
+);
 
 export const prioritizedTxIds = new Set<string>();
 


### PR DESCRIPTION
With debug logs enabled, we can debug complicated bundle indexing filters and see the tree of user provided filters and if they are matching or not. This can simplify debugging process for users with multiple filters or complicated match criteria.

EDIT: Im adding default argument to a logger that isn't passed to make it simpler to make tests and experiment in the cli. But if we pass the logger right then we get the trees correctly.