### PR TITLE
feat: s3 chunk data source

### DIFF
--- a/src/arweave/composite-client.ts
+++ b/src/arweave/composite-client.ts
@@ -61,6 +61,7 @@ import {
   PartialJsonTransaction,
   PartialJsonTransactionStore,
   Region,
+  ChunkDataByAnySourceParams,
 } from '../types.js';
 import { MAX_FORK_DEPTH } from './constants.js';
 
@@ -832,12 +833,12 @@ export class ArweaveCompositeClient
     throw new Error('Failed to fetch chunk from any peer');
   }
 
-  async getChunkByAny(
-    txSize: number,
-    absoluteOffset: number,
-    dataRoot: string,
-    relativeOffset: number,
-  ): Promise<Chunk> {
+  async getChunkByAny({
+    txSize,
+    absoluteOffset,
+    dataRoot,
+    relativeOffset,
+  }: ChunkDataByAnySourceParams): Promise<Chunk> {
     this.failureSimulator.maybeFail();
 
     try {
@@ -934,18 +935,18 @@ export class ArweaveCompositeClient
     throw new Error('Unable to fetch chunk from trusted node or peers');
   }
 
-  async getChunkDataByAny(
-    txSize: number,
-    absoluteOffset: number,
-    dataRoot: string,
-    relativeOffset: number,
-  ): Promise<ChunkData> {
-    const { hash, chunk } = await this.getChunkByAny(
+  async getChunkDataByAny({
+    txSize,
+    absoluteOffset,
+    dataRoot,
+    relativeOffset,
+  }: ChunkDataByAnySourceParams): Promise<ChunkData> {
+    const { hash, chunk } = await this.getChunkByAny({
       txSize,
       absoluteOffset,
       dataRoot,
       relativeOffset,
-    );
+    });
     return {
       hash,
       chunk,

--- a/src/data/read-through-chunk-data-cache.test.ts
+++ b/src/data/read-through-chunk-data-cache.test.ts
@@ -93,12 +93,12 @@ describe('ReadThroughChunkDataCache', () => {
       mock.method(chunkDataStore, 'get', async () => mockedChunkData);
       mock.method(chunkSource, 'getChunkByAny');
 
-      await chunkCache.getChunkDataByAny(
-        TX_SIZE,
-        ABSOLUTE_OFFSET,
-        B64_DATA_ROOT,
-        0,
-      );
+      await chunkCache.getChunkDataByAny({
+        txSize: TX_SIZE,
+        absoluteOffset: ABSOLUTE_OFFSET,
+        dataRoot: B64_DATA_ROOT,
+        relativeOffset: 0,
+      });
 
       assert.deepEqual((chunkSource.getChunkByAny as any).mock.callCount(), 0);
       assert.deepEqual((chunkDataStore.get as any).mock.callCount(), 1);
@@ -116,12 +116,12 @@ describe('ReadThroughChunkDataCache', () => {
         'getChunkByAny',
         async () => mockedChunk,
       );
-      await chunkCache.getChunkDataByAny(
-        TX_SIZE,
-        ABSOLUTE_OFFSET,
-        B64_DATA_ROOT,
-        0,
-      );
+      await chunkCache.getChunkDataByAny({
+        txSize: TX_SIZE,
+        absoluteOffset: ABSOLUTE_OFFSET,
+        dataRoot: B64_DATA_ROOT,
+        relativeOffset: 0,
+      });
       assert.deepEqual(chunkDataStoreGetSpy.mock.callCount(), 1);
       assert.deepEqual(chuunkDataStoreHasSpy.mock.callCount(), 1);
       assert.deepEqual(networkSpy.mock.callCount(), 1);
@@ -137,12 +137,12 @@ describe('ReadThroughChunkDataCache', () => {
         'getChunkByAny',
         async () => mockedChunk,
       );
-      await chunkCache.getChunkDataByAny(
-        TX_SIZE,
-        ABSOLUTE_OFFSET,
-        B64_DATA_ROOT,
-        0,
-      );
+      await chunkCache.getChunkDataByAny({
+        txSize: TX_SIZE,
+        absoluteOffset: ABSOLUTE_OFFSET,
+        dataRoot: B64_DATA_ROOT,
+        relativeOffset: 0,
+      });
 
       assert.deepEqual(storeGetSpy.mock.callCount(), 1);
       assert.deepEqual(storeHasSpy.mock.callCount(), 1);

--- a/src/data/read-through-chunk-data-cache.ts
+++ b/src/data/read-through-chunk-data-cache.ts
@@ -17,7 +17,12 @@
  */
 import winston from 'winston';
 
-import { ChunkData, ChunkDataByAnySource, ChunkDataStore } from '../types.js';
+import {
+  ChunkData,
+  ChunkDataByAnySource,
+  ChunkDataByAnySourceParams,
+  ChunkDataStore,
+} from '../types.js';
 
 export class ReadThroughChunkDataCache implements ChunkDataByAnySource {
   private log: winston.Logger;
@@ -38,12 +43,12 @@ export class ReadThroughChunkDataCache implements ChunkDataByAnySource {
     this.chunkStore = chunkDataStore;
   }
 
-  async getChunkDataByAny(
-    txSize: number,
-    absoluteOffset: number,
-    dataRoot: string,
-    relativeOffset: number,
-  ): Promise<ChunkData> {
+  async getChunkDataByAny({
+    txSize,
+    absoluteOffset,
+    dataRoot,
+    relativeOffset,
+  }: ChunkDataByAnySourceParams): Promise<ChunkData> {
     const chunkDataPromise = this.chunkStore
       .get(dataRoot, relativeOffset)
       .then(async (cachedChunkData) => {
@@ -57,12 +62,12 @@ export class ReadThroughChunkDataCache implements ChunkDataByAnySource {
         }
 
         // Fetch from ChunkSource
-        const chunkData = await this.chunkSource.getChunkDataByAny(
+        const chunkData = await this.chunkSource.getChunkDataByAny({
           txSize,
           absoluteOffset,
           dataRoot,
           relativeOffset,
-        );
+        });
 
         await this.chunkStore.set(dataRoot, relativeOffset, chunkData);
 

--- a/src/data/read-through-chunk-metadata-cache.ts
+++ b/src/data/read-through-chunk-metadata-cache.ts
@@ -19,6 +19,7 @@ import winston from 'winston';
 
 import {
   ChunkByAnySource,
+  ChunkDataByAnySourceParams,
   ChunkMetadata,
   ChunkMetadataByAnySource,
   ChunkMetadataStore,
@@ -43,12 +44,12 @@ export class ReadThroughChunkMetadataCache implements ChunkMetadataByAnySource {
     this.chunkMetadataStore = chunkMetadataStore;
   }
 
-  async getChunkMetadataByAny(
-    txSize: number,
-    absoluteOffset: number,
-    dataRoot: string,
-    relativeOffset: number,
-  ): Promise<ChunkMetadata> {
+  async getChunkMetadataByAny({
+    txSize,
+    absoluteOffset,
+    dataRoot,
+    relativeOffset,
+  }: ChunkDataByAnySourceParams): Promise<ChunkMetadata> {
     const chunkMetadataPromise = this.chunkMetadataStore
       .get(dataRoot, relativeOffset)
       .then(async (cachedChunkMetadata) => {
@@ -62,12 +63,12 @@ export class ReadThroughChunkMetadataCache implements ChunkMetadataByAnySource {
         }
 
         // Fetch from ChunkSource
-        const chunk = await this.chunkSource.getChunkByAny(
+        const chunk = await this.chunkSource.getChunkByAny({
           txSize,
           absoluteOffset,
           dataRoot,
           relativeOffset,
-        );
+        });
 
         // TODO use an assertion to compare the data root passed in with the
         // extracted value

--- a/src/data/s3-chunk-source.ts
+++ b/src/data/s3-chunk-source.ts
@@ -1,0 +1,84 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import winston from 'winston';
+import crypto from 'node:crypto';
+import { AwsLiteS3 } from '@aws-lite/s3-types';
+
+import {
+  ChunkData,
+  ChunkDataByAnySource,
+  ChunkDataByAnySourceParams,
+} from '../types.js';
+
+export class S3ChunkSource implements ChunkDataByAnySource {
+  private log: winston.Logger;
+  private s3Client: AwsLiteS3;
+  private s3Bucket: string;
+  private s3Prefix: string;
+
+  constructor({
+    log,
+    s3Client,
+    s3Bucket,
+    s3Prefix = '',
+  }: {
+    log: winston.Logger;
+    s3Client: AwsLiteS3;
+    s3Bucket: string;
+    s3Prefix?: string;
+  }) {
+    this.log = log.child({ class: this.constructor.name });
+    this.s3Client = s3Client;
+    this.s3Bucket = s3Bucket;
+    this.s3Prefix = s3Prefix;
+  }
+
+  async getChunkDataByAny({
+    dataRoot,
+    relativeOffset,
+  }: ChunkDataByAnySourceParams): Promise<ChunkData> {
+    if (!dataRoot || relativeOffset == null) {
+      throw new Error(
+        'S3ChunkSource.getChunkDataByAny called without dataRoot or relativeOffset',
+      );
+    }
+    const key = `${this.s3Prefix}/${dataRoot}/${relativeOffset}`;
+    this.log.debug('Fetching chunk from S3', {
+      bucket: this.s3Bucket,
+      key,
+    });
+
+    const response = await this.s3Client.GetObject({
+      Bucket: this.s3Bucket,
+      Key: key,
+    });
+
+    if (!response.Body) {
+      throw new Error(`Failed to fetch chunk data from S3: ${key}`);
+    }
+    const chunk = Buffer.from(await response.Body.transformToByteArray());
+
+    const hash = crypto.createHash('sha256').update(chunk).digest();
+
+    return {
+      hash, // Buffer containing the SHA-256 digest
+      chunk, // Buffer of the actual chunk data
+    };
+  }
+}

--- a/src/data/tx-chunks-data-source.ts
+++ b/src/data/tx-chunks-data-source.ts
@@ -77,12 +77,12 @@ export class TxChunksDataSource implements ContiguousDataSource {
         dataRoot: string,
         relativeOffset: number,
       ) =>
-        this.chunkSource.getChunkDataByAny(
-          size,
+        this.chunkSource.getChunkDataByAny({
+          txSize: size,
           absoluteOffset,
           dataRoot,
           relativeOffset,
-        );
+        });
       let chunkDataPromise: Promise<ChunkData> | undefined = getChunkDataByAny(
         startOffset,
         txDataRoot,

--- a/src/routes/chunk/handlers.ts
+++ b/src/routes/chunk/handlers.ts
@@ -82,12 +82,12 @@ export const createChunkOffsetHandler = ({
 
     // actually fetch the chunk data
     try {
-      chunkData = await chunkDataSource.getChunkDataByAny(
-        data_size,
-        offset,
-        data_root,
+      chunkData = await chunkDataSource.getChunkDataByAny({
+        txSize: data_size,
+        absoluteOffset: offset,
+        dataRoot: data_root,
         relativeOffset,
-      );
+      });
     } catch (error) {
       response.sendStatus(404);
       return;
@@ -111,12 +111,12 @@ export const createChunkOffsetHandler = ({
     let dataPath: string | undefined = undefined;
 
     try {
-      chunkMetadata = await chunkMetaDataSource.getChunkMetadataByAny(
-        data_size,
-        offset,
-        data_root,
+      chunkMetadata = await chunkMetaDataSource.getChunkMetadataByAny({
+        txSize: data_size,
+        absoluteOffset: offset,
+        dataRoot: data_root,
         relativeOffset,
-      );
+      });
     } catch (error) {
       log.error('Error fetching chunk metadata', { error });
     }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -481,31 +481,25 @@ export interface Chunk extends ChunkMetadata, ChunkData {
   tx_path: Buffer;
 }
 
+export interface ChunkDataByAnySourceParams {
+  txSize: number;
+  absoluteOffset: number;
+  dataRoot: string;
+  relativeOffset: number;
+}
+
 export interface ChunkByAnySource {
-  getChunkByAny(
-    txSize: number,
-    absoluteOffset: number,
-    dataRoot: string,
-    relativeOffset: number,
-  ): Promise<Chunk>;
+  getChunkByAny(params: ChunkDataByAnySourceParams): Promise<Chunk>;
 }
 
 export interface ChunkMetadataByAnySource {
   getChunkMetadataByAny(
-    txSize: number,
-    absoluteOffset: number,
-    dataRoot: string,
-    relativeOffset: number,
+    params: ChunkDataByAnySourceParams,
   ): Promise<ChunkMetadata>;
 }
 
 export interface ChunkDataByAnySource {
-  getChunkDataByAny(
-    txSize: number,
-    absoluteOffset: number,
-    dataRoot: string,
-    relativeOffset: number,
-  ): Promise<ChunkData>;
+  getChunkDataByAny(params: ChunkDataByAnySourceParams): Promise<ChunkData>;
 }
 
 type BroadcastChunkResponses = {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -27,6 +27,7 @@ import {
   ChunkByAnySource,
   ChunkData,
   ChunkDataByAnySource,
+  ChunkDataByAnySourceParams,
   JsonTransactionOffset,
   PartialJsonBlock,
   PartialJsonTransaction,
@@ -172,12 +173,12 @@ export class ArweaveChunkSourceStub
   implements ChunkByAnySource, ChunkDataByAnySource
 {
   stubData: string = 'abcdefghijklmnopqrstuvwxyz'.repeat(10);
-  async getChunkByAny(
-    txSize: number,
-    absoluteOffset: number,
-    dataRoot: string,
-    relativeOffset: number,
-  ): Promise<Chunk> {
+  async getChunkByAny({
+    txSize,
+    absoluteOffset,
+    dataRoot,
+    relativeOffset,
+  }: ChunkDataByAnySourceParams): Promise<Chunk> {
     if (fs.existsSync(`test/mock_files/chunks/${absoluteOffset}.json`)) {
       const jsonChunk = JSON.parse(
         fs.readFileSync(
@@ -209,18 +210,18 @@ export class ArweaveChunkSourceStub
     }
   }
 
-  async getChunkDataByAny(
-    txSize: number,
-    absoluteOffset: number,
-    dataRoot: string,
-    relativeOffset: number,
-  ): Promise<ChunkData> {
-    const { hash, chunk } = await this.getChunkByAny(
+  async getChunkDataByAny({
+    txSize,
+    absoluteOffset,
+    dataRoot,
+    relativeOffset,
+  }: ChunkDataByAnySourceParams): Promise<ChunkData> {
+    const { hash, chunk } = await this.getChunkByAny({
       txSize,
       absoluteOffset,
       dataRoot,
       relativeOffset,
-    );
+    });
     return {
       hash,
       chunk,


### PR DESCRIPTION
feat: add S3-based chunk data source and unify getChunkDataByAny signature

- Adds a new `S3ChunkSource` implementation of `ChunkDataByAnySource`, enabling
  chunk retrieval from S3 using the Arweave-compatible `/chunk/<offset>` interface.
- Refactors `getChunkDataByAny` and related methods to use a unified
  `ChunkDataByAnySourceParams` object for improved consistency and readability.
