### PR TITLE
PE-8321: Turbo Valkey/Redis Data Source

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -863,6 +863,10 @@ export const AWS_ELASTICACHE_TURBO_HOST = env.varOrUndefined(
 export const AWS_ELASTICACHE_TURBO_USE_TLS =
   env.varOrDefault('AWS_ELASTICACHE_TURBO_USE_TLS', 'false') === 'true';
 
+export const AWS_ELASTICACHE_TURBO_PORT = env.varOrUndefined(
+  'AWS_ELASTICACHE_TURBO_PORT',
+);
+
 // Chunk data source specifically set-up for interoperability with
 // the legacy arweave gateways
 export const LEGACY_AWS_S3_CHUNK_DATA_BUCKET = env.varOrUndefined(

--- a/src/config.ts
+++ b/src/config.ts
@@ -857,6 +857,11 @@ export const AWS_S3_TURBO_CONTIGUOUS_DATA_BUCKET = env.varOrUndefined(
 export const AWS_S3_TURBO_CONTIGUOUS_DATA_PREFIX = env.varOrUndefined(
   'AWS_S3_TURBO_CONTIGUOUS_DATA_PREFIX',
 );
+export const AWS_ELASTICACHE_TURBO_HOST = env.varOrUndefined(
+  'AWS_ELASTICACHE_TURBO_HOST',
+);
+export const AWS_ELASTICACHE_TURBO_USE_TLS =
+  env.varOrDefault('AWS_ELASTICACHE_TURBO_USE_TLS', 'false') === 'true';
 
 // Chunk data source specifically set-up for interoperability with
 // the legacy arweave gateways

--- a/src/data/ar-io-data-source.ts
+++ b/src/data/ar-io-data-source.ts
@@ -126,7 +126,13 @@ export class ArIODataSource
         maxAge: config.GATEWAY_PEERS_WEIGHTS_CACHE_DURATION_MS,
       },
     );
+    // TODO: Remove deprecated circuit breaker metrics setup
     metrics.circuitBreakerMetrics.add(this.arioGatewaysCircuitBreaker);
+    metrics.setUpCircuitBreakerListenerMetrics(
+      'ar-io-data-source',
+      this.arioGatewaysCircuitBreaker,
+      this.log,
+    );
   }
 
   stopUpdatingPeers() {

--- a/src/data/redis-data-source.ts
+++ b/src/data/redis-data-source.ts
@@ -1,0 +1,394 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import Redis, { Cluster } from 'ioredis';
+import {
+  ContiguousData,
+  ContiguousDataAttributes,
+  ContiguousDataSource,
+  Region,
+  RequestAttributes,
+} from '../types';
+import winston from 'winston';
+import CircuitBreaker from 'opossum';
+import { bufferToStream, ByteRangeTransform } from '../lib/stream';
+import { generateRequestAttributes } from '../lib/request-attributes';
+
+// A helper type that will allow us to pass around closures involving CacheService activities
+type CacheServiceTask<T> = () => Promise<T>;
+
+/**
+ *  Diagram of offsets represented in MinifiedTurboOffsetsInfo and TurboOffsetsInfo
+ *              ┌────────────────────────────────────────────┐ <---- offset 0 in raw parent
+ *              │            Raw Parent Buffer               │
+ *              │  ┌──────────────────────────────────────┐  │
+ *              │  │           Parent Header              │  │
+ *              │  └──────────────────────────────────────┘  │
+ *              │  ┌──────────────────────────────────────┐  │ <---- parentPayloadDataStart (ppds) in raw parent
+ *              │  │          Parent Payload              │  │
+ *              │  │                                      │  │
+ *              │  │  ┌────────────────────────────────┐  │  │ <---- startOffsetInRawParent (sorp) in raw parent
+ *              │  │  │   Raw Nested Item Buffer       │  │  │       offset 0 in raw nested item
+ *              │  │  │                                │  │  │
+ *              │  │  │ ┌────────────────────────────┐ │  │  │
+ *              │  │  │ │    Nested Item Header      │ │  │  │
+ *              │  │  │ └────────────────────────────┘ │  │  │
+ *              │  │  │ ┌────────────────────────────┐ │  │  │ <---- sorp + payloadDataStart (pds) in raw parent
+ *              │  │  │ │   Nested Item Payload      │ │  │  │       payloadDataStart in raw nested item
+ *              │  │  │ │                            │ │  │  │       0 in nested item payload
+ *              │  │  │ └────────────────────────────┘ │  │  │
+ *              │  │  └────────────────────────────────┘  │  │ <---- sorp + rawContentLength (rcl) in raw parent
+ *              │  └──────────────────────────────────────┘  │       rcl in raw nested item
+ *              └────────────────────────────────────────────┘       rcl - payloadDataStart in nested item payload
+ */
+type MinifiedTurboOffsetsInfo = {
+  pid: string; // parent data item id
+  ppds: number; // parent payload data start
+  sorp: number; // start offset of nested item in raw parent
+  rcl: number; // raw content length
+  pct: string; // payload content type
+  pds: number; // payload data start
+};
+
+type TurboOffsetsInfo = {
+  parentDataItemId: string;
+  parentPayloadDataStart: number;
+  startOffsetInRawParent: number;
+  rawContentLength: number;
+  payloadContentType: string;
+  payloadDataStart: number;
+};
+
+export class RedisDataSource implements ContiguousDataSource {
+  private redis: Cluster;
+  private log: winston.Logger;
+  private circuitBreaker: CircuitBreaker<[CacheServiceTask<unknown>], unknown>;
+
+  constructor({
+    redisHost,
+    redisUseTls,
+    log,
+  }: {
+    redisHost: string;
+    redisUseTls: boolean;
+    log: winston.Logger;
+  }) {
+    this.log = log;
+    this.redis = new Redis.Cluster(
+      [
+        {
+          host: redisHost,
+          port: 6379, // TODO: Parameterize
+        },
+      ],
+      {
+        dnsLookup: (address, callback) => callback(null, address),
+        redisOptions: {
+          tls: redisUseTls ? {} : undefined,
+        },
+      },
+    );
+
+    this.redis.on('connect', () =>
+      this.log.info(`Connected to Redis at ${redisHost}!`),
+    );
+    this.redis.on('ready', () =>
+      this.log.info(`Redis client is ready at ${redisHost}!`),
+    );
+    this.redis.on('reconnecting', () =>
+      this.log.warn(`Reconnecting to Redis at ${redisHost}...`),
+    );
+    this.redis.on('end', () =>
+      this.log.error(`Redis connection to ${redisHost} has ended.`),
+    );
+    this.redis.on('error', (err: Error) =>
+      this.log.error(`Connection error with Redis at host ${redisHost}:`, err),
+    );
+
+    this.circuitBreaker = new CircuitBreaker<
+      [CacheServiceTask<unknown>],
+      unknown
+    >(
+      async (...args: [CacheServiceTask<unknown>]) => {
+        if (this.redis.status !== 'ready') {
+          throw new Error(`Redis is not ready! Status: ${this.redis.status}`);
+        }
+        const [task] = args;
+        return task();
+      },
+      {
+        timeout: 3000,
+        errorThresholdPercentage: 10,
+        resetTimeout: 30000,
+      },
+    );
+
+    // TODO: Integrate with opossum-prometheus library
+    this.circuitBreaker.on('timeout', () =>
+      this.log.error('Redis circuit breaker command timed out'),
+    );
+  }
+
+  fire<T>(task: CacheServiceTask<T>): Promise<T> {
+    return this.circuitBreaker.fire(task) as Promise<T>;
+  }
+
+  async getData({
+    id,
+    dataAttributes,
+    requestAttributes,
+    region,
+  }: {
+    id: string;
+    dataAttributes?: ContiguousDataAttributes;
+    requestAttributes?: RequestAttributes;
+    region?: Region;
+  }): Promise<ContiguousData> {
+    // TODO: Configuration for whether metadata or offsets are checked first
+    try {
+      const offsetsInfo = await this.getCachedTurboOffsetsInfo(id);
+      if (offsetsInfo) {
+        this.log.debug(`Turbo Elasticache: Found offsets for ${id}`, {
+          offsetsInfo,
+        });
+
+        const {
+          parentDataItemId,
+          parentPayloadDataStart,
+          startOffsetInRawParent,
+          rawContentLength,
+          payloadContentType,
+          payloadDataStart,
+        } = offsetsInfo;
+
+        const startOffsetInParentPayload =
+          startOffsetInRawParent + payloadDataStart - parentPayloadDataStart;
+        const payloadLength = rawContentLength - payloadDataStart;
+
+        const nestedDataItemDataStream = await this.getData({
+          id: parentDataItemId,
+          region: {
+            offset: startOffsetInParentPayload + (region?.offset ?? 0),
+            size: region?.size ?? payloadLength,
+          },
+        });
+        if (nestedDataItemDataStream?.stream === undefined) {
+          const errMsg = `Turbo Elasticache: Parent ${parentDataItemId} payload data not found for nested data item ${id}`;
+          this.log.debug(errMsg, {
+            offsetsInfo,
+          });
+          throw new Error(errMsg);
+        }
+
+        this.log.debug(
+          `Turbo Elasticache: Found parent ${parentDataItemId} payload data stream for ${id}. Returning nested data item from offsets info.`,
+          {
+            offsetsInfo,
+          },
+        );
+
+        // track &&
+        //   turboPayloadFetchResultTotal.inc({
+        //     result: 'hit',
+        //     store: 'cache',
+        //     form: 'offsets',
+        //   });
+
+        const requestAttributesHeaders =
+          generateRequestAttributes(requestAttributes);
+
+        return {
+          stream: nestedDataItemDataStream.stream,
+          size: region?.size ?? payloadLength,
+          sourceContentType: payloadContentType,
+          verified: false,
+          trusted: true,
+          cached: false, // TODO: ?
+          requestAttributes: requestAttributesHeaders?.attributes,
+        };
+      }
+
+      // track &&
+      //   turboPayloadFetchResultTotal.inc({
+      //     result: 'miss',
+      //     store: 'cache',
+      //     form: 'offsets',
+      //   });
+
+      const metadata = await this.getCachedTurboMetadata(id);
+      if (metadata) {
+        this.log.debug(`Turbo Elasticache: Found metadata for ${id}`, {
+          metadata,
+        });
+        return this.getCachedTurboPayloadDataStreamFromMetadata({
+          dataItemId: id,
+          payloadContentType: metadata.payloadContentType,
+          payloadStartOffset: metadata.payloadStartOffset,
+          region,
+          requestAttributes,
+        });
+        // .then((dataStream) => {
+        //   TODO: Distinguish between 'cache' and 'fs' hits when fs is introduced
+        //   track &&
+        //     turboPayloadFetchResultTotal.inc({
+        //       result: dataStream?.stream ? 'hit' : 'miss',
+        //       store: 'cache',
+        //       form: 'raw',
+        //     });
+        //   return dataStream;
+        // });
+      } else {
+        this.log.debug(`Turbo Elasticache: Metadata not found for ${id}`);
+      }
+
+      this.log.debug(
+        `Turbo Elasticache: No metadata or offsets found for ${id}`,
+      );
+
+      // TODO: Inc a 'miss' on the 'fs' store as well once we have a fs implementation
+      // track &&
+      //   turboPayloadFetchResultTotal.inc({
+      //     result: 'miss',
+      //     store: 'cache',
+      //     form: 'raw',
+      //   });
+      throw new Error(`Data item ${id} not found in Redis`);
+    } catch (error) {
+      this.log.error(
+        `Turbo Elasticache error retrieving payload data for ${id}`,
+        error,
+      );
+
+      // TODO: Determine whether it was a cache or fs error when fs is introduced
+      // track &&
+      //   turboPayloadFetchResultTotal.inc({
+      //     result: 'error',
+      //     store: 'cache',
+      //   });
+
+      throw error;
+    }
+  }
+
+  redisIsAvailable(): boolean {
+    return !this.circuitBreaker.opened;
+  }
+
+  async getCachedTurboMetadata(txId: string): Promise<
+    | {
+        payloadContentType: string;
+        payloadStartOffset: number;
+      }
+    | undefined
+  > {
+    const metadataStr = await this.fire(() =>
+      this.redis.get(`metadata_{${txId}}`),
+    ).catch((error) => {
+      this.log.error(`Error retrieving Turbo metadata from cache`, {
+        txid: txId,
+        error,
+      });
+      return undefined;
+    });
+    if (typeof metadataStr !== 'string') return undefined;
+
+    const lastSemicolonIndex = metadataStr.lastIndexOf(';');
+    if (lastSemicolonIndex === -1) return undefined;
+
+    const payloadContentType = metadataStr.substring(0, lastSemicolonIndex);
+    const payloadStartStr = metadataStr.substring(lastSemicolonIndex + 1);
+
+    const payloadStartOffset = parseInt(payloadStartStr);
+    if (isNaN(payloadStartOffset)) return undefined;
+    return { payloadContentType, payloadStartOffset };
+  }
+
+  async getCachedTurboOffsetsInfo(
+    txId: string,
+  ): Promise<TurboOffsetsInfo | undefined> {
+    const offsetsJsonString = await this.fire(() =>
+      this.redis.get(`offsets_{${txId}}`),
+    ).catch((error) => {
+      this.log.error(`Error retrieving Turbo offsets from cache`, {
+        txid: txId,
+        error,
+      });
+      return undefined;
+    });
+    if (typeof offsetsJsonString !== 'string') {
+      this.log.debug(`Turbo offsets not found`, { txid: txId });
+      return undefined;
+    }
+    try {
+      return expandMinifiedTurboOffsetsInfo(JSON.parse(offsetsJsonString));
+    } catch (error) {
+      this.log.error(`Error parsing Turbo offsets JSON`, { txid: txId, error });
+      return undefined;
+    }
+  }
+
+  async getCachedTurboPayloadDataStreamFromMetadata({
+    dataItemId,
+    payloadContentType,
+    payloadStartOffset,
+    region,
+    requestAttributes,
+  }: {
+    dataItemId: string;
+    payloadContentType: string;
+    payloadStartOffset: number;
+    region?: Region;
+    requestAttributes?: RequestAttributes;
+  }): Promise<ContiguousData> {
+    // TODO: readthroughpromisecache-ing
+    const rawDataItemBuffer = await this.fire(() =>
+      this.redis.getBuffer(`raw_{${dataItemId}}`),
+    ).catch(() => undefined);
+    if (!rawDataItemBuffer) {
+      throw new Error(`Raw data for ${dataItemId} not found in Redis!`);
+    }
+    let stream = bufferToStream(
+      rawDataItemBuffer.subarray(
+        payloadStartOffset,
+        rawDataItemBuffer.byteLength,
+      ),
+    );
+    if (region) {
+      const byteRangeStream = new ByteRangeTransform(
+        region.offset,
+        region.size,
+      );
+      stream = stream.pipe(byteRangeStream);
+    }
+
+    const requestAttributesHeaders =
+      generateRequestAttributes(requestAttributes);
+
+    return {
+      stream,
+      sourceContentType: payloadContentType,
+      size: region?.size ?? rawDataItemBuffer.byteLength,
+      cached: false, // TODO: ?
+      trusted: true,
+      verified: false,
+      requestAttributes: requestAttributesHeaders?.attributes,
+    };
+  }
+}
+
+function expandMinifiedTurboOffsetsInfo(
+  offsetsInfo: MinifiedTurboOffsetsInfo,
+): TurboOffsetsInfo {
+  return {
+    parentDataItemId: offsetsInfo.pid,
+    parentPayloadDataStart: offsetsInfo.ppds,
+    startOffsetInRawParent: offsetsInfo.sorp,
+    rawContentLength: offsetsInfo.rcl,
+    payloadContentType: offsetsInfo.pct,
+    payloadDataStart: offsetsInfo.pds,
+  };
+}

--- a/src/data/turbo-redis-data-source.test.ts
+++ b/src/data/turbo-redis-data-source.test.ts
@@ -1,0 +1,401 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { strict as assert } from 'node:assert';
+import { afterEach, before, beforeEach, describe, it, mock } from 'node:test';
+import { Readable } from 'node:stream';
+import * as winston from 'winston';
+
+import { TurboRedisDataSource } from './turbo-redis-data-source.js';
+import { RequestAttributes } from '../types.js';
+
+let log: winston.Logger;
+let turboRedisDataSource: TurboRedisDataSource;
+let mockRedis: any;
+let mockCircuitBreaker: any;
+
+const testDataId = 'test-data-id';
+const testParentId = 'test-parent-id';
+
+before(async () => {
+  log = winston.createLogger({ silent: true });
+});
+
+beforeEach(async () => {
+  // Create mock objects
+  mockRedis = {
+    status: 'ready',
+    get: mock.fn(async () => null),
+    getBuffer: mock.fn(async () => null),
+    on: mock.fn(),
+  };
+
+  mockCircuitBreaker = {
+    fire: mock.fn(async (task: any) => task()),
+    opened: false,
+    on: mock.fn(),
+  };
+
+  // Create instance and inject mocks
+  turboRedisDataSource = new TurboRedisDataSource({
+    redisHost: 'test-host',
+    redisUseTls: false,
+    log,
+  });
+
+  // Replace the internal dependencies with mocks
+  (turboRedisDataSource as any).redis = mockRedis;
+  (turboRedisDataSource as any).circuitBreaker = mockCircuitBreaker;
+});
+
+afterEach(async () => {
+  mock.restoreAll();
+});
+
+describe('TurboRedisDataSource', () => {
+  describe('redisIsAvailable', () => {
+    for (const opened of [false, true]) {
+      it(`should return ${!opened} when circuit breaker is ${opened ? 'open' : 'closed'}`, () => {
+        mockCircuitBreaker.opened = opened;
+        assert.equal(turboRedisDataSource.redisIsAvailable(), !opened);
+      });
+    }
+  });
+
+  describe('getCachedTurboMetadata', () => {
+    it('should return parsed metadata when found', async () => {
+      const metadataString = 'image/png;1024';
+      mockRedis.get = mock.fn(async () => metadataString);
+
+      const result =
+        await turboRedisDataSource.getCachedTurboMetadata(testDataId);
+
+      assert.deepEqual(result, {
+        payloadContentType: 'image/png',
+        payloadStartOffset: 1024,
+      });
+      assert.equal((mockRedis.get as any).mock.callCount(), 1);
+      assert.equal(
+        (mockRedis.get as any).mock.calls[0].arguments[0],
+        `metadata_{${testDataId}}`,
+      );
+    });
+
+    it('should return undefined when metadata not found', async () => {
+      mockRedis.get = mock.fn(async () => null);
+
+      const result =
+        await turboRedisDataSource.getCachedTurboMetadata(testDataId);
+
+      assert.equal(result, undefined);
+    });
+
+    it('should return undefined when metadata format is invalid', async () => {
+      mockRedis.get = mock.fn(async () => 'invalid-format');
+
+      const result =
+        await turboRedisDataSource.getCachedTurboMetadata(testDataId);
+
+      assert.equal(result, undefined);
+    });
+
+    it('should return undefined when payload start offset is not a number', async () => {
+      mockRedis.get = mock.fn(async () => 'image/png;not-a-number');
+
+      const result =
+        await turboRedisDataSource.getCachedTurboMetadata(testDataId);
+
+      assert.equal(result, undefined);
+    });
+
+    it('should handle Redis errors gracefully', async () => {
+      mockRedis.get = mock.fn(async () => {
+        throw new Error('Redis error');
+      });
+
+      const result =
+        await turboRedisDataSource.getCachedTurboMetadata(testDataId);
+
+      assert.equal(result, undefined);
+    });
+  });
+
+  describe('getCachedTurboOffsetsInfo', () => {
+    it('should return expanded offsets info when found', async () => {
+      const minifiedOffsets = {
+        pid: testParentId,
+        ppds: 512,
+        sorp: 1024,
+        rcl: 2048,
+        pct: 'application/json',
+        pds: 256,
+      };
+      mockRedis.get = mock.fn(async () => JSON.stringify(minifiedOffsets));
+
+      const result =
+        await turboRedisDataSource.getCachedTurboOffsetsInfo(testDataId);
+
+      assert.deepEqual(result, {
+        parentDataItemId: testParentId,
+        parentPayloadDataStart: 512,
+        startOffsetInRawParent: 1024,
+        rawContentLength: 2048,
+        payloadContentType: 'application/json',
+        payloadDataStart: 256,
+      });
+      assert.equal(
+        (mockRedis.get as any).mock.calls[0].arguments[0],
+        `offsets_{${testDataId}}`,
+      );
+    });
+
+    it('should return undefined when offsets not found', async () => {
+      mockRedis.get = mock.fn(async () => null);
+
+      const result =
+        await turboRedisDataSource.getCachedTurboOffsetsInfo(testDataId);
+
+      assert.equal(result, undefined);
+    });
+
+    it('should return undefined when JSON parsing fails', async () => {
+      mockRedis.get = mock.fn(async () => 'invalid-json');
+
+      const result =
+        await turboRedisDataSource.getCachedTurboOffsetsInfo(testDataId);
+
+      assert.equal(result, undefined);
+    });
+
+    it('should handle Redis errors gracefully', async () => {
+      mockRedis.get = mock.fn(async () => {
+        throw new Error('Redis error');
+      });
+
+      const result =
+        await turboRedisDataSource.getCachedTurboOffsetsInfo(testDataId);
+
+      assert.equal(result, undefined);
+    });
+  });
+
+  describe('getCachedTurboPayloadDataStreamFromMetadata', () => {
+    it('should return data stream from cached buffer', async () => {
+      const testBuffer = Buffer.from('test payload data');
+      mockRedis.getBuffer = mock.fn(async () => testBuffer);
+
+      const result =
+        await turboRedisDataSource.getCachedTurboPayloadDataStreamFromMetadata({
+          dataItemId: testDataId,
+          payloadContentType: 'text/plain',
+          payloadStartOffset: 5,
+        });
+
+      assert.ok(result.stream instanceof Readable);
+      assert.equal(result.sourceContentType, 'text/plain');
+      assert.equal(result.size, testBuffer.byteLength);
+      assert.equal(result.cached, false);
+      assert.equal(result.trusted, true);
+      assert.equal(result.verified, false);
+
+      assert.equal(
+        (mockRedis.getBuffer as any).mock.calls[0].arguments[0],
+        `raw_{${testDataId}}`,
+      );
+
+      // Verify stream content
+      let streamData = '';
+      for await (const chunk of result.stream) {
+        streamData += chunk;
+      }
+      assert.equal(streamData, 'payload data');
+    });
+
+    it('should handle region offset and size', async () => {
+      const testBuffer = Buffer.from('test payload data for region');
+      mockRedis.getBuffer = mock.fn(async () => testBuffer);
+
+      const result =
+        await turboRedisDataSource.getCachedTurboPayloadDataStreamFromMetadata({
+          dataItemId: testDataId,
+          payloadContentType: 'text/plain',
+          payloadStartOffset: 5,
+          region: { offset: 2, size: 7 },
+        });
+
+      assert.equal(result.size, 7);
+
+      // Verify stream content with region
+      let streamData = '';
+      for await (const chunk of result.stream) {
+        streamData += chunk;
+      }
+      assert.equal(streamData, 'yload d');
+    });
+
+    it('should include request attributes', async () => {
+      const testBuffer = Buffer.from('test data');
+      mockRedis.getBuffer = mock.fn(async () => testBuffer);
+
+      const result =
+        await turboRedisDataSource.getCachedTurboPayloadDataStreamFromMetadata({
+          dataItemId: testDataId,
+          payloadContentType: 'text/plain',
+          payloadStartOffset: 0,
+          requestAttributes: { hops: 1, origin: 'test-origin' },
+        });
+
+      assert.deepEqual(result.requestAttributes, {
+        hops: 2,
+        origin: 'test-origin',
+      });
+    });
+
+    it('should throw error when raw data not found', async () => {
+      mockRedis.getBuffer = mock.fn(async () => null);
+
+      await assert.rejects(
+        turboRedisDataSource.getCachedTurboPayloadDataStreamFromMetadata({
+          dataItemId: testDataId,
+          payloadContentType: 'text/plain',
+          payloadStartOffset: 0,
+        }),
+        /Raw data for .* not found in Redis!/,
+      );
+    });
+
+    it('should handle Redis errors', async () => {
+      mockRedis.getBuffer = mock.fn(async () => {
+        throw new Error('Redis connection error');
+      });
+
+      await assert.rejects(
+        turboRedisDataSource.getCachedTurboPayloadDataStreamFromMetadata({
+          dataItemId: testDataId,
+          payloadContentType: 'text/plain',
+          payloadStartOffset: 0,
+        }),
+        /Raw data for .* not found in Redis!/,
+      );
+    });
+  });
+
+  describe('getData', () => {
+    it('should return data from metadata when available', async () => {
+      const testBuffer = Buffer.from('test metadata payload data');
+
+      mockRedis.get = mock.fn(async (key: string) => {
+        if (key === `offsets_{${testDataId}}`) {
+          return null; // No offsets
+        }
+        if (key === `metadata_{${testDataId}}`) {
+          return 'text/plain;5';
+        }
+        return null;
+      });
+
+      mockRedis.getBuffer = mock.fn(async () => testBuffer);
+
+      const result = await turboRedisDataSource.getData({ id: testDataId });
+
+      assert.ok(result.stream instanceof Readable);
+      assert.equal(result.sourceContentType, 'text/plain');
+      assert.equal(result.size, testBuffer.byteLength);
+      assert.equal(result.verified, false);
+      assert.equal(result.trusted, true);
+      assert.equal(result.cached, false);
+    });
+
+    it('should handle region parameters', async () => {
+      const testBuffer = Buffer.from('test data with region handling');
+
+      mockRedis.get = mock.fn(async (key: string) => {
+        if (key === `metadata_{${testDataId}}`) {
+          return 'text/plain;5';
+        }
+        return null;
+      });
+
+      mockRedis.getBuffer = mock.fn(async () => testBuffer);
+
+      const region = { offset: 2, size: 10 };
+      const result = await turboRedisDataSource.getData({
+        id: testDataId,
+        region,
+      });
+
+      assert.equal(result.size, 10);
+    });
+
+    it('should include request attributes in response', async () => {
+      const testBuffer = Buffer.from('test data');
+
+      mockRedis.get = mock.fn(async (key: string) => {
+        if (key === `metadata_{${testDataId}}`) {
+          return 'text/plain;0';
+        }
+        return null;
+      });
+
+      mockRedis.getBuffer = mock.fn(async () => testBuffer);
+
+      const requestAttributes: RequestAttributes = {
+        hops: 0,
+        origin: 'test-origin',
+      };
+      const result = await turboRedisDataSource.getData({
+        id: testDataId,
+        requestAttributes,
+      });
+
+      assert.deepEqual(result.requestAttributes, {
+        hops: 1,
+        origin: 'test-origin',
+      });
+    });
+
+    it('should throw error when data not found', async () => {
+      mockRedis.get = mock.fn(async () => null);
+
+      await assert.rejects(
+        turboRedisDataSource.getData({ id: testDataId }),
+        /Data item .* not found in Redis/,
+      );
+    });
+
+    it('should treat circuit breaker failures as cache misses', async () => {
+      mockCircuitBreaker.fire = mock.fn(async () => {
+        throw new Error('Redis connection failed');
+      });
+
+      await assert.rejects(
+        turboRedisDataSource.getData({ id: testDataId }),
+        /Data item .* not found in Redis/,
+      );
+    });
+  });
+
+  describe('circuit breaker integration', () => {
+    it('should use circuit breaker for Redis operations through public methods', async () => {
+      mockRedis.get = mock.fn(async () => 'image/png;1024');
+
+      await turboRedisDataSource.getCachedTurboMetadata(testDataId);
+
+      assert.equal((mockCircuitBreaker.fire as any).mock.callCount(), 1);
+    });
+
+    it('should treat circuit breaker failures as cache misses through getData method', async () => {
+      mockCircuitBreaker.fire = mock.fn(async () => {
+        throw new Error('Circuit breaker is open');
+      });
+
+      await assert.rejects(
+        turboRedisDataSource.getData({ id: testDataId }),
+        /Data item .* not found in Redis/,
+      );
+    });
+  });
+});

--- a/src/data/turbo-redis-data-source.ts
+++ b/src/data/turbo-redis-data-source.ts
@@ -139,7 +139,7 @@ export class TurboRedisDataSource implements ContiguousDataSource {
     );
   }
 
-  fire<T>(task: CacheServiceTask<T>): Promise<T> {
+  private fire<T>(task: CacheServiceTask<T>): Promise<T> {
     return this.circuitBreaker.fire(task) as Promise<T>;
   }
 

--- a/src/data/turbo-redis-data-source.ts
+++ b/src/data/turbo-redis-data-source.ts
@@ -71,10 +71,12 @@ export class TurboRedisDataSource implements ContiguousDataSource {
   constructor({
     redisHost,
     redisUseTls,
+    redisPort = 6379,
     log,
   }: {
     redisHost: string;
     redisUseTls: boolean;
+    redisPort?: number;
     log: winston.Logger;
   }) {
     this.log = log.child({ class: this.constructor.name });
@@ -82,7 +84,7 @@ export class TurboRedisDataSource implements ContiguousDataSource {
       [
         {
           host: redisHost,
-          port: 6379, // TODO: Parameterize
+          port: redisPort,
         },
       ],
       {
@@ -127,7 +129,6 @@ export class TurboRedisDataSource implements ContiguousDataSource {
       },
     );
 
-    // TODO: Integrate with opossum-prometheus library
     this.circuitBreaker.on('timeout', () =>
       this.log.error('Redis circuit breaker command timed out'),
     );
@@ -211,7 +212,7 @@ export class TurboRedisDataSource implements ContiguousDataSource {
           sourceContentType: payloadContentType,
           verified: false,
           trusted: true,
-          cached: false, // TODO: ?
+          cached: false,
           requestAttributes: requestAttributesHeaders?.attributes,
         };
       }
@@ -375,7 +376,7 @@ export class TurboRedisDataSource implements ContiguousDataSource {
       stream,
       sourceContentType: payloadContentType,
       size: region?.size ?? rawDataItemBuffer.byteLength,
-      cached: false, // TODO: ?
+      cached: false,
       trusted: true,
       verified: false,
       requestAttributes: requestAttributesHeaders?.attributes,

--- a/src/data/turbo-redis-data-source.ts
+++ b/src/data/turbo-redis-data-source.ts
@@ -16,6 +16,7 @@ import winston from 'winston';
 import CircuitBreaker from 'opossum';
 import { bufferToStream, ByteRangeTransform } from '../lib/stream';
 import { generateRequestAttributes } from '../lib/request-attributes';
+import { setUpCircuitBreakerListenerMetrics } from '../metrics';
 
 // A helper type that will allow us to pass around closures involving CacheService activities
 type CacheServiceTask<T> = () => Promise<T>;
@@ -129,6 +130,12 @@ export class TurboRedisDataSource implements ContiguousDataSource {
     // TODO: Integrate with opossum-prometheus library
     this.circuitBreaker.on('timeout', () =>
       this.log.error('Redis circuit breaker command timed out'),
+    );
+
+    setUpCircuitBreakerListenerMetrics(
+      'turbo_elasticache',
+      this.circuitBreaker,
+      this.log,
     );
   }
 

--- a/src/data/turbo-redis-data-source.ts
+++ b/src/data/turbo-redis-data-source.ts
@@ -11,12 +11,12 @@ import {
   ContiguousDataSource,
   Region,
   RequestAttributes,
-} from '../types';
+} from '../types.js';
 import winston from 'winston';
 import CircuitBreaker from 'opossum';
-import { bufferToStream, ByteRangeTransform } from '../lib/stream';
-import { generateRequestAttributes } from '../lib/request-attributes';
-import { setUpCircuitBreakerListenerMetrics } from '../metrics';
+import { bufferToStream, ByteRangeTransform } from '../lib/stream.js';
+import { generateRequestAttributes } from '../lib/request-attributes.js';
+import { setUpCircuitBreakerListenerMetrics } from '../metrics.js';
 
 // A helper type that will allow us to pass around closures involving CacheService activities
 type CacheServiceTask<T> = () => Promise<T>;

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -2868,12 +2868,27 @@ export class StandaloneSqliteDatabase
       },
     );
 
+    // TODO: Remove deprecated circuit breaker metrics setup
     metrics.circuitBreakerMetrics.add([
       this.getDataParentCircuitBreaker,
       this.getDataAttributesCircuitBreaker,
       this.getDataItemAttributesCircuitBreaker,
       this.getTransactionAttributesCircuitBreaker,
     ]);
+    Object.entries({
+      'get-data-parent': this.getDataParentCircuitBreaker,
+      'get-data-attributes': this.getDataAttributesCircuitBreaker,
+      'get-data-item-attributes': this.getDataItemAttributesCircuitBreaker,
+      'get-transaction-attributes': this.getTransactionAttributesCircuitBreaker,
+    } satisfies Partial<Record<metrics.BreakerSource, CircuitBreaker>>).forEach(
+      ([name, breaker]) => {
+        metrics.setUpCircuitBreakerListenerMetrics(
+          name as metrics.BreakerSource,
+          breaker,
+          this.log,
+        );
+      },
+    );
 
     //
     // Initialize method caches

--- a/src/lib/stream.ts
+++ b/src/lib/stream.ts
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { Transform, TransformCallback } from 'node:stream';
+import { Readable, Transform, TransformCallback } from 'node:stream';
 
 export class ByteRangeTransform extends Transform {
   private offset: number;
@@ -52,3 +52,13 @@ export class ByteRangeTransform extends Transform {
     callback();
   }
 }
+
+export const bufferToStream = (buffer: Buffer) => {
+  return new Readable({
+    objectMode: false,
+    read() {
+      this.push(buffer);
+      this.push(null);
+    },
+  });
+};

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -388,7 +388,6 @@ export const cacheSizeBytes = new promClient.Gauge({
 const breakerSourceNames = [
   // Keep this list alphabetized
   'ar-io-data-source',
-  'arns-names-cache',
   'get-data-attributes',
   'get-data-item-attributes',
   'get-data-parent',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -10,7 +10,12 @@ import { Gauge } from 'prom-client';
 /* eslint-disable */
 // @ts-ignore
 import PrometheusMetrics from 'opossum-prometheus';
+import CircuitBreaker from 'opossum';
+import winston from 'winston';
 
+/**
+ * @deprecated Use setUpCircuitBreakerListenerMetrics instead.
+ */
 export const circuitBreakerMetrics = new PrometheusMetrics({
   registry: promClient.register,
 });
@@ -376,3 +381,122 @@ export const cacheSizeBytes = new promClient.Gauge({
   help: 'Current cache size in bytes',
   labelNames: ['store_type', 'data_type'] as const,
 });
+
+//
+// Circuit breaker metrics
+//
+const breakerSourceNames = [
+  // Keep this list alphabetized
+  'ar-io-data-source',
+  'arns-names-cache',
+  'get-data-attributes',
+  'get-data-item-attributes',
+  'get-data-parent',
+  'get-transaction-attributes',
+  'turbo_elasticache',
+] as const;
+export type BreakerSource = (typeof breakerSourceNames)[number];
+const breakerSources: BreakerSource[] = [...breakerSourceNames];
+
+export const circuitBreakerOpenCount = createCounter({
+  name: 'circuit_breaker_open_count',
+  help: 'Count of occasions when a circuit breaker has opened',
+  labelNames: ['breaker'],
+  expectedLabelNames: {
+    breaker: breakerSources,
+  },
+});
+
+export const circuitBreakerState = createGauge({
+  name: 'circuit_breaker_state',
+  help: 'State of the circuit breaker (1 is open, 0 is closed, 0.5 is half open)',
+  labelNames: ['breaker'],
+  expectedLabelNames: {
+    breaker: breakerSources,
+  },
+});
+
+//
+// Helper functions
+//
+
+type CounterCfgPlusLabelValues = promClient.CounterConfiguration<string> & {
+  expectedLabelNames?: Record<string, string[]>;
+};
+
+function createCounter(
+  config: CounterCfgPlusLabelValues,
+): promClient.Counter<string> {
+  const counter = new promClient.Counter(config);
+  // Initialize the counter to zero so it will print right away
+  if (config.expectedLabelNames) {
+    for (const [labelName, labelValues] of Object.entries(
+      config.expectedLabelNames,
+    )) {
+      for (const labelValue of labelValues) {
+        counter.inc({ [labelName]: labelValue }, 0);
+      }
+    }
+  } else {
+    counter.inc(0);
+  }
+  return counter;
+}
+
+type GaugeCfgPlusLabelValues = promClient.GaugeConfiguration<string> & {
+  expectedLabelNames?: Record<string, string[]>;
+};
+
+function createGauge(config: GaugeCfgPlusLabelValues): Gauge<string> {
+  const gauge = new Gauge(config);
+  // Initialize the gauge to zero so it will print right away
+  if (config.expectedLabelNames) {
+    for (const [labelName, labelValues] of Object.entries(
+      config.expectedLabelNames,
+    )) {
+      for (const labelValue of labelValues) {
+        gauge.set({ [labelName]: labelValue }, 0);
+      }
+    }
+  } else {
+    gauge.set(0);
+  }
+  return gauge;
+}
+
+export function setUpCircuitBreakerListenerMetrics(
+  breakerName: BreakerSource,
+  breaker: CircuitBreaker,
+  logger?: winston.Logger | undefined,
+) {
+  breaker.on('open', () => {
+    circuitBreakerOpenCount.inc({
+      breaker: breakerName,
+    });
+    circuitBreakerState.set(
+      {
+        breaker: breakerName,
+      },
+      1,
+    );
+    logger?.error(`${breakerName} circuit breaker opened`);
+  });
+  breaker.on('close', () => {
+    circuitBreakerState.set(
+      {
+        breaker: breakerName,
+      },
+      0,
+    );
+    logger?.info(`${breakerName} circuit breaker closed`);
+  });
+  breaker.on('halfOpen', () => {
+    circuitBreakerState.set(
+      {
+        breaker: breakerName,
+      },
+      0.5,
+    );
+    logger?.info(`${breakerName} circuit breaker half-open`);
+  });
+}

--- a/src/system.ts
+++ b/src/system.ts
@@ -86,6 +86,7 @@ import { awsClient } from './aws-client.js';
 import { BlockedNamesCache } from './blocked-names-cache.js';
 import { KvArNSRegistryStore } from './store/kv-arns-base-name-store.js';
 import { CompositeChunkSource } from './data/composite-chunk-source.js';
+import { RedisDataSource } from './data/redis-data-source.js';
 
 process.on('uncaughtException', (error) => {
   metrics.uncaughtExceptionCounter.inc();
@@ -474,6 +475,15 @@ const turboS3DataSource =
       })
     : undefined;
 
+const turboElasticacheDataSouce =
+  config.AWS_ELASTICACHE_TURBO_HOST !== undefined
+    ? new RedisDataSource({
+        redisHost: config.AWS_ELASTICACHE_TURBO_HOST,
+        redisUseTls: config.AWS_ELASTICACHE_TURBO_USE_TLS,
+        log,
+      })
+    : undefined;
+
 // Create chunk data cache cleanup worker
 export const chunkDataFsCacheCleanupWorker =
   config.ENABLE_CHUNK_DATA_CACHE_CLEANUP
@@ -515,6 +525,8 @@ function getDataSource(sourceName: string): ContiguousDataSource | undefined {
       return s3DataSource;
     case 'turbo-s3':
       return turboS3DataSource;
+    case 'turbo-elasticache':
+      return turboElasticacheDataSouce;
     // ario-peer is for backwards compatibility
     case 'ario-peer':
     case 'ar-io-peers':

--- a/src/system.ts
+++ b/src/system.ts
@@ -86,7 +86,7 @@ import { awsClient } from './aws-client.js';
 import { BlockedNamesCache } from './blocked-names-cache.js';
 import { KvArNSRegistryStore } from './store/kv-arns-base-name-store.js';
 import { CompositeChunkSource } from './data/composite-chunk-source.js';
-import { RedisDataSource } from './data/redis-data-source.js';
+import { TurboRedisDataSource } from './data/turbo-redis-data-source.js';
 
 process.on('uncaughtException', (error) => {
   metrics.uncaughtExceptionCounter.inc();
@@ -477,7 +477,7 @@ const turboS3DataSource =
 
 const turboElasticacheDataSouce =
   config.AWS_ELASTICACHE_TURBO_HOST !== undefined
-    ? new RedisDataSource({
+    ? new TurboRedisDataSource({
         redisHost: config.AWS_ELASTICACHE_TURBO_HOST,
         redisUseTls: config.AWS_ELASTICACHE_TURBO_USE_TLS,
         log,

--- a/src/system.ts
+++ b/src/system.ts
@@ -480,6 +480,10 @@ const turboElasticacheDataSouce =
     ? new TurboRedisDataSource({
         redisHost: config.AWS_ELASTICACHE_TURBO_HOST,
         redisUseTls: config.AWS_ELASTICACHE_TURBO_USE_TLS,
+        redisPort:
+          config.AWS_ELASTICACHE_TURBO_PORT !== undefined
+            ? +config.AWS_ELASTICACHE_TURBO_PORT
+            : undefined,
         log,
       })
     : undefined;


### PR DESCRIPTION
- Adds data source for vertical integration with a Turbo-style Valkey cache. Mirrors the legacy gateway's implementation.
- Add AI-generated unit tests for the class.

General Notes:
- Turbo stores the data items it receives in Valkey if they are up to 256KiB in size
- Nested data items (only 1 level deep) within BDIs sent to Turbo are not stored in raw form; instead they are stored in offsets-parent-and-content-type form relative to their BDI parent data item
- Opossum is used for circuit breaking against Valkey and circuit breaker metrics are collected in the same manner as the other breakers around the app