### PR TITLE
feat: configurable Docker Compose host ports via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,6 @@
 # CLICKHOUSE_PORT_2=8123
 # CLICKHOUSE_PORT_3=8443
 # OBSERVER_PORT=5050
-# REDIS_PORT=6379
 
 # Number from 0 to 1, representing the probability of a request failing
 # SIMULATED_REQUEST_FAILURE_RATE=0

--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,13 @@
 # LOG_FORMAT="simple"
 
 # AR.IO node exposed port number
-# PORT=4000
+# CORE_PORT=4000
+# ENVOY_PORT=3000
+# CLICKHOUSE_PORT=9000
+# CLICKHOUSE_PORT_2=8123
+# CLICKHOUSE_PORT_3=8443
+# OBSERVER_PORT=5050
+# REDIS_PORT=6379
 
 # Number from 0 to 1, representing the probability of a request failing
 # SIMULATED_REQUEST_FAILURE_RATE=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added configurable Docker Compose host port environment variables
+  (`CORE_PORT`, `ENVOY_PORT`, `CLICKHOUSE_PORT`, `CLICKHOUSE_PORT_2`,
+  `CLICKHOUSE_PORT_3`, `OBSERVER_PORT`) to allow flexible port mapping while
+  maintaining container-internal port compatibility and security.
+
 ## [Release 38] - 2025-06-09
 
 This release focuses on data integrity and security improvements, introducing

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,7 +42,6 @@ services:
       - ${LMDB_DATA_PATH:-./data/lmdb}:/app/data/lmdb
       - ${PARQUET_DATA_PATH:-./data/parquet}:/app/data/parquet
     environment:
-      - PORT=${CORE_PORT:-4000}
       - NODE_ENV=${NODE_ENV:-production}
       - LOG_LEVEL=${CORE_LOG_LEVEL:-info}
       - LOG_FORMAT=${CORE_LOG_FORMAT:-simple}
@@ -163,7 +162,7 @@ services:
     command: redis-server --maxmemory ${REDIS_MAX_MEMORY:-256mb} --maxmemory-policy allkeys-lru ${EXTRA_REDIS_FLAGS:---save "" --appendonly no}
     restart: unless-stopped
     ports:
-      - '${REDIS_PORT:-6379}:6379' # don't expose redis externally by default
+      - '6379' # don't expose redis externally by default
     volumes:
       - ${REDIS_DATA_PATH:-./data/redis}:/data
     networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,14 +6,14 @@ services:
       context: envoy/
     restart: unless-stopped
     ports:
-      - '3000:3000'
+      - '${ENVOY_PORT:-3000}:3000'
       #- '9901:9901' # don't expose admin port by default
     environment:
       - LOG_LEVEL=${ENVOY_LOG_LEVEL:-info}
       - TVAL_AR_IO_HOST=core
-      - TVAL_AR_IO_PORT=4000
+      - TVAL_AR_IO_PORT=${CORE_PORT:-4000}
       - TVAL_OBSERVER_HOST=observer
-      - TVAL_OBSERVER_PORT=5050
+      - TVAL_OBSERVER_PORT=${OBSERVER_PORT:-5050}
       - TVAL_TRUSTED_NODE_HOST=${TRUSTED_NODE_HOST:-arweave.net}
       - TVAL_TRUSTED_NODE_PORT=${TRUSTED_NODE_PORT:-443}
       - TVAL_GRAPHQL_HOST=${GRAPHQL_HOST:-core}
@@ -31,7 +31,7 @@ services:
       context: .
     restart: unless-stopped
     ports:
-      - 4000:4000
+      - ${CORE_PORT:-4000}:${CORE_PORT:-4000}
     volumes:
       - ${CHUNKS_DATA_PATH:-./data/chunks}:/app/data/chunks
       - ${CONTIGUOUS_DATA_PATH:-./data/contiguous}:/app/data/contiguous
@@ -42,6 +42,7 @@ services:
       - ${LMDB_DATA_PATH:-./data/lmdb}:/app/data/lmdb
       - ${PARQUET_DATA_PATH:-./data/parquet}:/app/data/parquet
     environment:
+      - PORT=${CORE_PORT:-4000}
       - NODE_ENV=${NODE_ENV:-production}
       - LOG_LEVEL=${CORE_LOG_LEVEL:-info}
       - LOG_FORMAT=${CORE_LOG_FORMAT:-simple}
@@ -162,7 +163,7 @@ services:
     command: redis-server --maxmemory ${REDIS_MAX_MEMORY:-256mb} --maxmemory-policy allkeys-lru ${EXTRA_REDIS_FLAGS:---save "" --appendonly no}
     restart: unless-stopped
     ports:
-      - '6379' # don't expose redis externally by default
+      - '${REDIS_PORT:-6379}:6379' # don't expose redis externally by default
     volumes:
       - ${REDIS_DATA_PATH:-./data/redis}:/data
     networks:
@@ -173,9 +174,9 @@ services:
     profiles:
       - clickhouse
     ports:
-      - 8123:8123
-      - 8443:8443
-      - 9000:9000
+      - ${CLICKHOUSE_PORT_2:-8123}:8123
+      - ${CLICKHOUSE_PORT_3:-8443}:8443
+      - ${CLICKHOUSE_PORT:-9000}:${CLICKHOUSE_PORT:-9000}
     ulimits:
       nofile:
         soft: 262144
@@ -184,6 +185,7 @@ services:
       - ${CLICKHOUSE_DATA_PATH:-./data/clickhouse}:/var/lib/clickhouse
       - ${CLICKHOUSE_LOGS_PATH:-./logs/clickhouse}:/var/log/clickhouse-server
     environment:
+      - CLICKHOUSE_PORT=${CLICKHOUSE_PORT:-9000}
       - CLICKHOUSE_USER=${CLICKHOUSE_USER:-}
       - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:-}
     networks:
@@ -202,7 +204,7 @@ services:
     environment:
       - DEBUG=${CLICKHOUSE_DEBUG:-}
       - AR_IO_HOST=core
-      - AR_IO_PORT=4000
+      - AR_IO_PORT=${CORE_PORT:-4000}
       - ADMIN_API_KEY=${ADMIN_API_KEY:-}
       - CLICKHOUSE_HOST=${CLICKHOUSE_HOST:-clickhouse} # defaults to localhost in scripts
       - CLICKHOUSE_PORT=${CLICKHOUSE_PORT:-} # defaults to 9000 in scripts
@@ -221,13 +223,13 @@ services:
     image: ghcr.io/ar-io/ar-io-observer:${OBSERVER_IMAGE_TAG:-6cb911e4ac9fd04a1795144f86b77ad0174ee6d9}
     restart: unless-stopped
     ports:
-      - 5050:5050
+      - ${OBSERVER_PORT:-5050}:${OBSERVER_PORT:-5050}
     volumes:
       - ${TEMP_DATA_PATH:-./data/tmp}:/app/data/tmp
       - ${REPORTS_DATA_PATH:-./data/reports}:/app/data/reports
       - ${WALLETS_PATH:-./wallets}:/app/wallets
     environment:
-      - PORT=5050
+      - PORT=${OBSERVER_PORT:-5050}
       - LOG_LEVEL=${OBSERVER_LOG_LEVEL:-}
       - OBSERVER_WALLET=${OBSERVER_WALLET:-}
       - IO_PROCESS_ID=${IO_PROCESS_ID:-}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -227,7 +227,6 @@ services:
       - ${REPORTS_DATA_PATH:-./data/reports}:/app/data/reports
       - ${WALLETS_PATH:-./wallets}:/app/wallets
     environment:
-      - PORT=${OBSERVER_PORT:-5050}
       - LOG_LEVEL=${OBSERVER_LOG_LEVEL:-}
       - OBSERVER_WALLET=${OBSERVER_WALLET:-}
       - IO_PROCESS_ID=${IO_PROCESS_ID:-}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
       context: .
     restart: unless-stopped
     ports:
-      - ${CORE_PORT:-4000}:${CORE_PORT:-4000}
+      - ${CORE_PORT:-4000}:4000
     volumes:
       - ${CHUNKS_DATA_PATH:-./data/chunks}:/app/data/chunks
       - ${CONTIGUOUS_DATA_PATH:-./data/contiguous}:/app/data/contiguous
@@ -176,7 +176,7 @@ services:
     ports:
       - ${CLICKHOUSE_PORT_2:-8123}:8123
       - ${CLICKHOUSE_PORT_3:-8443}:8443
-      - ${CLICKHOUSE_PORT:-9000}:${CLICKHOUSE_PORT:-9000}
+      - ${CLICKHOUSE_PORT:-9000}:9000
     ulimits:
       nofile:
         soft: 262144
@@ -185,7 +185,6 @@ services:
       - ${CLICKHOUSE_DATA_PATH:-./data/clickhouse}:/var/lib/clickhouse
       - ${CLICKHOUSE_LOGS_PATH:-./logs/clickhouse}:/var/log/clickhouse-server
     environment:
-      - CLICKHOUSE_PORT=${CLICKHOUSE_PORT:-9000}
       - CLICKHOUSE_USER=${CLICKHOUSE_USER:-}
       - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:-}
     networks:
@@ -223,7 +222,7 @@ services:
     image: ghcr.io/ar-io/ar-io-observer:${OBSERVER_IMAGE_TAG:-6cb911e4ac9fd04a1795144f86b77ad0174ee6d9}
     restart: unless-stopped
     ports:
-      - ${OBSERVER_PORT:-5050}:${OBSERVER_PORT:-5050}
+      - ${OBSERVER_PORT:-5050}:5050
     volumes:
       - ${TEMP_DATA_PATH:-./data/tmp}:/app/data/tmp
       - ${REPORTS_DATA_PATH:-./data/reports}:/app/data/reports


### PR DESCRIPTION
## Summary
- Enable flexible host port configuration for Docker Compose services via environment variables
- Maintain backward compatibility with sensible defaults
- Preserve container-internal ports and Redis security

## Changes
- Add configurable host port variables to `.env.example` for core, envoy, clickhouse, and observer services
- Update `docker-compose.yaml` to use environment variables for host port mappings
- Keep container-internal ports static to maintain service compatibility
- Preserve Redis security by not exposing it to the host

## Environment Variables Added
- `CORE_PORT=4000` - Host port for AR.IO node service
- `ENVOY_PORT=3000` - Host port for Envoy proxy
- `CLICKHOUSE_PORT=9000` - Host port for ClickHouse native interface
- `CLICKHOUSE_PORT_2=8123` - Host port for ClickHouse HTTP interface
- `CLICKHOUSE_PORT_3=8443` - Host port for ClickHouse HTTPS interface
- `OBSERVER_PORT=5050` - Host port for Observer service

## Notes
Based on original work by @pierreneter in #394, with fixes for:
- Container port compatibility (keeping internal ports static)
- Redis security (not exposing to host)
- Removal of redundant environment variables

Addresses Jira ticket PE-8160.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>