### PR TITLE
feat(data): add trusted flag to prevent caching untrusted data PE-8147

### DIFF
--- a/src/arweave/composite-client.ts
+++ b/src/arweave/composite-client.ts
@@ -1125,6 +1125,7 @@ export class ArweaveCompositeClient
         stream,
         size: region ? region.size : size,
         verified: false,
+        trusted: true,
         cached: false,
       };
     } catch (error) {

--- a/src/data/ar-io-data-source.test.ts
+++ b/src/data/ar-io-data-source.test.ts
@@ -110,6 +110,7 @@ describe('ArIODataSource', () => {
         stream: axiosStreamData,
         size: 123,
         verified: false,
+        trusted: false,
         sourceContentType: 'application/octet-stream',
         cached: false,
         requestAttributes: {
@@ -163,6 +164,7 @@ describe('ArIODataSource', () => {
         stream: secondPeerStreamData,
         size: 10,
         verified: false,
+        trusted: false,
         sourceContentType: 'application/octet-stream',
         cached: false,
         requestAttributes: {
@@ -240,6 +242,7 @@ describe('ArIODataSource', () => {
         stream: axiosStreamData,
         size: 123,
         verified: false,
+        trusted: false,
         sourceContentType: 'application/octet-stream',
         cached: false,
         requestAttributes: {

--- a/src/data/ar-io-data-source.ts
+++ b/src/data/ar-io-data-source.ts
@@ -434,6 +434,7 @@ export class ArIODataSource
       stream,
       size: contentLength,
       verified: false,
+      trusted: false,
       sourceContentType: response.headers['content-type'],
       cached: false,
       requestAttributes,

--- a/src/data/gateways-data-source.ts
+++ b/src/data/gateways-data-source.ts
@@ -193,6 +193,7 @@ export class GatewaysDataSource implements ContiguousDataSource {
               stream,
               size: parseInt(response.headers['content-length']),
               verified: false,
+              trusted: true,
               sourceContentType: response.headers['content-type'],
               cached: false,
               requestAttributes: parseRequestAttributesHeaders({

--- a/src/data/read-through-data-cache.test.ts
+++ b/src/data/read-through-data-cache.test.ts
@@ -54,6 +54,7 @@ describe('ReadThroughDataCache', function () {
       stream: new Readable(),
       size: 100,
       verified: false,
+      trusted: false,
       cached: false,
     };
 
@@ -274,6 +275,7 @@ describe('ReadThroughDataCache', function () {
         size: 100,
         sourceContentType: 'plain/text',
         verified: true,
+        trusted: true,
         cached: true,
         requestAttributes: {
           hops: requestAttributes.hops + 1,
@@ -374,6 +376,7 @@ describe('ReadThroughDataCache', function () {
           size: 99,
           sourceContentType: 'plain/text',
           verified: true,
+          trusted: true,
           cached: false,
         });
       });
@@ -437,6 +440,7 @@ describe('ReadThroughDataCache', function () {
           size: 99,
           sourceContentType: 'plain/text',
           verified: true,
+          trusted: true,
           cached: false,
         });
       });
@@ -505,6 +509,7 @@ describe('ReadThroughDataCache', function () {
         size: 50,
         sourceContentType: 'plain/text',
         verified: true,
+        trusted: true,
         cached: true,
         requestAttributes: {
           hops: requestAttributes.hops + 1,
@@ -545,6 +550,7 @@ describe('ReadThroughDataCache', function () {
           size: 50,
           sourceContentType: 'plain/text',
           verified: true,
+          trusted: true,
           cached: false,
         });
       });

--- a/src/data/s3-data-source.ts
+++ b/src/data/s3-data-source.ts
@@ -158,6 +158,7 @@ export class S3DataSource implements ContiguousDataSource {
         stream,
         size: response.ContentLength,
         verified: false,
+        trusted: true, // we only cache trusted data
         sourceContentType,
         cached: false,
         requestAttributes: requestAttributesHeaders?.attributes,

--- a/src/data/tx-chunks-data-source.ts
+++ b/src/data/tx-chunks-data-source.ts
@@ -138,6 +138,7 @@ export class TxChunksDataSource implements ContiguousDataSource {
       await chunkDataPromise;
 
       if (region) {
+        // TODO: seek to chunks by offset instead of streaming all the chunks
         const byteRangeStream = new ByteRangeTransform(
           region.offset,
           region.size,
@@ -146,6 +147,7 @@ export class TxChunksDataSource implements ContiguousDataSource {
           stream: stream.pipe(byteRangeStream),
           size: region.size,
           verified: true,
+          trusted: true,
           cached: false,
           requestAttributes:
             generateRequestAttributes(requestAttributes)?.attributes,
@@ -156,6 +158,7 @@ export class TxChunksDataSource implements ContiguousDataSource {
         stream,
         size,
         verified: true,
+        trusted: true,
         cached: false,
         requestAttributes:
           generateRequestAttributes(requestAttributes)?.attributes,

--- a/src/routes/data/handlers.ts
+++ b/src/routes/data/handlers.ts
@@ -54,6 +54,8 @@ const setDigestStableVerifiedHeaders = ({
     res.setHeader(headerNames.stable, dataAttributes.stable ? 'true' : 'false');
     res.setHeader(
       headerNames.verified,
+      // NOTE: even if the DB indicates the data is verified, we can't be sure
+      // we're streaming the right data unless it comes from our local cache
       dataAttributes.verified && data.cached ? 'true' : 'false',
     );
 
@@ -73,7 +75,7 @@ const setDataHeaders = ({
   dataAttributes: ContiguousDataAttributes | undefined;
   data: ContiguousData;
 }) => {
-  // TODO cached header for zero length data (maybe...)
+  // TODO: cached header for zero length data (maybe...)
 
   // Allow range requests
   res.header('Accept-Ranges', 'bytes');

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -538,6 +538,7 @@ export interface ContiguousData {
   stream: Readable;
   size: number;
   verified: boolean;
+  trusted: boolean;
   sourceContentType?: string;
   cached: boolean;
   requestAttributes?: RequestAttributes;


### PR DESCRIPTION
Add a trusted flag to ContiguousData to distinguish between data from trusted sources (trusted nodes, S3, locally verified) and untrusted sources (AR.IO peers). Only cache data marked as trusted to prevent cache poisoning attacks.