### PR TITLE
Add AWS AppConfig docs with OpenAPI env schema

### DIFF
--- a/docs/aws-appconfig.md
+++ b/docs/aws-appconfig.md
@@ -1,0 +1,20 @@
+# AWS AppConfig for Docker Compose
+
+This guide explains how to manage the `.env` configuration used by
+`docker-compose.yaml` with **AWS AppConfig**. The configuration schema
+is provided in [openapi-env.yaml](./openapi-env.yaml) and can be used to
+validate configuration values uploaded to AppConfig.
+
+## Steps
+
+1. Create an AWS AppConfig configuration profile that references the
+   `openapi-env.yaml` schema. Set the content type to `application/openapi+yaml`.
+2. Upload a JSON document containing the key/value pairs for your
+   environment variables. Only variables defined in the schema are
+   validated. Values not included fall back to defaults in
+   `docker-compose.yaml`.
+3. Deploy the configuration. Download the values during container start
+   and write them to a `.env` file or pass them as environment variables.
+
+The schema documents every supported variable so AppConfig can ensure
+that your Docker Compose environment is well formed.

--- a/docs/openapi-env.yaml
+++ b/docs/openapi-env.yaml
@@ -1,0 +1,314 @@
+---
+openapi: 3.1.0
+info:
+  title: Docker Compose ENV configuration
+  version: 1.0.0
+  description: |
+    OpenAPI schema describing environment variables used by docker-compose.
+    The schema can be uploaded to AWS AppConfig to validate configuration
+    values provided via a .env file.
+components:
+  schemas:
+    EnvConfig:
+      type: object
+      properties:
+        START_HEIGHT:
+          type: number
+          description: "Starting block height for node synchronization (0 = start from the beginning)"
+          default: "0"
+        STOP_HEIGHT:
+          type: number
+          description: "Stop block height for node synchronization (Infinity = keep syncing until stopped)"
+          default: ""Infinity""
+        TRUSTED_NODE_URL:
+          type: string
+          description: "Arweave node to use for fetching data"
+          default: ""https://arweave.net""
+        TRUSTED_NODE_HOST:
+          type: string
+          description: "Hostname for the trusted Arweave node used by Envoy proxy"
+          default: ""arweave.net""
+        TRUSTED_NODE_PORT:
+          type: number
+          description: "Port for the trusted Arweave node used by Envoy proxy"
+          default: "443"
+        TRUSTED_GATEWAY_URL:
+          type: string
+          description: "Arweave node to use for proxying requests"
+          default: ""https://arweave.net""
+        TRUSTED_GATEWAYS_URLS:
+          type: string
+          description: "A JSON map of gateways and priority"
+          default: "TRUSTED_GATEWAY_URL"
+        TRUSTED_GATEWAYS_REQUEST_TIMEOUT_MS:
+          type: string
+          description: "Request timeout in milliseconds for trusted gateways"
+          default: ""10000""
+        TRUSTED_ARNS_GATEWAY_URL:
+          type: string
+          description: "ArNS gateway"
+          default: ""https://__NAME__.arweave.dev""
+        WEIGHTED_PEERS_TEMPERATURE_DELTA:
+          type: number
+          description: "Any positive number above 0, best to keep 1 or less. Used to determine the sensivity of which the probability of failing or succeeding peers decreases or increases."
+          default: "0.1"
+        INSTANCE_ID:
+          type: string
+          description: "Adds an \"INSTANCE_ID\" field to output logs"
+        LOG_FORMAT:
+          type: string
+          description: "Sets the format of output logs, accepts \"simple\" and \"json\""
+          default: ""simple""
+        SKIP_CACHE:
+          type: boolean
+          description: "If true, skips the local cache and always fetches headers from the node"
+          default: "false"
+        PORT:
+          type: number
+          description: "ar.io node exposed port number"
+          default: "4000"
+        SIMULATED_REQUEST_FAILURE_RATE:
+          type: number
+          description: "Number from 0 to 1, representing the probability of a request failing"
+          default: "0"
+        AR_IO_WALLET:
+          type: string
+          description: "Arweave wallet address used for staking and rewards"
+        ADMIN_API_KEY:
+          type: string
+          description: "API key used for admin API requests (if not set, it's generated and logged into the console)"
+          default: "Generated"
+        ADMIN_API_KEY_FILE:
+          type: string
+          description: "Alternative way to set the API key used for admin API requests via filepath, it takes precedene over ADMIN_API_KEY if defined"
+          default: "Generated"
+        BACKFILL_BUNDLE_RECORDS:
+          type: boolean
+          description: "If true, ar.io node will start indexing missing bundles"
+          default: "false"
+        FILTER_CHANGE_REPROCESS:
+          type: boolean
+          description: "If true, all indexed bundles will be reprocessed with the new filters (you can use this when you change the filters)"
+          default: "false"
+        ON_DEMAND_RETRIEVAL_ORDER:
+          type: string
+          description: "Data source retrieval order for on-demand data requests"
+          default: "s3,trusted-gateways,chunks,tx-data"
+        BACKGROUND_RETRIEVAL_ORDER:
+          type: string
+          description: "Data source retrieval order for background data requests (i.e., unbundling)"
+          default: "chunks,s3,trusted-gateways,chunks,tx-data"
+        ANS104_UNBUNDLE_FILTER:
+          type: string
+          description: "Only bundles compliant with this filter will be unbundled"
+          default: "{"never": true}"
+        ANS104_INDEX_FILTER:
+          type: string
+          description: "Only bundles compliant with this filter will be indexed"
+          default: "{"never": true}"
+        ANS104_DOWNLOAD_WORKERS:
+          type: string
+          description: "Sets the number of ANS-104 bundles to attempt to download in parallel"
+          default: "5"
+        ANS104_UNBUNDLE_WORKERS:
+          type: number
+          description: "Sets the number of workers used to handle unbundling"
+          default: "0, or 1 if filters are set"
+        DATA_ITEM_FLUSH_COUNT_THRESHOLD:
+          type: number
+          description: "Sets the number of new data items indexed before flushing to to stable data items"
+          default: "1000"
+        MAX_FLUSH_INTERVAL_SECONDS:
+          type: number
+          description: "Sets the maximum time interval in seconds before flushing to stable data items"
+          default: "600"
+        WRITE_ANS104_DATA_ITEM_DB_SIGNATURES:
+          type: boolean
+          description: "If true, the data item signatures will be written to the database."
+          default: "false"
+        WRITE_TRANSACTION_DB_SIGNATURES:
+          type: boolean
+          description: "If true, the transactions signatures will be written to the database."
+          default: "true"
+        ENABLE_DATA_DB_WAL_CLEANUP:
+          type: boolean
+          description: "If true, the data database WAL cleanup worker will be enabled"
+          default: "false"
+        ENABLE_BACKGROUND_DATA_VERIFICATION:
+          type: boolean
+          description: "If true, unverified data will be verified in background"
+          default: "false"
+        MAX_DATA_ITEM_QUEUE_SIZE:
+          type: number
+          description: "Sets the maximum number of data items to queue for indexing before skipping indexing new data items"
+          default: "100000"
+        ARNS_ROOT_HOST:
+          type: string
+          description: "Domain name for ArNS host"
+        SANDBOX_PROTOCOL:
+          type: string
+          description: "Protocol setting in process of creating sandbox domain in ArNS (ARNS_ROOT_HOST needs to be set for this env to have any effect)"
+        START_WRITERS:
+          type: boolean
+          description: "If true, start indexing blocks, tx, ANS104 bundles"
+          default: "true"
+        RUN_OBSERVER:
+          type: boolean
+          description: "If true, runs the Observer alongside the gateway to generate Network compliance reports"
+          default: "true"
+        MIN_RELEASE_NUMBER:
+          type: string
+          description: "Sets the minimum Gateway release version to check while doing a gateway version assessment"
+          default: "0"
+        AR_IO_NODE_RELEASE:
+          type: string
+          description: "Sets the current ar.io node version to be set on X-AR-IO-Node-Release header on requests to the reference gateway"
+          default: "0"
+        OBSERVER_WALLET:
+          type: string
+          description: "The public wallet address of the wallet being used to sign report upload transactions and contract interactions for Observer"
+          default: ""<example>""
+        CHUNKS_DATA_PATH:
+          type: string
+          description: "Sets the location for chunked data to be saved. If omitted, chunked data will be stored in the `data` directory"
+          default: ""./data/chunks""
+        CONTIGUOUS_DATA_PATH:
+          type: string
+          description: "Sets the location for contiguous data to be saved. If omitted, contiguous data will be stored in the `data` directory"
+          default: ""./data/contiguous""
+        HEADERS_DATA_PATH:
+          type: string
+          description: "Sets the location for header data to be saved. If omitted, header data will be stored in the `data` directory"
+          default: ""./data/headers""
+        SQLITE_DATA_PATH:
+          type: string
+          description: "Sets the location for sqlite indexed data to be saved. If omitted, sqlite data will be stored in the `data` directory"
+          default: ""./data/sqlite""
+        DUCKDB_DATA_PATH:
+          type: string
+          description: "Sets the location for duckdb data to be saved. If omitted, duckdb data will be stored in the `data` directory"
+          default: ""./data/duckdb""
+        TEMP_DATA_PATH:
+          type: string
+          description: "Sets the location for temporary data to be saved. If omitted, temporary data will be stored in the `data` directory"
+          default: ""./data/tmp""
+        LMDB_DATA_PATH:
+          type: string
+          description: "Sets the location for LMDB data to be saved. If omitted, LMDB data will be stored in the `data` directory"
+          default: ""./data/LMDB""
+        CHAIN_CACHE_TYPE:
+          type: string
+          description: "Sets the method for caching chain data, defaults redis if gateway is started with docker-compose, otherwise defaults to LMDB"
+          default: ""redis""
+        REDIS_CACHE_URL:
+          type: string
+          description: "URL of Redis database to be used for caching"
+          default: ""redis://localhost:6379""
+        REDIS_CACHE_TTL_SECONDS:
+          type: number
+          description: "TTL value for Redis cache, defaults to 8 hours (28800 seconds)"
+          default: "28800"
+        ENABLE_FS_HEADER_CACHE_CLEANUP:
+          type: boolean
+          description: "If true, periodically deletes cached header data"
+          default: "true if starting with docker, otherwise false"
+        NODE_JS_MAX_OLD_SPACE_SIZE:
+          type: number
+          description: "Sets the memory limit, in Megabytes, for NodeJs. Default value is 2048 if using less than 2 unbundle workers, otherwise 8192"
+          default: "2048 or 8192, depending on number of workers"
+        SUBMIT_CONTRACT_INTERACTIONS:
+          type: boolean
+          description: "If true, Observer will submit its generated reports to the ar.io Network"
+          default: "true"
+        REDIS_MAX_MEMORY:
+          type: string
+          description: "Sets the max memory allocated to Redis"
+          default: "256mb"
+        REDIS_EXTRA_FLAGS:
+          type: string
+          description: "Additional CLI flags passed to Redis"
+          default: "--save "" --appendonly no"
+        WEBHOOK_TARGET_SERVERS:
+          type: string
+          description: "Target servers for webhooks"
+        WEBHOOK_INDEX_FILTER:
+          type: string
+          description: "Only emit webhooks for transactions and data items compliant with this filter"
+          default: "{"never": true}"
+        WEBHOOK_BLOCK_FILTER:
+          type: string
+          description: "Only emit webhooks for blocks compliant with this filter"
+          default: "{"never": true}"
+        CONTIGUOUS_DATA_CACHE_CLEANUP_THRESHOLD:
+          type: number
+          description: "Sets the age threshold in seconds; files older than this are candidates for contiguous data cache cleanup"
+        ENABLE_MEMPOOL_WATCHER:
+          type: boolean
+          description: "If true, the observer will start indexing pending tx from the mempool"
+          default: "false"
+        MEMPOOL_POLLING_INTERVAL_MS:
+          type: number
+          description: "Sets the mempool polling interval in milliseconds"
+          default: "30000"
+        TAG_SELECTIVITY:
+          type: string
+          description: "A JSON map of tag names to selectivity weights used to order SQLite tag joins"
+          default: "Refer to config.ts"
+        MAX_EXPECTED_DATA_ITEM_INDEXING_INTERVAL_SECONDS:
+          type: number
+          description: "Sets the max expected data item indexing interval in seconds"
+        AR_IO_SQLITE_BACKUP_S3_BUCKET_NAME:
+          type: string
+          description: "S3-compatible bucket name, used by the Litestream backup service"
+        AR_IO_SQLITE_BACKUP_S3_BUCKET_REGION:
+          type: string
+          description: "S3-compatible bucket region, used by the Litestream backup service"
+        AR_IO_SQLITE_BACKUP_S3_BUCKET_ACCESS_KEY:
+          type: string
+          description: "S3-compatible bucket access_key credential, used by Litestream backup service, omit if using resource-based IAM role"
+        AR_IO_SQLITE_BACKUP_S3_BUCKET_SECRET_KEY:
+          type: string
+          description: "S3-compatible bucket access_secret_key credential, used by Litestream backup service, omit if using resource-based IAM role"
+        AR_IO_SQLITE_BACKUP_S3_BUCKET_PREFIX:
+          type: string
+          description: "A prepended prefix for the S3 bucket where SQLite backups are stored."
+        ARNS_MAX_CONCURRENT_RESOLUTIONS:
+          type: number
+          description: "Maximum number of concurrent resolutions allowed for ARNs."
+          default: "Number of ArNS resolvers"
+        AWS_ACCESS_KEY_ID:
+          type: string
+          description: "AWS access key ID for accessing AWS services"
+        AWS_SECRET_ACCESS_KEY:
+          type: string
+          description: "AWS secret access key for accessing AWS services"
+        AWS_REGION:
+          type: string
+          description: "AWS region where the resources are located"
+        AWS_ENDPOINT:
+          type: string
+          description: "Custom endpoint for AWS services"
+        AWS_S3_CONTIGUOUS_DATA_BUCKET:
+          type: string
+          description: "AWS S3 bucket name used for storing data"
+        AWS_S3_CONTIGUOUS_DATA_PREFIX:
+          type: string
+          description: "Prefix for the S3 bucket to organize data"
+        CHUNK_POST_MIN_SUCCESS_COUNT:
+          type: string
+          description: "Minimum count of 200 responses for of a given chunk to be considered properly seeded"
+          default: ""3""
+        BUNDLE_REPAIR_RETRY_INTERVAL_SECONDS:
+          type: string
+          description: "Interval in seconds for retrying bundles"
+          default: ""300""
+        BUNDLE_REPAIR_RETRY_BATCH_SIZE:
+          type: string
+          description: "Batch size for retrying bundles"
+          default: ""1000""
+        APEX_TX_ID:
+          type: string
+          description: "If set, serves this transaction ID's data at the root path (/)"
+        APEX_ARNS_NAME:
+          type: string
+          description: "If set, resolves and serves this ArNS name's content at the root path (/)"


### PR DESCRIPTION
## Summary
- document how to manage docker compose env values with AWS AppConfig
- generate an OpenAPI schema describing all .env variables

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68876c1d93c483289d863e4c3955bafb