### PR TITLE
feat: add Postgres support for legacy chunk metadata (PE-7904)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "p-debounce": "^4.0.0",
     "p-limit": "^6.2.0",
     "p-timeout": "^6.1.4",
+    "postgres": "^3.4.5",
     "prom-client": "^14.2.0",
     "ramda": "^0.30.1",
     "range-parser": "^1.2.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -223,6 +223,23 @@ export const BACKGROUND_RETRIEVAL_ORDER = env
   )
   .split(',');
 
+// By default it looks for chunk from the filesystem's dataDir
+// but it can be configured to use an s3 bucket that assumes a
+// specific kind of layout of /{dataRoot}/{relativeOffset}
+export const CHUNK_DATA_SOURCE_TYPE = env.varOrDefault(
+  'CHUNK_DATA_SOURCE_TYPE',
+  'fs',
+) as 'fs' | 'legacy-s3';
+
+// By default is uses FsChunkMetadataStore marked here as 'fs'
+// but it can be configured to use a "legacy" PostgreSQL database
+// that has a specific table "chunks" with specific columns. This
+// is designed for legacy arweave gateway support.
+export const CHUNK_METADATA_SOURCE_TYPE = env.varOrDefault(
+  'CHUNK_METADATA_SOURCE_TYPE',
+  'fs',
+) as 'fs' | 'legacy-psql';
+
 //
 // Indexing
 //
@@ -350,6 +367,30 @@ export const BUNDLE_REPAIR_RETRY_BATCH_SIZE = +env.varOrDefault(
   'BUNDLE_REPAIR_RETRY_BATCH_SIZE',
   '1000',
 );
+
+//
+// PostgreSQL
+//
+
+// A URL format of: postgres://username:password@host:port/database
+// the password can be omitted and passed in as filesystem path
+export const LEGACY_PSQL_CONNECTION_STRING = env.varOrUndefined(
+  'LEGACY_PSQL_CONNECTION_STRING',
+);
+
+// The path to the file containing the password for the PostgreSQL connection
+// this enhances security by not exposing the password in the connection string.
+// This is ar-io specific environment variable,
+// note that postgres.js also respects built-in env-vars like PGHOST, PGPORT etc.
+// see more: https://github.com/porsager/postgres?tab=readme-ov-file#environmental-variables
+export const LEGACY_PSQL_PASSWORD_FILE = env.varOrUndefined(
+  'LEGACY_PSQL_PASSWORD_FILE',
+);
+
+// very common workaround needed for various cloud providers
+// see more: https://github.com/porsager/postgres?tab=readme-ov-file#ssl
+export const LEGACY_PSQL_SSL_REJECT_UNAUTHORIZED =
+  env.varOrDefault('LEGACY_PSQL_SSL_REJECT_UNAUTHORIZED', 'true') === 'true';
 
 //
 // File system cleanup
@@ -689,6 +730,18 @@ export const AWS_S3_CONTIGUOUS_DATA_BUCKET = env.varOrUndefined(
 );
 export const AWS_S3_CONTIGUOUS_DATA_PREFIX = env.varOrUndefined(
   'AWS_S3_CONTIGUOUS_DATA_PREFIX',
+);
+
+// Chunk data source speficially set-up for interoperability with
+// the legacy arweave gateways
+export const LEGACY_AWS_S3_CHUNK_DATA_BUCKET = env.varOrUndefined(
+  'LEGACY_AWS_S3_CHUNK_DATA_BUCKET',
+);
+
+// Optional prefix for chunk data in the legacy S3 bucket, if omitted,
+// the root of the bucket will be /{dataRoot}/{relativeOffset}
+export const LEGACY_AWS_S3_CHUNK_DATA_PREFIX = env.varOrUndefined(
+  'LEGACY_AWS_S3_CHUNK_DATA_PREFIX',
 );
 
 //

--- a/src/data/legacy-psql-chunk-metadata-cache.ts
+++ b/src/data/legacy-psql-chunk-metadata-cache.ts
@@ -1,0 +1,125 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import winston from 'winston';
+
+import { fromB64Url } from '../lib/encoding.js';
+import type { PostgreSQL } from '../system.js';
+import {
+  ChunkMetadata,
+  ChunkMetadataByAnySource,
+  ChunkDataByAnySourceParams,
+} from '../types.js';
+
+type LegacyChunkMetadata = {
+  data_root: string;
+  data_size: number;
+  data_path: string;
+  chunk: string;
+  chunk_size: number;
+  offset: number;
+};
+
+export class LegacyPostgresChunkMetadataSource
+  implements ChunkMetadataByAnySource
+{
+  private log: winston.Logger;
+  private psql: PostgreSQL;
+
+  constructor({
+    log,
+    legacyPsql,
+  }: {
+    log: winston.Logger;
+    legacyPsql: PostgreSQL;
+  }) {
+    this.log = log.child({ class: this.constructor.name });
+    if (typeof legacyPsql !== 'function') {
+      throw new Error('chunkMetadataStore must be an object');
+    }
+    this.psql = legacyPsql;
+  }
+
+  async getChunkMetadataByAny({
+    dataRoot,
+    relativeOffset,
+  }: ChunkDataByAnySourceParams): Promise<ChunkMetadata> {
+    if (
+      dataRoot == null ||
+      dataRoot === undefined ||
+      relativeOffset == null ||
+      relativeOffset === undefined
+    ) {
+      throw new Error(
+        `Missing required parameters: dataRoot=${dataRoot}, relativeOffset=${relativeOffset}`,
+      );
+    }
+
+    // most editors have tagged template editor support for 'sql'
+    const sql = this.psql;
+    try {
+      const results = await sql<LegacyChunkMetadata[]>`
+        SELECT
+          data_root,
+          data_size,
+          data_path,
+          chunk_size,
+          "offset"
+        FROM chunks
+        WHERE data_root = ${dataRoot}
+        -- chunk starts at ("offset" + 1 - chunk_size)
+        AND ("offset" + 1 - chunk_size) <= ${relativeOffset}
+        -- chunk ends at "offset"
+        AND ${relativeOffset} <= "offset"
+        ORDER BY "offset" ASC
+        LIMIT 1;
+    `;
+
+      if (results.length === 0) {
+        throw new Error(
+          `Chunk metadata not found for dataRoot=${dataRoot}, relativeOffset=${relativeOffset}`,
+        );
+      }
+
+      this.log.debug(
+        `Found chunk metadata for dataRoot=${dataRoot}, relativeOffset=${relativeOffset}`,
+        { data_root: results[0].data_root, data_size: results[0].data_size },
+      );
+
+      const dataPathBuffer = fromB64Url(results[0].data_path);
+
+      return {
+        data_root: fromB64Url(results[0].data_root),
+        data_size: results[0].data_size,
+        data_path: dataPathBuffer,
+        chunk_size: results[0].chunk_size,
+        offset: results[0].offset,
+        hash: dataPathBuffer.slice(-64, -32),
+      };
+    } catch (errorUnknown: unknown) {
+      const error = errorUnknown as Error;
+      this.log.error('Failed to fetch chunk metadata from PostgreSQL', {
+        dataRoot,
+        relativeOffset,
+        message: error.message,
+        stack: error.stack,
+      });
+      throw error;
+    }
+  }
+}

--- a/src/data/s3-chunk-source.ts
+++ b/src/data/s3-chunk-source.ts
@@ -58,7 +58,9 @@ export class S3ChunkSource implements ChunkDataByAnySource {
         'S3ChunkSource.getChunkDataByAny called without dataRoot or relativeOffset',
       );
     }
-    const key = `${this.s3Prefix}/${dataRoot}/${relativeOffset}`;
+    const key = this.s3Prefix
+      ? `${this.s3Prefix}/${dataRoot}/${relativeOffset}`
+      : `${dataRoot}/${relativeOffset}`;
     this.log.debug('Fetching chunk from S3', {
       bucket: this.s3Bucket,
       key,

--- a/src/store/fs-chunk-data-store.ts
+++ b/src/store/fs-chunk-data-store.ts
@@ -103,7 +103,6 @@ export class FsChunkDataStore implements ChunkDataStore {
     try {
       const chunkDataRootDir = this.chunkDataRootDir(dataRoot);
       await fs.promises.mkdir(chunkDataRootDir, { recursive: true });
-
       await fs.promises.mkdir(this.chunkHashDir(chunkData.hash), {
         recursive: true,
       });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -470,6 +470,7 @@ export interface ChunkData {
 }
 
 export interface ChunkMetadata {
+  chunk_size?: number;
   data_root: Buffer;
   data_size: number;
   data_path: Buffer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6812,6 +6812,11 @@ pony-cause@^2.1.4:
   resolved "https://registry.yarnpkg.com/pony-cause/-/pony-cause-2.1.11.tgz#d69a20aaccdb3bdb8f74dd59e5c68d8e6772e4bd"
   integrity sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==
 
+postgres@^3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/postgres/-/postgres-3.4.5.tgz#1ef99e51b0ba9b53cbda8a215dd406725f7d15f9"
+  integrity sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg==
+
 prebuild-install@^7.1.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.3.tgz#d630abad2b147443f20a212917beae68b8092eec"


### PR DESCRIPTION
- Add `postgres` as a new dependency.
- Introduce configuration options for PostgreSQL in `config.ts`, including support for secure password files and SSL.
- Establish a conditional `postgres` client instance in `system.ts` that only connects when configuration is provided.
- Define a new `LegacyChunkMetadata` type to match the legacy chunk structure in Postgres.
- Prepare system to support a new Postgres-based implementation of `ChunkMetadataByAnySource` for serving chunk metadata via the standard `/chunk/<offset>` interface.