### PR TITLE
refactor(sqlite graphql): adjust cursors to align with ClickHouse adapter PE-6482

### DIFF
--- a/src/database/standalone-sqlite.test.ts
+++ b/src/database/standalone-sqlite.test.ts
@@ -51,8 +51,9 @@ import wait from 'wait';
 const HEIGHT = 1138;
 const BLOCK_TX_INDEX = 42;
 const DATA_ITEM_ID = 'zoljIRyzG5hp-R4EZV2q8kFI49OAoy23_B9YJ_yEEws';
+const ID = 'zoljIRyzG5hp-R4EZV2q8kFI49OAoy23_B9YJ_yEEws';
 const CURSOR =
-  'WzExMzgsNDIsInpvbGpJUnl6RzVocC1SNEVaVjJxOGtGSTQ5T0FveTIzX0I5WUpfeUVFd3MiLDE2MzAwMDAwMDAsInpvbGpJUnl6RzVocC1SNEVaVjJxOGtGSTQ5T0FveTIzX0I5WUpfeUVFd3MiXQ';
+  'WzExMzgsNDIsdHJ1ZSwiem9saklSeXpHNWhwLVI0RVpWMnE4a0ZJNDlPQW95MjNfQjlZSl95RUV3cyIsMTYzMDAwMDAwMF0';
 const INDEXED_AT = 1630000000;
 
 const dataItemRootTxId = '0000000000000000000000000000000000000000000';
@@ -98,14 +99,14 @@ describe('SQLite helper functions', () => {
 
 describe('SQLite GraphQL cursor functions', () => {
   describe('encodeTransactionGqlCursor', () => {
-    it('should encode a height, blockTransactionIndex, indexedAt, and dataItemId', () => {
+    it('should encode a height, blockTransactionIndex, dataItemId, indexedAt, and id', () => {
       assert.equal(
         encodeTransactionGqlCursor({
           height: HEIGHT,
           blockTransactionIndex: BLOCK_TX_INDEX,
           dataItemId: DATA_ITEM_ID,
           indexedAt: INDEXED_AT,
-          id: DATA_ITEM_ID,
+          id: ID,
         }),
         CURSOR,
       );
@@ -119,7 +120,25 @@ describe('SQLite GraphQL cursor functions', () => {
         blockTransactionIndex: BLOCK_TX_INDEX,
         dataItemId: DATA_ITEM_ID,
         indexedAt: INDEXED_AT,
-        id: DATA_ITEM_ID,
+        id: ID,
+      });
+    });
+
+    it('should decode a cursor without a data item ID', () => {
+      const cursor = encodeTransactionGqlCursor({
+        height: HEIGHT,
+        blockTransactionIndex: BLOCK_TX_INDEX,
+        dataItemId: 'AA',
+        indexedAt: INDEXED_AT,
+        id: ID,
+      });
+
+      assert.deepEqual(decodeTransactionGqlCursor(cursor), {
+        height: HEIGHT,
+        blockTransactionIndex: BLOCK_TX_INDEX,
+        dataItemId: 'AA',
+        indexedAt: INDEXED_AT,
+        id: ID,
       });
     });
 

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -95,8 +95,16 @@ export function encodeTransactionGqlCursor({
   indexedAt: number | null;
   id: string | null;
 }) {
+  // We use AA (0x00) to indicate lack of data item ID for layer 1 transactions
+  const isDataItem = dataItemId != 'AA';
   return utf8ToB64Url(
-    JSON.stringify([height, blockTransactionIndex, dataItemId, indexedAt, id]),
+    JSON.stringify([
+      height,
+      blockTransactionIndex,
+      isDataItem,
+      id,
+      indexedAt,
+    ]),
   );
 }
 
@@ -112,16 +120,28 @@ export function decodeTransactionGqlCursor(cursor: string | undefined) {
       };
     }
 
-    const [height, blockTransactionIndex, dataItemId, indexedAt, id] =
-      JSON.parse(b64UrlToUtf8(cursor)) as [
-        number | null,
-        number | null,
-        string | null,
-        number | null,
-        string | null,
-      ];
+    const [
+      height,
+      blockTransactionIndex,
+      isDataItem,
+      id,
+      indexedAt,
+    ] = JSON.parse(b64UrlToUtf8(cursor)) as [
+      number | null,
+      number | null,
+      boolean | null,
+      string | null,
+      number | null,
+      string | null,
+    ];
 
-    return { height, blockTransactionIndex, dataItemId, indexedAt, id };
+    return {
+      height,
+      blockTransactionIndex,
+      dataItemId: isDataItem ? id : 'AA',
+      indexedAt,
+      id,
+    };
   } catch (error) {
     throw new ValidationError('Invalid transaction cursor');
   }


### PR DESCRIPTION
In SQLite we sort results using a placeholder value for data item IDs when data items are not available. In the ClickHouse adapter we instead sort results using a flag indicating whether or not the row is a data item (the order is the same with both approaches). Until this commit, GraphQL cursors in both implementations reflected this difference. This change adjusts the SQLite cursors to match the ClickHouse cursors so that we can more easily combine results in the future. This is accomplished by converting placeholder data item ID values to/from boolean data item indicators in the cursor.