### PR TITLE
feat: introduce CompositeChunkSource and refactor chunk handling (PE-8012)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -727,6 +727,8 @@ export const AWS_ACCESS_KEY_ID = env.varOrUndefined('AWS_ACCESS_KEY_ID');
 export const AWS_SECRET_ACCESS_KEY = env.varOrUndefined(
   'AWS_SECRET_ACCESS_KEY',
 );
+// The session token is optional, but if it is set, it must be used
+export const AWS_SESSION_TOKEN = env.varOrUndefined('AWS_SESSION_TOKEN');
 export const AWS_REGION = env.varOrUndefined('AWS_REGION');
 export const AWS_ENDPOINT = env.varOrUndefined('AWS_ENDPOINT');
 

--- a/src/data/composite-chunk-source.ts
+++ b/src/data/composite-chunk-source.ts
@@ -1,0 +1,58 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  ChunkMetadataByAnySource,
+  ChunkByAnySource,
+  ChunkDataByAnySource,
+  ChunkDataByAnySourceParams,
+  Chunk,
+} from '../types';
+
+export class CompositeChunkSource implements ChunkByAnySource {
+  private readonly chunkMetaDataSource: ChunkMetadataByAnySource;
+  private readonly chunkDataSource: ChunkDataByAnySource;
+
+  constructor(
+    chunkMetaDataSource: ChunkMetadataByAnySource,
+    chunkDataSource: ChunkDataByAnySource,
+  ) {
+    this.chunkMetaDataSource = chunkMetaDataSource;
+    this.chunkDataSource = chunkDataSource;
+  }
+
+  async getChunkByAny(params: ChunkDataByAnySourceParams): Promise<Chunk> {
+    const metadata =
+      await this.chunkMetaDataSource.getChunkMetadataByAny(params);
+
+    const chunkDataParams: ChunkDataByAnySourceParams = {
+      txSize: params.txSize,
+      absoluteOffset: params.absoluteOffset,
+      dataRoot: params.dataRoot,
+      relativeOffset: metadata.offset, // aligned offset
+    };
+
+    const data = await this.chunkDataSource.getChunkDataByAny(chunkDataParams);
+
+    return {
+      ...metadata,
+      ...data,
+      tx_path: undefined,
+    };
+  }
+}

--- a/src/data/read-through-chunk-metadata-cache.ts
+++ b/src/data/read-through-chunk-metadata-cache.ts
@@ -74,7 +74,10 @@ export class ReadThroughChunkMetadataCache implements ChunkMetadataByAnySource {
         // extracted value
 
         const chunkMetadata = {
-          data_root: chunk.tx_path.slice(-64, -32),
+          data_root:
+            chunk.tx_path === undefined
+              ? chunk.data_root
+              : chunk.tx_path.slice(-64, -32),
           data_size: chunk.chunk.length,
           offset: relativeOffset,
           data_path: chunk.data_path,

--- a/src/routes/chunk/index.ts
+++ b/src/routes/chunk/index.ts
@@ -22,12 +22,7 @@ import {
   createChunkPostHandler,
 } from './handlers.js';
 import log from '../../log.js';
-import {
-  arweaveClient,
-  chunkDataSource,
-  chunkMetaDataSource,
-  db,
-} from '../../system.js';
+import { arweaveClient, chunkSource, db } from '../../system.js';
 
 // To add a GET route for /chunk/:offset where :offset is restricted to a positive integer,
 // we can use a regular expression in your route path to constrain :offset.
@@ -42,8 +37,7 @@ chunkRouter.use(json({ limit: MAX_CHUNK_SIZE }));
 chunkRouter.get(
   CHUNK_OFFSET_PATH,
   createChunkOffsetHandler({
-    chunkDataSource,
-    chunkMetaDataSource,
+    chunkSource,
     db,
     log: log.child({ class: 'ChunkGetOffsetHandler' }),
   }),

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -479,7 +479,7 @@ export interface ChunkMetadata {
 }
 
 export interface Chunk extends ChunkMetadata, ChunkData {
-  tx_path: Buffer;
+  tx_path: Buffer | undefined;
 }
 
 export interface ChunkDataByAnySourceParams {


### PR DESCRIPTION
- Create CompositeChunkSource to unify chunk data and metadata retrieval
- Replace separate chunkDataSource and chunkMetaDataSource with unified chunkSource in route handlers
- Refactor handler to work with composite Chunk objects (data + metadata)
- Remove redundant metadata fetch logic from chunk handler
- Introduce new Chunk interface that extends ChunkMetadata and ChunkData with optional tx_path
- Update S3ChunkSource to support rawResponsePayload mode using aws-lite
- Ensure chunk body is a Buffer and validate S3 responses defensively
- Add support for AWS_SESSION_TOKEN in config and awsClient setup
- Restructure system.ts to initialize chunkSource conditionally based on config
- Clean up imports and parameter lists in affected modules
