### PR TITLE
feat(data): add hash validation for peer data fetching PE-8238

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,7 @@ export const headerNames = {
   origin: 'X-AR-IO-Origin',
   originNodeRelease: 'X-AR-IO-Origin-Node-Release',
   digest: 'X-AR-IO-Digest',
+  expectedDigest: 'X-AR-IO-Expected-Digest',
   stable: 'X-AR-IO-Stable',
   verified: 'X-AR-IO-Verified',
   trusted: 'X-AR-IO-Trusted',

--- a/src/data/ar-io-data-source.test.ts
+++ b/src/data/ar-io-data-source.test.ts
@@ -430,11 +430,14 @@ describe('ArIODataSource', () => {
       it('should accept data when peer digest matches expected hash', async () => {
         const expectedHash = 'test-hash-123';
         const streamData = Readable.from(['valid data']);
-        
+
         mock.method(axios, 'get', async (url, config) => {
           // Verify expected digest header is sent
-          assert.equal(config.headers[headerNames.expectedDigest], expectedHash);
-          
+          assert.equal(
+            config.headers[headerNames.expectedDigest],
+            expectedHash,
+          );
+
           return {
             status: 200,
             data: streamData,
@@ -449,7 +452,7 @@ describe('ArIODataSource', () => {
 
         const data = await dataSource.getData({
           id: 'dataId',
-          dataAttributes: { 
+          dataAttributes: {
             hash: expectedHash,
             size: 10,
             isManifest: false,
@@ -479,7 +482,7 @@ describe('ArIODataSource', () => {
         const expectedHash = 'expected-hash-123';
         const wrongHash = 'wrong-hash-456';
         const streamData = Readable.from(['invalid data']);
-        
+
         mock.method(axios, 'get', async () => ({
           status: 200,
           data: streamData,
@@ -511,18 +514,21 @@ describe('ArIODataSource', () => {
 
         // Verify the stream was destroyed
         assert.equal(streamData.destroyed, true);
-        
+
         // Verify error metrics were incremented
-        assert.equal((metrics.getDataErrorsTotal.inc as any).mock.callCount(), 2);
+        assert.equal(
+          (metrics.getDataErrorsTotal.inc as any).mock.callCount(),
+          2,
+        );
       });
 
       it('should not send expected digest header when no hash is provided', async () => {
         const streamData = Readable.from(['data without hash']);
-        
+
         mock.method(axios, 'get', async (url, config) => {
           // Verify expected digest header is NOT sent
           assert.equal(config.headers[headerNames.expectedDigest], undefined);
-          
+
           return {
             status: 200,
             data: streamData,
@@ -543,7 +549,7 @@ describe('ArIODataSource', () => {
       it('should accept data when peer does not provide digest header', async () => {
         const expectedHash = 'test-hash-123';
         const streamData = Readable.from(['data without digest']);
-        
+
         mock.method(axios, 'get', async () => ({
           status: 200,
           data: streamData,


### PR DESCRIPTION
## Summary
- Added hash validation when fetching data from ar.io network peers
- Prevents accidental propagation of data that doesn't match local hashes
- Maintains backward compatibility with peers that don't support digest headers

## Changes
- Added `X-AR-IO-Expected-Digest` header constant
- Updated `ArIODataSource` to send expected hash in request headers when available
- Added validation in `parseResponse()` to check peer's `X-AR-IO-Digest` against expected hash
- Added comprehensive unit tests for all hash validation scenarios

## Test Plan
- [x] All existing tests pass
- [x] Added unit tests for hash validation:
  - Test successful data fetch when hashes match
  - Test rejection when hashes don't match
  - Test behavior when no expected hash is provided
  - Test backward compatibility when peer doesn't provide digest header
- [x] Build succeeds (`yarn build`)
- [x] Lint passes (`yarn lint:check`)