### PR TITLE
Allow SQL comments in yesql files

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
     "umzug": "^3.8.2",
     "wait": "^0.4.2",
     "winston": "^3.17.0",
-    "yaml": "^2.7.0",
-    "yesql": "^7.0.0"
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
     "@aws-lite/s3-types": "^0.2.6",

--- a/src/database/sql-loader.test.ts
+++ b/src/database/sql-loader.test.ts
@@ -1,0 +1,440 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { parseSqlStatements } from './sql-loader.js';
+
+describe('parseSqlStatements', () => {
+  it('should parse a single statement', () => {
+    const content = `-- selectAll
+SELECT * FROM users;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      selectAll: 'SELECT * FROM users;',
+    });
+  });
+
+  it('should parse multiple statements separated by blank lines', () => {
+    const content = `-- selectAll
+SELECT * FROM users;
+
+-- updateUser
+UPDATE users SET name = ? WHERE id = ?;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      selectAll: 'SELECT * FROM users;',
+      updateUser: 'UPDATE users SET name = ? WHERE id = ?;',
+    });
+  });
+
+  it('should handle statements at the start of file without blank line', () => {
+    const content = `-- firstStatement
+SELECT 1;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      firstStatement: 'SELECT 1;',
+    });
+  });
+
+  it('should strip inline comments within statements', () => {
+    const content = `-- selectWithComments
+SELECT id, -- user identifier
+  name, -- user full name
+  email
+FROM users;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      selectWithComments: `SELECT id,
+  name,
+  email
+FROM users;`,
+    });
+  });
+
+  it('should skip lines starting with block comments', () => {
+    const content = `-- selectWithBlockComment
+SELECT id,
+  /* this is a
+     multi-line comment */
+  name
+FROM users;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      selectWithBlockComment: `SELECT id,
+  name
+FROM users;`,
+    });
+  });
+
+  it('should handle block comments spanning multiple lines', () => {
+    const content = `-- complexQuery
+SELECT 
+  /*
+   * This is a big comment
+   * that spans multiple lines
+   */
+  id, name
+FROM users;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      complexQuery: `SELECT
+  id, name
+FROM users;`,
+    });
+  });
+
+  it('should require blank line before statement names', () => {
+    const content = `-- firstStatement
+SELECT 1;
+-- notAStatement
+This should be part of firstStatement;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      firstStatement: `SELECT 1;
+This should be part of firstStatement;`,
+    });
+  });
+
+  it('should handle Windows-style line endings', () => {
+    const content = `-- statement1\r\nSELECT 1;\r\n\r\n-- statement2\r\nSELECT 2;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      statement1: 'SELECT 1;',
+      statement2: 'SELECT 2;',
+    });
+  });
+
+  it('should trim whitespace from statement names', () => {
+    const content = `--   statementWithSpaces   
+SELECT 1;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      statementWithSpaces: 'SELECT 1;',
+    });
+  });
+
+  it('should handle empty statements', () => {
+    const content = `-- emptyStatement
+
+-- nextStatement
+SELECT 1;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      emptyStatement: '',
+      nextStatement: 'SELECT 1;',
+    });
+  });
+
+  it('should handle statements with only whitespace', () => {
+    const content = `-- whitespaceOnly
+   
+   
+-- nextStatement
+SELECT 1;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      whitespaceOnly: '',
+      nextStatement: 'SELECT 1;',
+    });
+  });
+
+  it('should parse complex SQL with multiple comment types', () => {
+    const content = `-- createTable
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY, -- primary key
+  name TEXT NOT NULL, -- user name
+  /* email field with unique constraint */
+  email TEXT UNIQUE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- insertUser
+INSERT INTO users (name, email) 
+VALUES (?, ?); -- bind parameters
+
+-- selectActiveUsers
+SELECT 
+  id,
+  name,
+  email
+FROM users
+WHERE 
+  /* Check if user is active based on:
+     1. Not deleted
+     2. Verified email
+  */
+  deleted_at IS NULL
+  AND email_verified = true
+ORDER BY created_at DESC;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      createTable: `CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT UNIQUE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);`,
+      insertUser: `INSERT INTO users (name, email)
+VALUES (?, ?);`,
+      selectActiveUsers: `SELECT
+  id,
+  name,
+  email
+FROM users
+WHERE
+  deleted_at IS NULL
+  AND email_verified = true
+ORDER BY created_at DESC;`,
+    });
+  });
+
+  it('should handle block comments that close on same line', () => {
+    const content = `-- queryWithInlineBlock
+SELECT /* inline comment */ id FROM users;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      queryWithInlineBlock: 'SELECT  id FROM users;',
+    });
+  });
+
+  it('should not parse content before first statement', () => {
+    const content = `This is some header text
+that should be ignored
+
+-- firstStatement
+SELECT 1;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      firstStatement: 'SELECT 1;',
+    });
+  });
+
+  it('should handle statement names with special characters', () => {
+    const content = `-- select-with-dashes
+SELECT 1;
+
+-- select_with_underscores
+SELECT 2;
+
+-- selectWithNumbers123
+SELECT 3;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      'select-with-dashes': 'SELECT 1;',
+      select_with_underscores: 'SELECT 2;',
+      selectWithNumbers123: 'SELECT 3;',
+    });
+  });
+
+  it('should handle consecutive blank lines between statements', () => {
+    const content = `-- statement1
+SELECT 1;
+
+
+
+-- statement2
+SELECT 2;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      statement1: 'SELECT 1;',
+      statement2: 'SELECT 2;',
+    });
+  });
+
+  it('should handle tabs and mixed whitespace', () => {
+    const content = `-- statement1
+SELECT\t1;
+
+\t\t
+-- statement2
+SELECT 2;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      statement1: 'SELECT\t1;',
+      statement2: 'SELECT 2;',
+    });
+  });
+
+  it('should handle empty input', () => {
+    const result = parseSqlStatements('');
+    assert.deepStrictEqual(result, {});
+  });
+
+  it('should handle input with only comments', () => {
+    const content = `-- This is just a comment
+-- Another comment`;
+
+    const result = parseSqlStatements(content);
+    assert.deepStrictEqual(result, {
+      'This is just a comment': '',
+    });
+  });
+
+  it('should preserve indentation within statements', () => {
+    const content = `-- formattedQuery
+SELECT 
+    id,
+    name,
+    email
+FROM 
+    users
+WHERE 
+    active = true;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      formattedQuery: `SELECT
+    id,
+    name,
+    email
+FROM
+    users
+WHERE
+    active = true;`,
+    });
+  });
+
+  it('should handle block comments with */ in string literals correctly', () => {
+    const content = `-- queryWithTrickyComment
+SELECT '/* this is not a comment */' as text
+/* but this is */
+FROM dual;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      queryWithTrickyComment: `SELECT '/* this is not a comment */' as text
+FROM dual;`,
+    });
+  });
+
+  it('should handle SQL with -- in string literals', () => {
+    const content = `-- queryWithDashesInString
+SELECT '-- this is not a comment' as text
+FROM dual;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      queryWithDashesInString: `SELECT '-- this is not a comment' as text
+FROM dual;`,
+    });
+  });
+
+  it('should strip trailing whitespace from statements', () => {
+    const content = `-- statementWithTrailing
+SELECT 1;   \t   
+
+-- nextStatement
+SELECT 2;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      statementWithTrailing: 'SELECT 1;',
+      nextStatement: 'SELECT 2;',
+    });
+  });
+
+  it('should handle CodeRabbit edge case: inline block comment with SQL after', () => {
+    const content = `-- hintQuery
+/* hint */ SELECT 1;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      hintQuery: 'SELECT 1;',
+    });
+  });
+
+  it('should prevent SQL preparation errors by stripping problematic comments', () => {
+    const content = `-- problematicQuery
+SELECT * FROM foo -- tenant filter
+WHERE id = 1; -- another comment`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      problematicQuery: `SELECT * FROM foo
+WHERE id = 1;`,
+    });
+  });
+
+  it('should handle escaped quotes in string literals correctly', () => {
+    const content = `-- queryWithEscapedQuotes
+SELECT 'This is a \\'comment\\' -- not really' as text
+FROM dual;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      queryWithEscapedQuotes: `SELECT 'This is a \\'comment\\' -- not really' as text
+FROM dual;`,
+    });
+  });
+
+  it('should handle nested comment-like sequences', () => {
+    const content = `-- nestedComments
+SELECT '/* not a comment */' as text1, -- this is a comment
+       '-- also not a comment' as text2 /* this is a comment */
+FROM dual;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      nestedComments: `SELECT '/* not a comment */' as text1,
+       '-- also not a comment' as text2
+FROM dual;`,
+    });
+  });
+
+  it('should handle multiple inline block comments on same line', () => {
+    const content = `-- multipleBlockComments
+SELECT /* comment1 */ id, /* comment2 */ name /* comment3 */ FROM users;`;
+
+    const result = parseSqlStatements(content);
+
+    assert.deepStrictEqual(result, {
+      multipleBlockComments: 'SELECT  id,  name  FROM users;',
+    });
+  });
+});

--- a/src/database/sql-loader.ts
+++ b/src/database/sql-loader.ts
@@ -1,0 +1,202 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Strip comments from a SQL line while preserving content inside string literals.
+ * Handles both inline -- comments and block comments.
+ */
+function stripCommentsFromLine(line: string): {
+  cleanedLine: string;
+  inBlockComment: boolean;
+  blockCommentEnd: boolean;
+} {
+  let result = '';
+  let inString = false;
+  let stringChar = '';
+  let inBlockComment = false;
+  let blockCommentEnd = false;
+  let i = 0;
+
+  while (i < line.length) {
+    const char = line[i];
+    const nextChar = i + 1 < line.length ? line[i + 1] : '';
+
+    // Handle string literals (single or double quotes)
+    if (!inBlockComment && (char === '"' || char === "'")) {
+      if (!inString) {
+        inString = true;
+        stringChar = char;
+        result += char;
+      } else if (char === stringChar) {
+        // Check for escaped quotes
+        if (i > 0 && line[i - 1] === '\\') {
+          result += char;
+        } else {
+          inString = false;
+          stringChar = '';
+          result += char;
+        }
+      } else {
+        result += char;
+      }
+      i++;
+      continue;
+    }
+
+    // If we're inside a string literal, preserve everything
+    if (inString) {
+      result += char;
+      i++;
+      continue;
+    }
+
+    // Handle block comment start
+    if (!inBlockComment && char === '/' && nextChar === '*') {
+      inBlockComment = true;
+      i += 2;
+      continue;
+    }
+
+    // Handle block comment end
+    if (inBlockComment && char === '*' && nextChar === '/') {
+      inBlockComment = false;
+      blockCommentEnd = true;
+      i += 2;
+      continue;
+    }
+
+    // If we're inside a block comment, skip everything
+    if (inBlockComment) {
+      i++;
+      continue;
+    }
+
+    // Handle line comment start
+    if (char === '-' && nextChar === '-') {
+      // Rest of the line is a comment, break here
+      break;
+    }
+
+    // Regular character, add to result
+    result += char;
+    i++;
+  }
+
+  return {
+    cleanedLine: result.trimEnd(),
+    inBlockComment,
+    blockCommentEnd,
+  };
+}
+
+/**
+ * Parse SQL content into named statements. Statement names must appear on their
+ * own line prefixed with `--` and be separated from the previous statement by
+ * at least one blank line or the start of the file. Any other `--` comments or
+ * block comments are stripped from the statement before it is returned.
+ *
+ * @param content - SQL file content to parse
+ * @returns Record mapping statement names to SQL statements
+ */
+export function parseSqlStatements(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  const lines = content.replace(/\r\n/g, '\n').split('\n');
+
+  let name: string | null = null;
+  let buf: string[] = [];
+  let inBlockComment = false;
+
+  const push = () => {
+    if (name != null) {
+      result[name] = buf.join('\n').trim();
+      name = null;
+      buf = [];
+    }
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    // Handle statement names (-- at start of line after blank line)
+    if (!inBlockComment && trimmed.startsWith('--')) {
+      const prevBlank = i === 0 || lines[i - 1].trim() === '';
+      if (prevBlank) {
+        push();
+        name = trimmed.slice(2).trim();
+        continue;
+      }
+    }
+
+    // Skip lines that start with block comments only if we're not already in one
+    if (
+      !inBlockComment &&
+      trimmed.startsWith('/*') &&
+      !trimmed.includes('*/')
+    ) {
+      inBlockComment = true;
+      continue;
+    }
+
+    // If we're in a block comment spanning multiple lines
+    if (inBlockComment) {
+      if (line.includes('*/')) {
+        inBlockComment = false;
+        // Check if there's content after the block comment end
+        const afterComment = line.substring(line.indexOf('*/') + 2);
+        const { cleanedLine } = stripCommentsFromLine(afterComment);
+        if (name != null && cleanedLine.trim()) {
+          buf.push(cleanedLine);
+        }
+      }
+      continue;
+    }
+
+    // Process the line if we have a statement name
+    if (name != null) {
+      const { cleanedLine, inBlockComment: lineStartsBlock } =
+        stripCommentsFromLine(line);
+
+      if (lineStartsBlock) {
+        inBlockComment = true;
+      }
+
+      // Only add non-empty lines or preserve empty lines for formatting
+      if (cleanedLine || line.trim() === '') {
+        buf.push(cleanedLine);
+      }
+    }
+  }
+
+  push();
+  return result;
+}
+
+/**
+ * Load SQL statements from a directory while allowing comments within the
+ * statements. Statement names must appear on their own line prefixed with
+ * `--` and be separated from the previous statement by at least one blank line
+ * or the start of the file. Any other `--` comments or block comments are
+ * stripped from the statement before it is returned.
+ */
+export default function loadSql(dir: string): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.sql'));
+
+  for (const file of files) {
+    const full = path.resolve(dir, file);
+    const content = fs.readFileSync(full, 'utf8');
+    const statements = parseSqlStatements(content);
+
+    Object.assign(result, statements);
+  }
+
+  return result;
+}

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -24,7 +24,7 @@ import NodeCache from 'node-cache';
 /* eslint-disable */
 // @ts-ignore
 // TODO sort out types
-import { default as yesql } from 'yesql';
+import loadSql from './sql-loader.js';
 
 import { MAX_FORK_DEPTH } from '../arweave/constants.js';
 import {
@@ -469,7 +469,7 @@ export class StandaloneSqliteDatabaseWorker {
 
     for (const [stmtsKey, stmts] of Object.entries(this.stmts)) {
       const sqlUrl = new URL(`./sql/${stmtsKey}`, import.meta.url);
-      const coreSql = yesql(sqlUrl.pathname) as { [key: string]: string };
+      const coreSql = loadSql(sqlUrl.pathname);
       for (const [k, sql] of Object.entries(coreSql)) {
         // Skip the key containing the complete file
         if (!k.endsWith('.sql')) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10395,11 +10395,6 @@ yargs@^17.7.2:
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
 
-yesql@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/yesql/-/yesql-7.0.0.tgz"
-  integrity sha512-sosfr7agy4ibLM7BvXBkM6BpBmKMGuBO8DUYQEuey+QqaqrgW+2bsSg6D050ocBYIz0PuHxUyehyzEztZTU4pw==
-
 yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz"


### PR DESCRIPTION
## Summary
- add `loadSql` helper to strip inline SQL comments
- use the helper when loading SQL statements

## Testing
- `yarn test` *(fails: 5 failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_6841a6ae22888324b8fc14aa291bbbc9