### PR TITLE
feat(api): add peer list endpoint

### DIFF
--- a/src/arweave/composite-client.ts
+++ b/src/arweave/composite-client.ts
@@ -62,6 +62,7 @@ import {
   PartialJsonTransactionStore,
   Region,
   ChunkDataByAnySourceParams,
+  WithPeers,
 } from '../types.js';
 import { MAX_FORK_DEPTH } from './constants.js';
 
@@ -95,7 +96,8 @@ export class ArweaveCompositeClient
     ChunkBroadcaster,
     ChunkByAnySource,
     ChunkDataByAnySource,
-    ContiguousDataSource
+    ContiguousDataSource,
+    WithPeers<Peer>
 {
   private arweave: Arweave;
   private log: winston.Logger;
@@ -417,6 +419,10 @@ export class ArweaveCompositeClient
     } catch (error) {
       metrics.arweavePeerRefreshErrorCounter.inc();
     }
+  }
+
+  getPeers(): Record<string, Peer> {
+    return this.peers;
   }
 
   selectPeers(peerCount: number, peerListName: WeightedPeerListName): string[] {

--- a/src/data/ar-io-data-source.ts
+++ b/src/data/ar-io-data-source.ts
@@ -29,6 +29,7 @@ import {
   ContiguousDataSource,
   Region,
   RequestAttributes,
+  WithPeers,
 } from '../types.js';
 import {
   generateRequestAttributes,
@@ -44,7 +45,9 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 10_000; // 10 seconds
 const DEFAULT_UPDATE_PEERS_REFRESH_INTERVAL_MS = 3_600_000; // 1 hour
 const DEFAULT_MAX_HOPS_ALLOWED = 3;
 
-export class ArIODataSource implements ContiguousDataSource {
+export class ArIODataSource
+  implements ContiguousDataSource, WithPeers<WeightedElement<string>>
+{
   private log: winston.Logger;
   private nodeWallet: string | undefined;
   private maxHopsAllowed: number;
@@ -134,6 +137,14 @@ export class ArIODataSource implements ContiguousDataSource {
     if (this.intervalId) {
       clearInterval(this.intervalId);
     }
+  }
+
+  getPeers(): Record<string, WeightedElement<string>> {
+    const peers: Record<string, WeightedElement<string>> = {};
+    for (const peer of this.weightedPeers) {
+      peers[peer.id] = peer;
+    }
+    return peers;
   }
 
   async updatePeerList() {

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -105,9 +105,15 @@ arIoRouter.get('/ar-io/info', arIoInfoHandler);
 
 // peer list
 arIoRouter.get('/ar-io/peers', async (_req, res) => {
-  const gateways = await system.arIODataSource.getPeers();
-  const nodes = await system.arweaveClient.getPeers();
-  res.json({ gateways, nodes });
+  try {
+    const [gateways, nodes] = await Promise.all([
+      system.arIODataSource.getPeers(),
+      system.arweaveClient.getPeers(),
+    ]);
+    res.json({ gateways, nodes });
+  } catch (error: any) {
+    res.status(500).send(error?.message);
+  }
 });
 
 // Only allow access to admin routes if the bearer token matches the admin api key

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -106,11 +106,11 @@ arIoRouter.get('/ar-io/info', arIoInfoHandler);
 // peer list
 arIoRouter.get('/ar-io/peers', async (_req, res) => {
   try {
-    const [gateways, nodes] = await Promise.all([
+    const [gateways, arweaveNodes] = await Promise.all([
       system.arIODataSource.getPeers(),
       system.arweaveClient.getPeers(),
     ]);
-    res.json({ gateways, nodes });
+    res.json({ gateways, arweaveNodes });
   } catch (error: any) {
     res.status(500).send(error?.message);
   }

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -103,6 +103,13 @@ export const arIoInfoHandler = (_req: Request, res: Response) => {
 };
 arIoRouter.get('/ar-io/info', arIoInfoHandler);
 
+// peer list
+arIoRouter.get('/ar-io/peers', async (_req, res) => {
+  const gateways = await system.arIODataSource.getPeers();
+  const nodes = await system.arweaveClient.getPeers();
+  res.json({ gateways, nodes });
+});
+
 // Only allow access to admin routes if the bearer token matches the admin api key
 arIoRouter.use('/ar-io/admin', (req, res, next) => {
   if (req.headers.authorization === `Bearer ${config.ADMIN_API_KEY}`) {

--- a/src/system.ts
+++ b/src/system.ts
@@ -433,7 +433,7 @@ const gatewaysDataSource = new GatewaysDataSource({
   trustedGatewaysUrls: config.TRUSTED_GATEWAYS_URLS,
 });
 
-const arIODataSource = new ArIODataSource({
+export const arIODataSource = new ArIODataSource({
   log,
   networkProcess,
   nodeWallet: config.AR_IO_WALLET,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -750,3 +750,7 @@ export interface OwnerSource {
 
   getTransactionOwner({ id }: { id: string }): Promise<string | undefined>;
 }
+
+export interface WithPeers<T> {
+  getPeers(): Record<string, T>;
+}

--- a/test/end-to-end/ar-io.test.ts
+++ b/test/end-to-end/ar-io.test.ts
@@ -1,0 +1,52 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { strict as assert } from 'node:assert';
+import { after, before, describe, it } from 'node:test';
+import { StartedDockerComposeEnvironment } from 'testcontainers';
+import axios from 'axios';
+import { cleanDb, composeUp } from './utils.js';
+
+let compose: StartedDockerComposeEnvironment;
+
+before(async function () {
+  await cleanDb();
+
+  compose = await composeUp({
+    START_WRITERS: 'false',
+  });
+});
+
+after(async function () {
+  await compose.down();
+});
+
+describe('ArIO', function () {
+  it('should return the network contract info on the /info endpoint', async function () {
+    const res = await axios.get('http://localhost:4000/ar-io/info');
+    assert.ok(res.data.wallet);
+    assert.ok(res.data.processId);
+    assert.ok(res.data.supportedManifestVersions);
+    assert.ok(res.data.release);
+  });
+
+  it('should return a list of peers', async function () {
+    const res = await axios.get('http://localhost:4000/ar-io/peers');
+    assert.ok(res.data.nodes);
+    assert.ok(res.data.gateways);
+  });
+});

--- a/test/end-to-end/ar-io.test.ts
+++ b/test/end-to-end/ar-io.test.ts
@@ -46,7 +46,7 @@ describe('ArIO', function () {
 
   it('should return a list of peers', async function () {
     const res = await axios.get('http://localhost:4000/ar-io/peers');
-    assert.ok(res.data.nodes);
+    assert.ok(res.data.arweaveNodes);
     assert.ok(res.data.gateways);
   });
 });

--- a/test/end-to-end/ar-io.test.ts
+++ b/test/end-to-end/ar-io.test.ts
@@ -38,7 +38,6 @@ after(async function () {
 describe('ArIO', function () {
   it('should return the network contract info on the /info endpoint', async function () {
     const res = await axios.get('http://localhost:4000/ar-io/info');
-    assert.ok(res.data.wallet);
     assert.ok(res.data.processId);
     assert.ok(res.data.supportedManifestVersions);
     assert.ok(res.data.release);


### PR DESCRIPTION
Includes gateways and nodes. We can add more to the gateways peer lists based on weights when useful.
