### PR TITLE
Fix typo in data verification log message

### DIFF
--- a/src/workers/data-verification.ts
+++ b/src/workers/data-verification.ts
@@ -154,7 +154,7 @@ export class DataVerificationWorker {
         return false;
       }
 
-      log.debug('Data root verified successfull.');
+      log.debug('Data root verified successfully.');
       await this.contiguousDataIndex.saveVerificationStatus(id);
       log.debug('Saved verified status successfully.');
       return true;


### PR DESCRIPTION
## Summary
- fix typo in DataVerificationWorker log statement

## Testing
- `node --import ./register.js --test src/workers/data-verification.test.ts` *(fails: cannot find package 'ts-node')*