### PR TITLE
feat: add bypassDataItemFilter flag and convert to object parameters (PE-8173)

### DIFF
--- a/src/lib/ans-104.ts
+++ b/src/lib/ans-104.ts
@@ -281,11 +281,13 @@ export class Ans104Parser {
     parentId,
     parentIndex,
     rootParentOffset,
+    bypassDataItemFilter = false,
   }: {
     rootTxId: string;
     parentId: string;
     parentIndex: number;
     rootParentOffset: number;
+    bypassDataItemFilter?: boolean;
   }): Promise<void> {
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
@@ -347,6 +349,7 @@ export class Ans104Parser {
                 parentIndex,
                 bundlePath,
                 rootParentOffset,
+                bypassDataItemFilter,
               },
             });
             this.drainQueue();
@@ -421,8 +424,14 @@ if (!isMainThread) {
       process.exit(0);
     }
 
-    const { rootTxId, parentId, parentIndex, bundlePath, rootParentOffset } =
-      message;
+    const {
+      rootTxId,
+      parentId,
+      parentIndex,
+      bundlePath,
+      rootParentOffset,
+      bypassDataItemFilter = false,
+    } = message;
     let stream: fs.ReadStream | undefined = undefined;
     try {
       stream = fs.createReadStream(bundlePath);
@@ -478,7 +487,7 @@ if (!isMainThread) {
           rootParentOffset,
         });
 
-        if (await filter.match(normalizedDataItem)) {
+        if (bypassDataItemFilter || (await filter.match(normalizedDataItem))) {
           matchedItemCount++;
           parentPort?.postMessage({
             eventName: DATA_ITEM_MATCHED,

--- a/src/system.ts
+++ b/src/system.ts
@@ -611,11 +611,19 @@ export type QueueBundleResponse = {
   status: 'skipped' | 'queued' | 'error';
   error?: string;
 };
-export async function queueBundle(
-  item: NormalizedDataItem | PartialJsonTransaction,
-  isPrioritized = false,
-  bypassFilter = false,
-): Promise<QueueBundleResponse> {
+export interface QueueBundleOptions {
+  item: NormalizedDataItem | PartialJsonTransaction;
+  prioritized?: boolean;
+  bypassBundleFilter?: boolean;
+  bypassDataItemFilter?: boolean;
+}
+
+export async function queueBundle({
+  item,
+  prioritized = false,
+  bypassBundleFilter = false,
+  bypassDataItemFilter = false,
+}: QueueBundleOptions): Promise<QueueBundleResponse> {
   try {
     if ('root_tx_id' in item && item.root_tx_id === null) {
       log.debug('Skipping download of optimistically indexed data item', {
@@ -632,7 +640,10 @@ export async function queueBundle(
       format: 'ans-104',
     });
 
-    if (bypassFilter || (await config.ANS104_UNBUNDLE_FILTER.match(item))) {
+    if (
+      bypassBundleFilter ||
+      (await config.ANS104_UNBUNDLE_FILTER.match(item))
+    ) {
       metrics.bundlesMatchedCounter.inc({ bundle_format: 'ans-104' });
       const {
         unbundleFilterId,
@@ -662,17 +673,18 @@ export async function queueBundle(
         return { status: 'skipped' };
       }
 
-      bundleDataImporter.queueItem(
-        {
+      bundleDataImporter.queueItem({
+        item: {
           ...item,
           index:
             'parent_index' in item && item.parent_index !== undefined
               ? item.parent_index
               : -1, // parent indexes are not needed for L1
         },
-        isPrioritized,
-        bypassFilter,
-      );
+        prioritized,
+        bypassBundleFilter,
+        bypassDataItemFilter,
+      });
       metrics.bundlesQueuedCounter.inc({ bundle_format: 'ans-104' });
     } else {
       await db.saveBundle({
@@ -701,7 +713,7 @@ eventEmitter.on(
     const isPrioritized = prioritizedTxIds.has(item.id);
     prioritizedTxIds.delete(item.id);
 
-    await queueBundle(item, isPrioritized);
+    await queueBundle({ item, prioritized: isPrioritized });
   },
 );
 
@@ -709,7 +721,7 @@ eventEmitter.on(
 eventEmitter.on(
   events.ANS104_NESTED_BUNDLE_INDEXED,
   async (item: NormalizedDataItem | PartialJsonTransaction) => {
-    await queueBundle(item, true);
+    await queueBundle({ item, prioritized: true });
   },
 );
 

--- a/src/workers/ans104-unbundler.test.ts
+++ b/src/workers/ans104-unbundler.test.ts
@@ -68,7 +68,7 @@ describe('Ans104Unbundler', () => {
       shouldUnbundleMock.mock.mockImplementation(() => false);
 
       for (let i = 0; i < 10; i++) {
-        ans104Unbundler.queueItem(mockItem, false);
+        ans104Unbundler.queueItem({ item: mockItem, prioritized: false });
       }
 
       assert.equal(shouldUnbundleMock.mock.calls.length, 10);
@@ -77,7 +77,7 @@ describe('Ans104Unbundler', () => {
 
     it('should queue item when shouldUnbundle returns true', async () => {
       for (let i = 0; i < 10; i++) {
-        ans104Unbundler.queueItem(mockItem, false);
+        ans104Unbundler.queueItem({ item: mockItem, prioritized: false });
       }
 
       assert.equal(shouldUnbundleMock.mock.calls.length, 10);
@@ -88,7 +88,7 @@ describe('Ans104Unbundler', () => {
       shouldUnbundleMock.mock.mockImplementation(() => false);
 
       for (let i = 0; i < 10; i++) {
-        ans104Unbundler.queueItem(mockItem, true);
+        ans104Unbundler.queueItem({ item: mockItem, prioritized: true });
       }
 
       assert.equal(shouldUnbundleMock.mock.calls.length, 10);
@@ -99,7 +99,7 @@ describe('Ans104Unbundler', () => {
       ans104Unbundler['workerCount'] = 0;
 
       for (let i = 0; i < 10; i++) {
-        ans104Unbundler.queueItem(mockItem, false);
+        ans104Unbundler.queueItem({ item: mockItem, prioritized: false });
       }
 
       assert.equal(shouldUnbundleMock.mock.calls.length, 0);
@@ -115,7 +115,11 @@ describe('Ans104Unbundler', () => {
         root_tx_id: 'root_tx_id',
       } as UnbundleableItem;
 
-      await ans104Unbundler.queueItem(mockItem, false, true);
+      await ans104Unbundler.queueItem({
+        item: mockItem,
+        prioritized: false,
+        bypassBundleFilter: true,
+      });
 
       assert.deepEqual(
         (mockAns104Parser.parseBundle as any).mock.calls[0].arguments[0],
@@ -124,6 +128,7 @@ describe('Ans104Unbundler', () => {
           parentIndex: undefined,
           rootParentOffset: 0,
           rootTxId: 'root_tx_id',
+          bypassDataItemFilter: false,
         },
       );
     });

--- a/src/workers/data-importer.test.ts
+++ b/src/workers/data-importer.test.ts
@@ -31,7 +31,12 @@ import { ContiguousDataSource } from '../types.js';
 import { DataImporter } from './data-importer.js';
 
 class Ans104UnbundlerStub {
-  async queueItem(): Promise<void> {
+  async queueItem(_options: {
+    item: any;
+    prioritized?: boolean;
+    bypassBundleFilter?: boolean;
+    bypassDataItemFilter?: boolean;
+  }): Promise<void> {
     return;
   }
 
@@ -100,7 +105,10 @@ describe('DataImporter', () => {
     it('should queue a non-prioritized item if queue is not full', async () => {
       mock.method(contiguousDataSource, 'getData');
 
-      await bundleDataImporter.queueItem(mockItem, false);
+      await bundleDataImporter.queueItem({
+        item: mockItem,
+        prioritized: false,
+      });
 
       assert.deepEqual(
         (contiguousDataSource.getData as any).mock.calls[0].arguments[0],
@@ -111,7 +119,10 @@ describe('DataImporter', () => {
     it('should not queue a non-prioritized item if queue is full', async () => {
       mock.method(contiguousDataSource, 'getData');
 
-      await bundleDataImporterWithFullQueue.queueItem(mockItem, false);
+      await bundleDataImporterWithFullQueue.queueItem({
+        item: mockItem,
+        prioritized: false,
+      });
 
       assert.equal((contiguousDataSource.getData as any).mock.callCount(), 0);
     });
@@ -119,7 +130,7 @@ describe('DataImporter', () => {
     it('should queue a prioritized item if the queue is not full', async () => {
       mock.method(contiguousDataSource, 'getData');
 
-      await bundleDataImporter.queueItem(mockItem, true);
+      await bundleDataImporter.queueItem({ item: mockItem, prioritized: true });
 
       assert.deepEqual(
         (contiguousDataSource.getData as any).mock.calls[0].arguments[0],
@@ -130,7 +141,10 @@ describe('DataImporter', () => {
     it('should queue a prioritized item if the queue is full', async () => {
       mock.method(contiguousDataSource, 'getData');
 
-      await bundleDataImporterWithFullQueue.queueItem(mockItem, true);
+      await bundleDataImporterWithFullQueue.queueItem({
+        item: mockItem,
+        prioritized: true,
+      });
 
       assert.deepEqual(
         (contiguousDataSource.getData as any).mock.calls[0].arguments[0],
@@ -153,12 +167,20 @@ describe('DataImporter', () => {
       await bundleDataImporter.download({
         item: mockItem,
         prioritized: true,
-        bypassFilter: false,
+        bypassBundleFilter: false,
+        bypassDataItemFilter: false,
       });
 
       assert.deepEqual(
         (ans104Unbundler.queueItem as any).mock.calls[0].arguments,
-        [mockItem, true, false],
+        [
+          {
+            item: mockItem,
+            prioritized: true,
+            bypassBundleFilter: false,
+            bypassDataItemFilter: false,
+          },
+        ],
       );
     });
 


### PR DESCRIPTION
## Summary
Add bypassDataItemFilter flag and convert function parameters to object-based pattern for better maintainability and extensibility.

## Changes
- Added `bypassDataItemFilter` parameter to bypass data item filtering during bundle processing
- Converted multiple function signatures from positional parameters to object-based parameters
- Maintained backward compatibility for legacy `bypassFilter` parameter in API endpoint
- Updated all related tests to use new object parameter pattern

## Test plan
- [x] All existing tests pass
- [x] New parameter functionality tested
- [x] Backward compatibility maintained for API endpoints
- [x] Object parameter pattern applied consistently across codebase

🤖 Generated with [Claude Code](https://claude.ai/code)