### PR TITLE
feat: implement partition-based verification filtering (PE-8163)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -323,6 +323,16 @@ export const MAX_VERIFICATION_RETRIES = +env.varOrDefault(
   '5', // Maximum number of verification retry attempts
 );
 
+export const VERIFICATION_PARTITION_COUNT = +env.varOrDefault(
+  'VERIFICATION_PARTITION_COUNT',
+  '64', // Number of partitions to divide ID space
+);
+
+export const VERIFICATION_PARTITION_THRESHOLD = +env.varOrDefault(
+  'VERIFICATION_PARTITION_THRESHOLD',
+  '70', // Only partition filter IDs with priority below this threshold
+);
+
 // Filter determining which ANS-104 bundles to unbundle
 export const ANS104_UNBUNDLE_FILTER_PARSED = JSON.parse(
   env.varOrDefault('ANS104_UNBUNDLE_FILTER', '{"never": true}'),

--- a/src/lib/verification-partition.ts
+++ b/src/lib/verification-partition.ts
@@ -1,0 +1,45 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import crypto from 'node:crypto';
+
+export function getNodePartition(
+  partitionSeed: string,
+  totalPartitions: number,
+): number {
+  const hash = crypto.createHash('sha256').update(partitionSeed).digest();
+  // Use first 4 bytes as 32-bit integer
+  const hashInt = hash.readUInt32BE(0);
+  return hashInt % totalPartitions;
+}
+
+export function getIdPartition(id: string, totalPartitions: number): number {
+  // Convert base64url ID to buffer
+  const idBuffer = Buffer.from(id, 'base64url');
+  // Use first 4 bytes as 32-bit integer
+  const idInt = idBuffer.readUInt32BE(0);
+  return idInt % totalPartitions;
+}
+
+export function shouldVerifyId(
+  id: string,
+  nodePartition: number,
+  totalPartitions: number,
+  priority?: number,
+  partitionThreshold: number = 70,
+): boolean {
+  // High priority items bypass partition filtering
+  if (priority !== undefined && priority >= partitionThreshold) {
+    return true;
+  }
+
+  // Check if ID belongs to this node's partition
+  return getIdPartition(id, totalPartitions) === nodePartition;
+}
+
+export function generatePartitionSeed(wallet?: string): string {
+  return wallet ?? crypto.randomBytes(32).toString('hex');
+}


### PR DESCRIPTION
## Summary

This PR implements partition-based verification filtering to reduce verification workload while ensuring network-wide coverage of all data.

## Changes

### Configuration
- Add `VERIFICATION_PARTITION_COUNT` (default: 64) - number of partitions to divide ID space
- Add `VERIFICATION_PARTITION_THRESHOLD` (default: 70) - priority threshold for partition filtering

### Partition Assignment
- Each node is assigned to 1 of 64 partitions at startup
- Assignment based on:
  - AR_IO_WALLET address (if configured) - deterministic
  - Random bytes (if no wallet) - random distribution
- Partition assignment is logged at startup

### Verification Filtering
- IDs with priority < 70 are filtered by partition
- High-priority data (priority ≥ 70) bypasses filtering and is verified by all nodes
- Filtering happens in the data verification worker after retrieving verifiable IDs
- Skipped IDs have their retry count incremented to ensure eventual verification

### Implementation Details
- Created `src/lib/verification-partition.ts` with partition calculation functions
- Updated data verification worker to apply partition filtering
- No database changes required - filtering happens at application level

## Benefits
- Reduces verification workload by ~98.4% (63/64) for low-priority data
- Ensures high-priority ArNS data is still verified by all nodes
- Deterministic partitioning for nodes with wallets
- Fair distribution through retry count increments

## Testing
- [ ] Verify partition assignment at startup
- [ ] Confirm high-priority data bypasses filtering
- [ ] Check retry count increments for skipped IDs
- [ ] Test with different partition counts
- [ ] Verify deterministic behavior with wallets

## Related
- Jira: [PE-8163](https://ardrive.atlassian.net/browse/PE-8163)
- Builds on PR #447 (demand-driven verification for ArNS data)

🤖 Generated with [Claude Code](https://claude.ai/code)

[PE-8163]: https://ardrive.atlassian.net/browse/PE-8163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ