### PR TITLE
fix(routes): apply default middleware after arns PE-7310

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -62,8 +62,8 @@ app.use(
   }),
 );
 
-app.use(defaultRouter);
 app.use(arnsRouter);
+app.use(defaultRouter);
 app.use(openApiRouter);
 app.use(arIoRouter);
 app.use(dataRouter);


### PR DESCRIPTION
Applying the default route middleware before ArNS breaks ArNS handling.