### PR TITLE
Fix duplicate fallback logic in manifest parser

### DIFF
--- a/src/lib/encoding.ts
+++ b/src/lib/encoding.ts
@@ -350,16 +350,6 @@ export function parseManifestStream(stream: Readable): EventEmitter {
       fallbackId = data;
     }
 
-    // Fallback - { "fallback": { "id": "<data-id>" } }
-    if (
-      keyPath.length === 1 &&
-      keyPath[0] === 'fallback' &&
-      isManifestV2 &&
-      currentKey === 'id'
-    ) {
-      fallbackId = data;
-    }
-
     // Paths - { "paths": { "some/path/file.html": { "id": "<data-id>" } }
     if (
       keyPath.length === 2 &&


### PR DESCRIPTION
## Summary
- remove duplicate fallback clause in `parseManifestStream`

## Testing
- `yarn test` *(fails: package not in lockfile)*