### PR TITLE
fix(envoy): add /height to envoy routing

### DIFF
--- a/envoy/envoy.template.yaml
+++ b/envoy/envoy.template.yaml
@@ -110,6 +110,17 @@ static_resources:
                               max_internal_redirects: 10
                               allow_cross_scheme_redirect: true
                               redirect_response_codes: [301, 302, 303]
+                        - match: { prefix: '/height' }
+                          route:
+                            cluster: legacy_gateways
+                            retry_policy:
+                              retry_on: '5xx,reset,retriable-status-codes'
+                              num_retries: 5
+                            auto_host_rewrite: true
+                            internal_redirect_policy:
+                              max_internal_redirects: 10
+                              allow_cross_scheme_redirect: true
+                              redirect_response_codes: [301, 302, 303]
                         - match: { prefix: '/tx/' }
                           route:
                             cluster: legacy_gateways


### PR DESCRIPTION
This routes /height to arweave nodes. The openapi docs alreay have the endpoint documented, but it did not route as expected.

Existing docs: https://github.com/ar-io/ar-io-node/blob/develop/docs/openapi.yaml#L919-L931

```bash
❯ curl localhost:3000/height
1659148
```