### PR TITLE
chore(arns): bump ar-io-sdk and update tests to use custom CU url

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/ar-io/ar-io-node"
   },
   "dependencies": {
-    "@ar.io/sdk": "^3.5.0-alpha.3",
+    "@ar.io/sdk": "^3.8.4",
     "@aws-lite/client": "^0.22.4",
     "@aws-lite/s3": "^0.2.6",
     "@clickhouse/client": "^1.10.1",

--- a/src/resolution/on-demand-arns-resolver.ts
+++ b/src/resolution/on-demand-arns-resolver.ts
@@ -26,7 +26,6 @@ import {
   AoARIORead,
   AoArNSNameDataWithName,
   AoClient,
-  sortANTRecords,
 } from '@ar.io/sdk';
 import * as config from '../config.js';
 import { connect } from '@permaweb/aoconnect';
@@ -139,7 +138,7 @@ export class OnDemandArNSResolver implements NameResolver {
       const undername =
         name === baseName ? '@' : name.replace(`_${baseName}`, '');
 
-      // enforce the limit of undername resolution, the ant contract is responsible for returning names in the order they should be resolved
+      // sdk sorts the records by priority, we will use the undername to get the record
       const antRecords = await ant.getRecords();
       const antRecord = antRecords[undername];
 
@@ -149,11 +148,9 @@ export class OnDemandArNSResolver implements NameResolver {
       }
 
       // sort the records by priority
-      const sortedRecords = sortANTRecords(antRecords);
-      const sortedAntRecord = sortedRecords[undername];
-      const resolvedId = sortedAntRecord.transactionId;
-      const ttl = sortedAntRecord.ttlSeconds;
-      const index = sortedAntRecord.index;
+      const resolvedId = antRecord.transactionId;
+      const ttl = antRecord.ttlSeconds;
+      const index = antRecord.index;
 
       if (!isValidDataId(resolvedId)) {
         throw new Error('Invalid resolved data ID');

--- a/test/end-to-end/arns.test.ts
+++ b/test/end-to-end/arns.test.ts
@@ -29,6 +29,7 @@ before(async function () {
   compose = await composeUp({
     START_WRITERS: 'false',
     ARNS_ROOT_HOST: 'ar-io.localhost',
+    AO_CU_URL: 'https://cu.ardrive.io', // TODO: replace with local ao-cu
   });
 });
 
@@ -179,7 +180,7 @@ describe('ArNS', function () {
           for (let i = 0; i <= 10; i++) {
             const res = await axios.get('http://localhost:4000', {
               headers: {
-                Host: `${i === 0 ? '@' : i}_undername-limits.ar-io.localhost`,
+                Host: `${i === 0 ? '' : `${i}_`}undername-limits.ar-io.localhost`,
               },
             });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,10 +119,10 @@
   dependencies:
     xss "^1.0.8"
 
-"@ar.io/sdk@^3.5.0-alpha.3":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.5.0.tgz#ee83344f8c7a5c243bc91396414647f475975556"
-  integrity sha512-25G7i7GMKsbjwEdZATZSitwbx44MF/+ePvjIfgbPjmj5NaKaDtSgLOX9T+z6d1YkSU+My/4GLsZ7VB/ac2Ry8A==
+"@ar.io/sdk@^3.8.4":
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.8.4.tgz#1cab7cdf18c5b8e8720cbaf81241225df078ca5a"
+  integrity sha512-VVFynJEfv5PjBddxJFXlMO3vKynvZM+TsbkZ0NWk/+5nF04Q0W7iqpsHEyACVfydJBNiYLtMLxYdT5ARv+OQFA==
   dependencies:
     "@dha-team/arbundles" "^1.0.1"
     "@permaweb/aoconnect" "^0.0.57"


### PR DESCRIPTION
We will replace this URL with a local cu, but the setup requires a bit more work so these changes fix the current tests and use https://cu.ardrive.io by default

Isolated test results:
```bash
yarn run v1.22.22
$ node --import ./register.js --test test/**/arns.test.ts
▶ ArNS
  ▶ Subdomain resolution
    ▶ Base names
      ✔ Verifying "__unknown__.ar-io.localhost" returns 404 (2449.51303ms)
      ✔ Verifying "ardrive.ar-io.localhost" returns 200 (573.922816ms)
      ✔ Verifying "ardrive.ar-io.localhost" X-ArNS-Resolved-ID header (22.543828ms)
      ✔ Verifying "ardrive.ar-io.localhost" X-ArNS-TTL-Seconds header (13.362679ms)
      ✔ Verifying "ardrive.ar-io.localhost" X-ArNS-Process-ID header (15.827781ms)
      ✔ Verifying "ardrive.ar-io.localhost/{txid}" is redirected (7.624408ms)
      ✔ Verifying "ardrive.ar-io.localhost" X-ArNS-Record-Index header (17.735972ms)
      ✔ Verifying "ardrive.ar-io.localhost" X-ArNS-Undername-Limit header (19.643343ms)
    ▶ Base names (3121.725992ms)
    ▶ Undernames
      ✔ Verifying "dapp_ardrive.ar-io.localhost" returns 200 (477.724133ms)
      ✔ Verifying "dapp_ardrive.ar-io.localhost" X-ArNS-Resolved-ID header (27.297217ms)
      ✔ Verifying "dapp_ardrive.ar-io.localhost" X-ArNS-TTL-Seconds header (20.534677ms)
      ✔ Verifying "dapp_ardrive.ar-io.localhost" X-ArNS-Process-ID header (19.992465ms)
      ✔ Verifying "dapp_ardrive.ar-io.localhost" X-ArNS-Record-Index header (18.108208ms)
      ✔ Verifying "dapp_ardrive.ar-io.localhost" X-ArNS-Undername-Limit header (14.7669ms)
      ▶ Undername limit exceeded
        ✔ Verifying names under the undername limit return 200 (3612.252557ms)
        ✔ Verifying "11_undername-limits.ar-io.localhost" returns 402 (282.548975ms)
      ▶ Undername limit exceeded (3895.137491ms)
    ▶ Undernames (4474.613946ms)
  ▶ Subdomain resolution (7597.496303ms)
  ▶ Resolver endpoint resolution
    ✔ Verifying /ar-io/resolver/ardrive returns 200 and resolution data (4.429987ms)
    ✔ Verifying /ar-io/resolver/ardrive returns 200 and sets the correct headers (3.928018ms)
    ✔ Verifying /ar-io/resolver/dapp_ardrive returns 200 and resolution data for an undername (3.947094ms)
    ✔ Verifying 200 is returned for name that exceeds undername limit (4.112559ms)
    ✔ Verifying /ar-io/resolver/<non-existent-name> returns 404 for nonexistent name (10006.231823ms)
  ▶ Resolver endpoint resolution (10023.227763ms)
▶ ArNS (117557.053673ms)
ℹ tests 21
ℹ suites 6
ℹ pass 21
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 121089.972597
✨  Done in 121.59s.
```