### PR TITLE
fix(headers): add content-* headers to CORS

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -52,7 +52,7 @@ const app = express();
 app.use(
   cors({
     exposedHeaders: [
-      'content-type',
+      // these are not exposed by default and must be added manually to be used on browsers
       'content-length',
       'content-encoding',
       ...Object.values(headerNames),

--- a/src/app.ts
+++ b/src/app.ts
@@ -51,7 +51,12 @@ const app = express();
 
 app.use(
   cors({
-    exposedHeaders: Object.values(headerNames),
+    exposedHeaders: [
+      'content-type',
+      'content-length',
+      'content-encoding',
+      ...Object.values(headerNames),
+    ],
   }),
 );
 


### PR DESCRIPTION
These are needed, specifically content-length, for wayfinder to verify data from the gateway.