### PR TITLE
chore(docs): set regex for /api-docs to allow optional /

### DIFF
--- a/src/middleware/arns.ts
+++ b/src/middleware/arns.ts
@@ -58,7 +58,7 @@ export const createArnsMiddleware = ({
         req.path.match(/^\/local\//) ||
         req.path.match(/^\/ar-io\//) ||
         req.path.match(/^\/chunk\//) ||
-        req.path.match(/^\/api-docs\//) ||
+        req.path.match(/^\/api-docs(?:\/|$)/) ||
         req.path === '/openapi.json' ||
         req.path === '/graphql'
       ) {


### PR DESCRIPTION
When APEX_ARNS_NAME is set, navigating to /api-docs/  works but /api-docs **does not**
