### PR TITLE
feat: implement demand-driven opt-out background verification for ArNS data (PE-8163)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ import { createFilter } from './filters.js';
 import * as env from './lib/env.js';
 import { release } from './version.js';
 import logger from './log.js';
+import { verificationPriorities } from './constants.js';
 
 //
 // HTTP server
@@ -314,7 +315,7 @@ export const BACKGROUND_DATA_VERIFICATION_STREAM_TIMEOUT_MS = +env.varOrDefault(
 
 export const MIN_DATA_VERIFICATION_PRIORITY = +env.varOrDefault(
   'MIN_DATA_VERIFICATION_PRIORITY',
-  '80', // Only verify data with priority 80 or higher
+  `${verificationPriorities.arns}`, // Verify all ArNS data (priority 60+) and preferred names (priority 80)
 );
 
 export const MAX_VERIFICATION_RETRIES = +env.varOrDefault(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,11 @@ export const headerNames = {
   arnsIndex: 'X-ArNS-Record-Index',
 };
 
+export const verificationPriorities = {
+  preferredArns: 80,
+  arns: 60,
+} as const;
+
 export const DATA_PATH_REGEX =
   /^\/?([a-zA-Z0-9-_]{43})\/?$|^\/?([a-zA-Z0-9-_]{43})\/(.*)$/i;
 export const RAW_DATA_PATH_REGEX = /^\/raw\/([a-zA-Z0-9-_]{43})\/?$/i;

--- a/src/system.ts
+++ b/src/system.ts
@@ -233,6 +233,7 @@ export const contiguousDataFsCacheCleanupWorker = !isNaN(
       log,
       basePath: 'data/contiguous',
       dataType: 'contiguous_data',
+      initialDelay: contiguousDataCacheCleanupThresholdSeconds * 1000, // Use cleanup threshold as initial delay
       shouldDelete: async (path) => {
         try {
           const stats = await fs.promises.stat(path);


### PR DESCRIPTION
## Summary
- Implements a three-tier verification priority system for ArNS data
- Lowers the default MIN_DATA_VERIFICATION_PRIORITY from 80 to 60 to enable verification of all ArNS data
- Adds initial delay to filesystem cleanup worker to ensure metadata cache population

## Changes
- Add `verificationPriorities` constants in `src/constants.ts` following existing patterns
- Update `calculateVerificationPriority` method to implement three-tier system:
  - Preferred ArNS names: priority 80 (unchanged)
  - All other ArNS data: priority 60 (new)
  - Non-ArNS data: undefined/no priority
- Lower `MIN_DATA_VERIFICATION_PRIORITY` default to 60 using the new constant
- Add `initialDelay` parameter to `FsCleanupWorker` for configurable startup delay
- Configure contiguous data cleanup worker to wait before starting (using cleanup threshold as delay)
- Add debug logging when verification priorities are set