### PR TITLE
feat: implement chunk data cache cleanup (PE-8304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added automatic chunk data cache cleanup functionality with configurable retention period. Chunks are now automatically removed after 4 hours by default (configurable via `CHUNK_DATA_CACHE_CLEANUP_THRESHOLD`). The cleanup can be disabled by setting `ENABLE_CHUNK_DATA_CACHE_CLEANUP=false`. This helps manage disk space usage while maintaining cache performance benefits.
+
 ### Changed
 
+- Simplified chunk data storage by removing the dual-storage approach (by-hash and by-dataroot with symlinks). Chunks are now stored directly by data root only, reducing complexity and improving performance.
 - Revamped chunk broadcasting architecture from 3-tier system to unified peer-based approach. Chunk broadcasting now uses individual fastq queues per peer with configurable concurrency and queue depth protection. Added support for preferred chunk POST peers via `PREFERRED_CHUNK_POST_URLS` environment variable. This change improves broadcast reliability and performance while simplifying the codebase by removing circuit breakers and tier-based logic.
 
 ## [Release 42] - 2025-07-14

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,8 @@ system.headerFsCacheCleanupWorker?.start();
 
 system.contiguousDataFsCacheCleanupWorker?.start();
 
+system.chunkDataFsCacheCleanupWorker?.start();
+
 // Allow starting without writers to support SQLite replication
 if (config.START_WRITERS) {
   system.blockImporter.start();

--- a/src/config.ts
+++ b/src/config.ts
@@ -615,6 +615,20 @@ export const ENABLE_FS_HEADER_CACHE_CLEANUP =
   env.varOrDefault('ENABLE_FS_HEADER_CACHE_CLEANUP', 'false') === 'true';
 
 //
+// Chunk data caching
+//
+
+// Whether or not to cleanup filesystem chunk cache files
+export const ENABLE_CHUNK_DATA_CACHE_CLEANUP =
+  env.varOrDefault('ENABLE_CHUNK_DATA_CACHE_CLEANUP', 'true') === 'true';
+
+// The threshold in seconds to cleanup the filesystem chunk data cache
+export const CHUNK_DATA_CACHE_CLEANUP_THRESHOLD = +env.varOrDefault(
+  'CHUNK_DATA_CACHE_CLEANUP_THRESHOLD',
+  `${60 * 60 * 4}`, // 4 hours by default
+);
+
+//
 // Contiguous data caching
 //
 

--- a/src/data/read-through-chunk-data-cache.test.ts
+++ b/src/data/read-through-chunk-data-cache.test.ts
@@ -94,12 +94,12 @@ describe('ReadThroughChunkDataCache', () => {
     });
 
     it('should fetch chunk data from network when not in local cache', async () => {
-      const chuunkDataStoreHasSpy = mock.method(
+      const chunkDataStoreGetSpy = mock.method(
         chunkDataStore,
-        'has',
-        async () => false,
+        'get',
+        async () => undefined,
       );
-      const chunkDataStoreGetSpy = mock.method(chunkDataStore, 'get');
+      const chunkDataStoreSetSpy = mock.method(chunkDataStore, 'set');
       const networkSpy = mock.method(
         chunkSource,
         'getChunkByAny',
@@ -112,29 +112,7 @@ describe('ReadThroughChunkDataCache', () => {
         relativeOffset: 0,
       });
       assert.deepEqual(chunkDataStoreGetSpy.mock.callCount(), 1);
-      assert.deepEqual(chuunkDataStoreHasSpy.mock.callCount(), 1);
-      assert.deepEqual(networkSpy.mock.callCount(), 1);
-    });
-
-    it('should fetch chunk data from network when an error occurs fetching from local cache', async () => {
-      const storeHasSpy = mock.method(chunkDataStore, 'has', async () => {
-        throw new Error('Error');
-      });
-      const storeGetSpy = mock.method(chunkDataStore, 'get');
-      const networkSpy = mock.method(
-        chunkSource,
-        'getChunkByAny',
-        async () => mockedChunk,
-      );
-      await chunkCache.getChunkDataByAny({
-        txSize: TX_SIZE,
-        absoluteOffset: ABSOLUTE_OFFSET,
-        dataRoot: B64_DATA_ROOT,
-        relativeOffset: 0,
-      });
-
-      assert.deepEqual(storeGetSpy.mock.callCount(), 1);
-      assert.deepEqual(storeHasSpy.mock.callCount(), 1);
+      assert.deepEqual(chunkDataStoreSetSpy.mock.callCount(), 1);
       assert.deepEqual(networkSpy.mock.callCount(), 1);
     });
   });

--- a/src/store/fs-chunk-data-store.test.ts
+++ b/src/store/fs-chunk-data-store.test.ts
@@ -1,0 +1,293 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
+import * as winston from 'winston';
+import crypto from 'node:crypto';
+
+import { FsChunkDataStore } from './fs-chunk-data-store.js';
+import { ChunkData } from '../types.js';
+
+describe('FsChunkDataStore', () => {
+  let log: winston.Logger;
+  let tempDir: string;
+  let store: FsChunkDataStore;
+
+  before(() => {
+    log = winston.createLogger({ silent: true });
+  });
+
+  beforeEach(() => {
+    // Create a temporary directory for each test
+    tempDir = mkdtempSync(join(tmpdir(), 'fs-chunk-data-store-test-'));
+    store = new FsChunkDataStore({ log, baseDir: tempDir });
+  });
+
+  afterEach(() => {
+    // Clean up the temporary directory
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('set', () => {
+    it('should save chunk data to the correct path', async () => {
+      const dataRoot = 'wRq6f05oRupfTW_M5dcYBtwK5P8rSNYu20vC6D_o-M4';
+      const relativeOffset = 0;
+      const chunkData: ChunkData = {
+        chunk: Buffer.from('test chunk data'),
+        hash: crypto.createHash('sha256').update('test chunk data').digest(),
+      };
+
+      await store.set(dataRoot, relativeOffset, chunkData);
+
+      // Verify the file was created at the expected path
+      const expectedPath = join(
+        tempDir,
+        'by-dataroot',
+        'wR',
+        'q6',
+        dataRoot,
+        relativeOffset.toString(),
+      );
+      const fs = await import('node:fs');
+      assert.ok(fs.existsSync(expectedPath));
+
+      // Verify the content
+      const savedContent = fs.readFileSync(expectedPath);
+      assert.deepEqual(savedContent, chunkData.chunk);
+    });
+
+    it('should create nested directory structure', async () => {
+      const dataRoot = '3nH8US975eWwHT-hG9HSdXFxH0FiMBBMHw6D_eBC7C0';
+      const relativeOffset = 1048576;
+      const chunkData: ChunkData = {
+        chunk: Buffer.from('another chunk'),
+        hash: crypto.createHash('sha256').update('another chunk').digest(),
+      };
+
+      await store.set(dataRoot, relativeOffset, chunkData);
+
+      // Verify directory structure
+      const fs = await import('node:fs');
+      assert.ok(fs.existsSync(join(tempDir, 'by-dataroot')));
+      assert.ok(fs.existsSync(join(tempDir, 'by-dataroot', '3n')));
+      assert.ok(fs.existsSync(join(tempDir, 'by-dataroot', '3n', 'H8')));
+      assert.ok(
+        fs.existsSync(join(tempDir, 'by-dataroot', '3n', 'H8', dataRoot)),
+      );
+    });
+
+    it('should handle multiple chunks for the same data root', async () => {
+      const dataRoot = 'kB-rvhmqrG0CNSEY7KLuje2EdQgbsBMeL9Ck1-fC2es';
+      const chunks = [
+        { offset: 0, data: Buffer.from('chunk 0') },
+        { offset: 262144, data: Buffer.from('chunk 1') },
+        { offset: 524288, data: Buffer.from('chunk 2') },
+      ];
+
+      for (const { offset, data } of chunks) {
+        const chunkData: ChunkData = {
+          chunk: data,
+          hash: crypto.createHash('sha256').update(data).digest(),
+        };
+        await store.set(dataRoot, offset, chunkData);
+      }
+
+      // Verify all chunks were saved
+      const fs = await import('node:fs');
+      for (const { offset } of chunks) {
+        const path = join(
+          tempDir,
+          'by-dataroot',
+          'kB',
+          '-r',
+          dataRoot,
+          offset.toString(),
+        );
+        assert.ok(fs.existsSync(path));
+      }
+    });
+
+    it('should overwrite existing chunk data', async () => {
+      const dataRoot = 'QUkmf47wCb77v7IG42spdNgJbmtPn_2DUfQtgpxRYvg';
+      const relativeOffset = 0;
+
+      const originalData: ChunkData = {
+        chunk: Buffer.from('original data'),
+        hash: crypto.createHash('sha256').update('original data').digest(),
+      };
+
+      const newData: ChunkData = {
+        chunk: Buffer.from('new data'),
+        hash: crypto.createHash('sha256').update('new data').digest(),
+      };
+
+      await store.set(dataRoot, relativeOffset, originalData);
+      await store.set(dataRoot, relativeOffset, newData);
+
+      // Verify the new data overwrote the original
+      const fs = await import('node:fs');
+      const path = join(tempDir, 'by-dataroot', 'QU', 'km', dataRoot, '0');
+      const savedContent = fs.readFileSync(path);
+      assert.deepEqual(savedContent, newData.chunk);
+    });
+  });
+
+  describe('get', () => {
+    it('should retrieve previously saved chunk data', async () => {
+      const dataRoot = 'jVn_rdsZx2nHYgKhhI25MzveuYvH7rCd8J0WIVp4EVs';
+      const relativeOffset = 1024;
+      const originalChunk = Buffer.from('test data for retrieval');
+      const chunkData: ChunkData = {
+        chunk: originalChunk,
+        hash: crypto.createHash('sha256').update(originalChunk).digest(),
+      };
+
+      await store.set(dataRoot, relativeOffset, chunkData);
+      const retrieved = await store.get(dataRoot, relativeOffset);
+
+      assert.ok(retrieved);
+      assert.deepEqual(retrieved.chunk, originalChunk);
+      assert.deepEqual(retrieved.hash, chunkData.hash);
+    });
+
+    it('should return undefined for non-existent chunk', async () => {
+      const result = await store.get('non-existent-root', 0);
+      assert.strictEqual(result, undefined);
+    });
+
+    it('should calculate hash correctly when retrieving', async () => {
+      const dataRoot = 'l14EgjvxeJeH6qJ4yqWQEQXy7UMPctMPAW26Ean-QEE';
+      const relativeOffset = 0;
+      const chunkContent = Buffer.from('content for hash verification');
+      const expectedHash = crypto
+        .createHash('sha256')
+        .update(chunkContent)
+        .digest();
+
+      // Manually create the file to ensure we're testing hash calculation
+      const fs = await import('node:fs');
+      const dir = join(tempDir, 'by-dataroot', 'l1', '4E', dataRoot);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(join(dir, '0'), chunkContent);
+
+      const retrieved = await store.get(dataRoot, relativeOffset);
+
+      assert.ok(retrieved);
+      assert.deepEqual(retrieved.hash, expectedHash);
+    });
+
+    it('should return undefined when file read fails', async () => {
+      const dataRoot = 'SwiDNS9zjqMk0MZDAxW2yV_8gmdFmOmJpmq869u9STM';
+      const relativeOffset = 0;
+
+      // Create a directory instead of a file to cause read error
+      const fs = await import('node:fs');
+      const path = join(tempDir, 'by-dataroot', 'Sw', 'iD', dataRoot, '0');
+      fs.mkdirSync(path, { recursive: true });
+
+      const result = await store.get(dataRoot, relativeOffset);
+      assert.strictEqual(result, undefined);
+    });
+  });
+
+  describe('has', () => {
+    it('should return true for existing chunk', async () => {
+      const dataRoot = 'YCBTU_-umYKVoBT_YtX0_rghFSl1bVROJydZQc_Dh4g';
+      const relativeOffset = 2048;
+      const chunkData: ChunkData = {
+        chunk: Buffer.from('chunk for has test'),
+        hash: crypto.createHash('sha256').update('chunk for has test').digest(),
+      };
+
+      await store.set(dataRoot, relativeOffset, chunkData);
+      const exists = await store.has(dataRoot, relativeOffset);
+
+      assert.strictEqual(exists, true);
+    });
+
+    it('should return false for non-existent chunk', async () => {
+      const exists = await store.has('non-existent-root', 999);
+      assert.strictEqual(exists, false);
+    });
+
+    it('should return false when directory exists but file does not', async () => {
+      const dataRoot = 'aQHTabwvnlgqBDDgJmd_yhrp89gJCfbvwa8PgeOp4cI';
+
+      // Create the directory structure without the file
+      const fs = await import('node:fs');
+      const dir = join(tempDir, 'by-dataroot', 'aQ', 'HT', dataRoot);
+      fs.mkdirSync(dir, { recursive: true });
+
+      const exists = await store.has(dataRoot, 0);
+      assert.strictEqual(exists, false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle very large relative offsets', async () => {
+      const dataRoot = 'mLcNjqsYgNAeDWQCIhXATDkWtQ7739rJ2AbX3W6UTjo';
+      const relativeOffset = 2147483647; // Max 32-bit integer
+      const chunkData: ChunkData = {
+        chunk: Buffer.from('large offset test'),
+        hash: crypto.createHash('sha256').update('large offset test').digest(),
+      };
+
+      await store.set(dataRoot, relativeOffset, chunkData);
+      const retrieved = await store.get(dataRoot, relativeOffset);
+
+      assert.ok(retrieved);
+      assert.deepEqual(retrieved.chunk, chunkData.chunk);
+    });
+
+    it('should handle empty chunk data', async () => {
+      const dataRoot = 'tne4Fh9gC2AYX_ZUO5fV_ppKe0pwCwjOK4uTtg1OIjk';
+      const relativeOffset = 0;
+      const chunkData: ChunkData = {
+        chunk: Buffer.alloc(0),
+        hash: crypto.createHash('sha256').update(Buffer.alloc(0)).digest(),
+      };
+
+      await store.set(dataRoot, relativeOffset, chunkData);
+      const retrieved = await store.get(dataRoot, relativeOffset);
+
+      assert.ok(retrieved);
+      assert.strictEqual(retrieved.chunk.length, 0);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle write permission errors gracefully', async () => {
+      const dataRoot = 'wD75deO8zEyEDs3iI2b_IPpw6kZ2hTfCEXGOrm0Xtpg';
+      const relativeOffset = 0;
+      const chunkData: ChunkData = {
+        chunk: Buffer.from('permission test'),
+        hash: crypto.createHash('sha256').update('permission test').digest(),
+      };
+
+      // Make the base directory read-only
+      const fs = await import('node:fs');
+      const baseDir = join(tempDir, 'by-dataroot');
+      fs.mkdirSync(baseDir);
+      fs.chmodSync(baseDir, 0o444);
+
+      try {
+        // This should not throw, just log the error
+        await store.set(dataRoot, relativeOffset, chunkData);
+      } finally {
+        // Restore permissions for cleanup
+        fs.chmodSync(baseDir, 0o755);
+      }
+
+      // Verify nothing was written
+      const exists = await store.has(dataRoot, relativeOffset);
+      assert.strictEqual(exists, false);
+    });
+  });
+});

--- a/src/system.ts
+++ b/src/system.ts
@@ -474,7 +474,7 @@ export const chunkDataFsCacheCleanupWorker =
             const stats = await fs.promises.stat(path);
             // Use the more recent of atime or mtime, matching contiguous data cleanup pattern
             const mostRecentTimeMs =
-              stats.atime > stats.mtime ? stats.atime : stats.mtime;
+              stats.atime > stats.mtime ? stats.atimeMs : stats.mtimeMs;
             const ageInSeconds = (Date.now() - mostRecentTimeMs) / 1000;
 
             // Delete if file is older than threshold


### PR DESCRIPTION
## Summary
- Implement chunk data cache cleanup functionality
- Simplify chunk storage to only use data root (remove hash-based storage)
- Add automatic cleanup based on file age

## Changes
- **Simplified FsChunkDataStore**: Removed hash-based storage and symlink management, now stores chunks directly by data root
- **Added configuration**: `ENABLE_CHUNK_DATA_CACHE_CLEANUP` and `CHUNK_DATA_CACHE_CLEANUP_THRESHOLD`
- **Created cleanup worker**: Uses existing `FsCleanupWorker` infrastructure to clean up old chunks
- **Automatic metrics**: Tracks cache size and object count
- **Fixed tests**: Updated to match actual behavior (FsChunkDataStore returns undefined on error)

## Benefits
- Simpler codebase without symlink complexity
- Easier cleanup implementation
- Better performance with direct file access
- Automatic metrics tracking for monitoring

## Configuration
To enable chunk cache cleanup with a 7-day threshold:
```bash
ENABLE_CHUNK_DATA_CACHE_CLEANUP=true
CHUNK_DATA_CACHE_CLEANUP_THRESHOLD=604800  # 7 days in seconds
```

## Test plan
- [x] Verify chunk storage works correctly with new simplified structure
- [x] Test cleanup worker removes old chunks based on threshold
- [x] Confirm metrics are tracked properly
- [x] Ensure no regression in chunk retrieval performance

Jira: [PE-8304](https://ardrive.atlassian.net/browse/PE-8304)

🤖 Generated with [Claude Code](https://claude.ai/code)

[PE-8304]: https://ardrive.atlassian.net/browse/PE-8304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ