### PR TITLE
feat: add bundle metadata columns to data.db (PE-8335)

### DIFF
--- a/migrations/2025.07.23T20.12.40.data.add-bundle-metadata.sql
+++ b/migrations/2025.07.23T20.12.40.data.add-bundle-metadata.sql
@@ -1,0 +1,11 @@
+-- up migration
+-- Add bundle metadata columns to contiguous_data_ids table
+
+-- Add columns for tracking bundle hierarchy and data locations
+ALTER TABLE contiguous_data_ids ADD COLUMN root_transaction_id BLOB;
+ALTER TABLE contiguous_data_ids ADD COLUMN root_parent_offset INTEGER;
+ALTER TABLE contiguous_data_ids ADD COLUMN data_offset INTEGER;
+ALTER TABLE contiguous_data_ids ADD COLUMN data_size INTEGER;
+ALTER TABLE contiguous_data_ids ADD COLUMN data_item_offset INTEGER;
+ALTER TABLE contiguous_data_ids ADD COLUMN data_item_size INTEGER;
+ALTER TABLE contiguous_data_ids ADD COLUMN format_id INTEGER;

--- a/migrations/down/2025.07.23T20.12.40.data.add-bundle-metadata.sql
+++ b/migrations/down/2025.07.23T20.12.40.data.add-bundle-metadata.sql
@@ -1,0 +1,39 @@
+-- down migration
+-- Remove bundle metadata columns from contiguous_data_ids table
+
+-- SQLite doesn't support dropping columns directly, so we need to recreate the table
+-- Create a new table without the new columns
+CREATE TABLE contiguous_data_ids_new (
+  id BLOB PRIMARY KEY,
+  contiguous_data_hash BLOB,
+  verified BOOLEAN NOT NULL DEFAULT FALSE,
+  indexed_at INTEGER NOT NULL,
+  verified_at INTEGER,
+  verification_retry_count INTEGER,
+  verification_priority INTEGER,
+  first_verification_attempted_at INTEGER,
+  last_verification_attempted_at INTEGER
+);
+
+-- Copy data from old table to new table
+INSERT INTO contiguous_data_ids_new 
+  (id, contiguous_data_hash, verified, indexed_at, verified_at, 
+   verification_retry_count, verification_priority, 
+   first_verification_attempted_at, last_verification_attempted_at)
+SELECT 
+  id, contiguous_data_hash, verified, indexed_at, verified_at,
+  verification_retry_count, verification_priority,
+  first_verification_attempted_at, last_verification_attempted_at
+FROM contiguous_data_ids;
+
+-- Drop the old table
+DROP TABLE contiguous_data_ids;
+
+-- Rename the new table to the original name
+ALTER TABLE contiguous_data_ids_new RENAME TO contiguous_data_ids;
+
+-- Recreate the existing indexes
+CREATE INDEX contiguous_data_ids_contiguous_data_hash_idx ON contiguous_data_ids (contiguous_data_hash);
+CREATE INDEX contiguous_data_ids_verification_priority_retry_idx 
+ON contiguous_data_ids (verification_priority DESC, verification_retry_count ASC, id ASC) 
+WHERE verified = FALSE;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,3 +42,7 @@ export const DATA_PATH_REGEX =
 export const RAW_DATA_PATH_REGEX = /^\/raw\/([a-zA-Z0-9-_]{43})\/?$/i;
 export const FARCASTER_FRAME_DATA_PATH_REGEX =
   /^\/local\/farcaster\/frame\/([a-zA-Z0-9-_]{43})\/?$/i;
+
+// Bundle format IDs
+export const ANS_102_FORMAT_ID = 0;
+export const ANS_104_FORMAT_ID = 1;

--- a/src/database/sql/data/verification.sql
+++ b/src/database/sql/data/verification.sql
@@ -12,9 +12,7 @@ UPDATE contiguous_data_ids
 SET
   verified = 1,
   verified_at = @verified_at
-WHERE id = @id OR id IN (
-  SELECT id FROM bundles.bundle_data_items WHERE root_transaction_id = @id
-);
+WHERE id = @id OR root_transaction_id = @id;
 
 -- incrementVerificationRetryCount
 UPDATE contiguous_data_ids

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -552,6 +552,8 @@ export interface ContiguousDataAttributes {
   rootParentOffset?: number;
   dataOffset?: number;
   itemSize?: number;
+  dataItemOffset?: number;
+  formatId?: number;
   signatureSize?: number;
   signatureOffset?: number;
   ownerOffset?: number;
@@ -600,6 +602,12 @@ export interface ContiguousDataIndex {
     cachedAt,
     verified,
     verificationPriority,
+    rootTransactionId,
+    rootParentOffset,
+    dataOffset,
+    dataItemSize,
+    dataItemOffset,
+    formatId,
   }: {
     id: string;
     parentId?: string;
@@ -610,6 +618,12 @@ export interface ContiguousDataIndex {
     cachedAt?: number;
     verified?: boolean;
     verificationPriority?: number;
+    rootTransactionId?: string;
+    rootParentOffset?: number;
+    dataOffset?: number;
+    dataItemSize?: number;
+    dataItemOffset?: number;
+    formatId?: number;
   }): Promise<void>;
   getVerifiableDataIds(options?: {
     minVerificationPriority?: number;

--- a/src/workers/ans104-data-indexer.ts
+++ b/src/workers/ans104-data-indexer.ts
@@ -16,6 +16,7 @@ import {
   NestedDataIndexWriter,
   NormalizedDataItem,
 } from '../types.js';
+import { ANS_104_FORMAT_ID } from '../constants.js';
 
 const DEFAULT_WORKER_COUNT = 1;
 
@@ -84,7 +85,11 @@ export class Ans104DataIndexer {
         typeof item.data_offset === 'number' &&
         !Number.isNaN(item.data_offset) &&
         typeof item.data_size === 'number' &&
-        !Number.isNaN(item.data_size)
+        !Number.isNaN(item.data_size) &&
+        typeof item.size === 'number' &&
+        !Number.isNaN(item.size) &&
+        typeof item.offset === 'number' &&
+        !Number.isNaN(item.offset)
       ) {
         log.debug('Indexing data item data...');
         if (item.data_hash != null) {
@@ -94,6 +99,12 @@ export class Ans104DataIndexer {
             hash: item.data_hash,
             dataSize: item.data_size,
             contentType: item.content_type,
+            rootTransactionId: item.root_tx_id,
+            rootParentOffset: item.root_parent_offset,
+            dataOffset: item.data_offset,
+            dataItemSize: item.size,
+            dataItemOffset: item.offset,
+            formatId: ANS_104_FORMAT_ID,
           });
 
           // Index data hash to parent ID relationship

--- a/src/workers/data-content-attribute-importer.ts
+++ b/src/workers/data-content-attribute-importer.ts
@@ -22,6 +22,12 @@ export type DataContentAttributeProperties = {
   cachedAt?: number;
   verified?: boolean;
   verificationPriority?: number;
+  rootTransactionId?: string;
+  rootParentOffset?: number;
+  dataOffset?: number;
+  dataItemSize?: number;
+  dataItemOffset?: number;
+  formatId?: number;
 };
 
 export class DataContentAttributeImporter {

--- a/test/data-schema.sql
+++ b/test/data-schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE contiguous_data_ids (
   verified BOOLEAN NOT NULL DEFAULT FALSE,
   indexed_at INTEGER NOT NULL,
   verified_at INTEGER
-, verification_retry_count INTEGER, verification_priority INTEGER, first_verification_attempted_at INTEGER, last_verification_attempted_at INTEGER);
+, verification_retry_count INTEGER, verification_priority INTEGER, first_verification_attempted_at INTEGER, last_verification_attempted_at INTEGER, root_transaction_id BLOB, root_parent_offset INTEGER, data_offset INTEGER, data_size INTEGER, data_item_offset INTEGER, data_item_size INTEGER, format_id INTEGER);
 CREATE INDEX contiguous_data_ids_contiguous_data_hash_idx ON contiguous_data_ids (contiguous_data_hash);
 CREATE TABLE data_roots (
   data_root BLOB PRIMARY KEY,


### PR DESCRIPTION
## Summary
- Add bundle metadata columns to data.db to enable data distribution independent of bundle.db
- Store both data item metadata AND data portion metadata for complete tracking
- Optimize getRootTxId to check data.db first before cross-database queries

## Changes
- Add 7 new columns to contiguous_data_ids table:
  - `root_transaction_id`: stores the root transaction ID for data items
  - `root_parent_offset`: stores the parent offset within the root transaction
  - `data_offset`: offset of the data portion within the data item
  - `data_size`: size of just the data payload
  - `data_item_offset`: offset of the entire data item within its parent
  - `data_item_size`: total size of the data item (including headers)
  - `format_id`: stores the bundle format (0 for ANS-102, 1 for ANS-104)
- Update `getRootTxId` to check data.db first before querying core/bundles DBs
- Simplify `updateDataItemVerificationStatus` to use `root_transaction_id`
- Add `ANS_102_FORMAT_ID` and `ANS_104_FORMAT_ID` constants
- Update ans104-data-indexer to pass all new fields when indexing data items
- Update all related types, interfaces, and SQL statements

## Important Distinction
The implementation now properly tracks two sets of offsets/sizes:
1. **Data item position within parent** (includes headers/metadata):
   - `data_item_offset`: where the data item starts within its parent
   - `data_item_size`: total size of the data item
2. **Data portion position within data item** (just the payload):
   - `data_offset`: where the actual data starts within the data item
   - `data_size`: size of just the data payload

## Test plan
- [x] Run database migrations: `yarn db:migrate up`
- [x] Update test schemas: `./test/dump-test-schemas`
- [x] Run lint check: `yarn lint:check`
- [x] Run tests: All tests pass
- [x] Verify data indexing works correctly with new fields
- [x] Test getRootTxId returns correct values from data.db
- [x] Verify backward compatibility with existing data

## Related
- Jira: [PE-8335](https://ardrive.atlassian.net/browse/PE-8335)

🤖 Generated with [Claude Code](https://claude.ai/code)

[PE-8335]: https://ardrive.atlassian.net/browse/PE-8335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ