### PR TITLE
chore(app): expose all ario headers in cors configuration

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -51,14 +51,7 @@ const app = express();
 
 app.use(
   cors({
-    exposedHeaders: [
-      headerNames.arnsResolvedId,
-      headerNames.arnsTtlSeconds,
-      headerNames.arnsProcessId,
-      headerNames.arnsResolvedAt,
-      headerNames.arnsIndex,
-      headerNames.arnsLimit,
-    ],
+    exposedHeaders: Object.values(headerNames),
   }),
 );
 


### PR DESCRIPTION
Browsers do not allow accessing of headers if they are not set in the cors configuration.