### PR TITLE
Fix test dir exclusion

### DIFF
--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -4,5 +4,5 @@
     "sourceMap": false
   },
   "include": ["src"],
-  "exclude": ["tests", "**/*.test.ts"]
+  "exclude": ["test", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- update `tsconfig.prod.json` to exclude the `test` dir

## Testing
- `yarn build` *(fails: package not present in lockfile)*