### PR TITLE
fix(parquet): fix export parquet names

### DIFF
--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -373,8 +373,7 @@ arIoRouter.post(
         startHeight < 0 ||
         !Number.isInteger(endHeight) ||
         endHeight < 0 ||
-        !Number.isInteger(maxFileRows) ||
-        maxFileRows < 0
+        (Number.isInteger(maxFileRows) && maxFileRows <= 0)
       ) {
         res.status(400).send('Invalid or missing required parameters');
         return;

--- a/src/workers/parquet-exporter.ts
+++ b/src/workers/parquet-exporter.ts
@@ -521,7 +521,7 @@ const exportToParquet = async ({
         rowCount,
       });
 
-      const fileName = `${tableName}-${currentRangeStart}-${height}-rowCount:${rowCount}.parquet`;
+      const fileName = `${tableName}-minHeight:${currentRangeStart}-maxHeight:${height}-rowCount:${rowCount}.parquet`;
       const filePath = `${outputDir}/${fileName}`;
 
       try {


### PR DESCRIPTION
Exported parquet file names are now aligned with what import parquet script expects.

Example:
```
blocks-0-185-rowCount:186.parquet
transactions-0-185-rowCount:331.parquet
```