### PR TITLE
PE-8322: Turbo DynamoDB Data Source

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@ardrive/ardrive-promise-cache": "^1.1.8",
     "@aws-lite/client": "^0.23.2",
     "@aws-lite/s3": "^0.2.6",
+    "@aws-sdk/client-dynamodb": "^3.858.0",
     "@aws-sdk/credential-providers": "^3.823.0",
     "@clickhouse/client": "^1.10.1",
     "@dha-team/arbundles": "^1.0.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -867,6 +867,14 @@ export const AWS_ELASTICACHE_TURBO_PORT = env.varOrUndefined(
   'AWS_ELASTICACHE_TURBO_PORT',
 );
 
+export const AWS_DYNAMODB_TURBO_REGION = env.varOrUndefined(
+  'AWS_DYNAMODB_TURBO_REGION',
+);
+
+export const AWS_DYNAMODB_TURBO_ENDPOINT = env.varOrUndefined(
+  'AWS_DYNAMODB_TURBO_ENDPOINT',
+);
+
 // Chunk data source specifically set-up for interoperability with
 // the legacy arweave gateways
 export const LEGACY_AWS_S3_CHUNK_DATA_BUCKET = env.varOrUndefined(

--- a/src/data/turbo-dynamodb-data-source.test.ts
+++ b/src/data/turbo-dynamodb-data-source.test.ts
@@ -1,0 +1,525 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { describe, it, before, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { mock } from 'node:test';
+import { gzipSync } from 'node:zlib';
+import winston from 'winston';
+
+import { TurboDynamoDbDataSource } from './turbo-dynamodb-data-source.js';
+
+// Table names that match the actual implementation
+const CACHE_TABLE = 'upload-service-cache-local';
+const OFFSETS_TABLE = 'upload-service-offsets-local';
+
+const testDataId = 'UavUNnE2MGZgnkZ_lZor361AX2jBhcRUi3gEbHvPrFQ'; // Valid base64url
+const testParentId = 'ParentDataIdForTesting123456789AbCdEfGhI'; // Valid base64url
+
+let log: winston.Logger;
+let turboDynamoDbDataSource: TurboDynamoDbDataSource;
+let mockDynamoClient: any;
+
+before(async () => {
+  log = winston.createLogger({ silent: true });
+});
+
+beforeEach(async () => {
+  // Set environment variables for table names
+  process.env.DDB_DATA_ITEM_TABLE = CACHE_TABLE;
+  process.env.DDB_OFFSETS_TABLE = OFFSETS_TABLE;
+
+  // Create mock DynamoDB client
+  mockDynamoClient = {
+    send: mock.fn(async () => ({ Item: null })),
+  };
+
+  // Create instance with injected DynamoDB mock
+  turboDynamoDbDataSource = new TurboDynamoDbDataSource({
+    dynamoClient: mockDynamoClient as any,
+    log,
+  });
+});
+
+describe('TurboDynamoDbDataSource', () => {
+  describe('constructor', () => {
+    it('should create instance with provided DynamoDB client', () => {
+      const dataSource = new TurboDynamoDbDataSource({
+        dynamoClient: mockDynamoClient as any,
+        log,
+      });
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      assert.ok(dataSource);
+    });
+
+    it('should create instance with region configuration', () => {
+      const dataSource = new TurboDynamoDbDataSource({
+        region: 'us-east-1',
+        log,
+      });
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      assert.ok(dataSource);
+    });
+
+    it('should throw error when neither client nor region provided', () => {
+      assert.throws(() => {
+        new TurboDynamoDbDataSource({ log });
+      }, /TurboDynamoDbDataSource requires either a DynamoDBClient instance or region configuration/);
+    });
+
+    it('should throw error when region is empty string', () => {
+      assert.throws(() => {
+        new TurboDynamoDbDataSource({ region: '', log });
+      }, /TurboDynamoDbDataSource requires either a DynamoDBClient instance or region configuration/);
+    });
+  });
+
+  describe('getDataItem', () => {
+    it('should return data item when found in the cache table', async () => {
+      mockDynamoClient.send = mock.fn(async (command: any) => {
+        const tableName = command.input.TableName;
+        if (tableName === CACHE_TABLE) {
+          return {
+            Item: {
+              D: { B: gzipSync(Buffer.from('test data')) },
+              P: { N: '0' },
+              C: { S: 'image/png' },
+            },
+          };
+        }
+        return { Item: null };
+      });
+
+      const result = await (turboDynamoDbDataSource as any).getDataItem(
+        testDataId,
+      );
+      assert.ok(result);
+      assert.equal(result.buffer.toString(), 'test data');
+      assert.equal(result.info.payloadDataStart, 0);
+      assert.equal(result.info.payloadContentType, 'image/png');
+    });
+
+    it('should return undefined when item not found', async () => {
+      const result = await (turboDynamoDbDataSource as any).getDataItem(
+        testDataId,
+      );
+      assert.equal(result, undefined);
+    });
+
+    it('should return undefined when payload start missing', async () => {
+      mockDynamoClient.send = mock.fn(async (command: any) => {
+        const tableName = command.input.TableName;
+        if (tableName === CACHE_TABLE) {
+          return {
+            Item: {
+              D: { B: gzipSync(Buffer.from('test data')) },
+              // Missing P field
+              C: { S: 'image/png' },
+            },
+          };
+        }
+        return { Item: null };
+      });
+
+      const result = await (turboDynamoDbDataSource as any).getDataItem(
+        testDataId,
+      );
+      assert.equal(result, undefined);
+    });
+
+    it('should return data with default content type when content type is missing', async () => {
+      mockDynamoClient.send = mock.fn(async (command: any) => {
+        const tableName = command.input.TableName;
+        if (tableName === CACHE_TABLE) {
+          return {
+            Item: {
+              D: { B: gzipSync(Buffer.from('test data')) },
+              P: { N: '0' },
+              // Missing C field
+            },
+          };
+        }
+        return { Item: null };
+      });
+
+      const result = await (turboDynamoDbDataSource as any).getDataItem(
+        testDataId,
+      );
+      // Should still return result with default content type
+      assert.ok(result);
+      assert.equal(result.buffer.toString(), 'test data');
+      assert.equal(result.info.payloadDataStart, 0);
+      assert.equal(result.info.payloadContentType, 'application/octet-stream');
+    });
+
+    it('should handle parent data item that contains nested data', async () => {
+      // Simulate a parent data item that contains nested child data
+      const parentData = 'prefix-data|nested-child-data|suffix-data';
+      mockDynamoClient.send = mock.fn(async (command: any) => {
+        const tableName = command.input.TableName;
+        if (tableName === CACHE_TABLE) {
+          return {
+            Item: {
+              D: { B: gzipSync(Buffer.from(parentData)) },
+              P: { N: '12' }, // payload starts after 'prefix-data|'
+              C: { S: 'application/octet-stream' },
+            },
+          };
+        }
+        return { Item: null };
+      });
+
+      const result = await (turboDynamoDbDataSource as any).getDataItem(
+        testParentId,
+      );
+      assert.ok(result);
+      assert.equal(result.buffer.toString(), parentData);
+      assert.equal(result.info.payloadDataStart, 12);
+      assert.equal(result.info.payloadContentType, 'application/octet-stream');
+    });
+
+    it('should handle large binary data with various content types', async () => {
+      const binaryData = Buffer.alloc(1024, 0xab); // 1KB of binary data
+      mockDynamoClient.send = mock.fn(async (command: any) => {
+        const tableName = command.input.TableName;
+        if (tableName === CACHE_TABLE) {
+          return {
+            Item: {
+              D: { B: gzipSync(binaryData) },
+              P: { N: '100' }, // payload starts at offset 100
+              C: { S: 'application/wasm' },
+            },
+          };
+        }
+        return { Item: null };
+      });
+
+      const result = await (turboDynamoDbDataSource as any).getDataItem(
+        testDataId,
+      );
+      assert.ok(result);
+      assert.equal(result.buffer.length, 1024);
+      assert.equal(result.buffer[0], 0xab);
+      assert.equal(result.info.payloadDataStart, 100);
+      assert.equal(result.info.payloadContentType, 'application/wasm');
+    });
+
+    it('should handle DynamoDB client errors gracefully', async () => {
+      mockDynamoClient.send = mock.fn(async () => {
+        throw new Error('DynamoDB connection timeout');
+      });
+
+      const result = await (turboDynamoDbDataSource as any).getDataItem(
+        testDataId,
+      );
+      assert.equal(result, undefined);
+    });
+  });
+
+  describe('getOffsetsInfo', () => {
+    it('should return offsets info when found in offsets table', async () => {
+      mockDynamoClient.send = mock.fn(async (command: any) => {
+        const tableName = command.input.TableName;
+        if (tableName === OFFSETS_TABLE) {
+          return {
+            Item: {
+              PId: { B: Buffer.from(testParentId, 'base64url') },
+              SP: { N: '1024' }, // startOffsetInParentPayload
+              S: { N: '2048' }, // rawContentLength
+              C: { S: 'application/json' }, // payloadContentType
+              P: { N: '0' }, // payloadDataStart
+            },
+          };
+        }
+        return { Item: null };
+      });
+
+      const result = await (turboDynamoDbDataSource as any).getOffsetsInfo(
+        testDataId,
+      );
+      assert.ok(result);
+      assert.equal(result.dataItemId, testDataId);
+      assert.ok(result.parentInfo);
+      assert.equal(result.parentInfo.parentDataItemId, testParentId);
+      assert.equal(result.parentInfo.startOffsetInParentPayload, 1024);
+      assert.equal(result.rawContentLength, 2048);
+      assert.equal(result.payloadContentType, 'application/json');
+      assert.equal(result.payloadDataStart, 0);
+    });
+
+    it('should return undefined when offsets not found', async () => {
+      const result = await (turboDynamoDbDataSource as any).getOffsetsInfo(
+        testDataId,
+      );
+      assert.equal(result, undefined);
+    });
+
+    it('should handle offsets info without parent info', async () => {
+      mockDynamoClient.send = mock.fn(async (command: any) => {
+        const tableName = command.input.TableName;
+        if (tableName === OFFSETS_TABLE) {
+          return {
+            Item: {
+              // Missing PId and SP (parent info)
+              S: { N: '1024' }, // rawContentLength
+              C: { S: 'text/plain' }, // payloadContentType
+              P: { N: '10' }, // payloadDataStart
+            },
+          };
+        }
+        return { Item: null };
+      });
+
+      const result = await (turboDynamoDbDataSource as any).getOffsetsInfo(
+        testDataId,
+      );
+      assert.ok(result);
+      assert.equal(result.dataItemId, testDataId);
+      assert.equal(result.parentInfo, undefined);
+      assert.equal(result.rawContentLength, 1024);
+      assert.equal(result.payloadContentType, 'text/plain');
+      assert.equal(result.payloadDataStart, 10);
+    });
+
+    it('should handle DynamoDB errors gracefully', async () => {
+      mockDynamoClient.send = mock.fn(async () => {
+        throw new Error('DynamoDB timeout');
+      });
+
+      const result = await (turboDynamoDbDataSource as any).getOffsetsInfo(
+        testDataId,
+      );
+      assert.equal(result, undefined);
+    });
+  });
+
+  describe('getData', () => {
+    it('should return data from nested item using both offsets and cache tables', async () => {
+      // Setup parent data in cache table
+      const parentData = 'header-data__nested-json-payload__footer-data';
+      const nestedJsonData = 'nested-json-payload';
+
+      mockDynamoClient.send = mock.fn(async (command: any) => {
+        const tableName = command.input.TableName;
+
+        // When getting offsets for nested item
+        if (
+          tableName === OFFSETS_TABLE &&
+          Buffer.from(command.input.Key.Id.B).toString('base64url') ===
+            testDataId
+        ) {
+          return {
+            Item: {
+              PId: { B: Buffer.from(testParentId, 'base64url') },
+              SP: { N: '13' }, // offset to start of nested data in parent
+              S: { N: '19' }, // total length of nested item
+              C: { S: 'application/json' },
+              P: { N: '0' }, // payload starts at beginning of nested data
+            },
+          };
+        }
+
+        // When getting parent data from cache table
+        if (
+          tableName === CACHE_TABLE &&
+          Buffer.from(command.input.Key.Id.B).toString('base64url') ===
+            testParentId
+        ) {
+          return {
+            Item: {
+              D: { B: gzipSync(Buffer.from(parentData)) },
+              P: { N: '0' },
+              C: { S: 'application/octet-stream' },
+            },
+          };
+        }
+
+        return { Item: null };
+      });
+
+      const result = await turboDynamoDbDataSource.getData({ id: testDataId });
+
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      assert.ok(result);
+      assert.equal(result.sourceContentType, 'application/json');
+      assert.equal(result.size, 19); // size of nested data
+
+      // Verify stream content contains the nested data
+      let streamData = '';
+      for await (const chunk of result.stream) {
+        streamData += chunk;
+      }
+      assert.equal(streamData, nestedJsonData);
+    });
+
+    it('should throw error when nested item offsets reference missing parent', async () => {
+      // Nested item exists in offsets table but parent is missing from cache table
+      mockDynamoClient.send = mock.fn(async (command: any) => {
+        const tableName = command.input.TableName;
+
+        // When getting offsets for nested item - return valid offsets
+        if (
+          tableName === OFFSETS_TABLE &&
+          Buffer.from(command.input.Key.Id.B).toString('base64url') ===
+            testDataId
+        ) {
+          return {
+            Item: {
+              PId: { B: Buffer.from(testParentId, 'base64url') },
+              SP: { N: '10' },
+              S: { N: '100' },
+              C: { S: 'text/plain' },
+              P: { N: '0' },
+            },
+          };
+        }
+
+        // Parent not found in cache table
+        return { Item: null };
+      });
+
+      await assert.rejects(
+        turboDynamoDbDataSource.getData({ id: testDataId }),
+        /Data item .* not found in DynamoDB/,
+      );
+    });
+
+    it('should throw error when data not found', async () => {
+      await assert.rejects(
+        turboDynamoDbDataSource.getData({ id: testDataId }),
+        /Data item .* not found in DynamoDB/,
+      );
+    });
+
+    it('should return data from raw item when no offsets available', async () => {
+      mockDynamoClient.send = mock.fn(async (command: any) => {
+        const tableName = command.input.TableName;
+        if (tableName === CACHE_TABLE) {
+          return {
+            Item: {
+              D: { B: gzipSync(Buffer.from('test data')) },
+              P: { N: '0' },
+              C: { S: 'image/png' },
+            },
+          };
+        }
+        return { Item: null };
+      });
+
+      const result = await turboDynamoDbDataSource.getData({ id: testDataId });
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      assert.ok(result);
+      assert.equal(result.sourceContentType, 'image/png');
+      assert.equal(result.size, 9); // "test data".length
+    });
+
+    it('should handle region offset and size', async () => {
+      const testPayload = 'test payload data for region';
+      mockDynamoClient.send = mock.fn(async (command: any) => {
+        const tableName = command.input.TableName;
+        if (tableName === CACHE_TABLE) {
+          return {
+            Item: {
+              D: { B: gzipSync(Buffer.from(testPayload)) },
+              P: { N: '5' }, // payloadStartOffset
+              C: { S: 'text/plain' },
+            },
+          };
+        }
+        return { Item: null };
+      });
+
+      const result = await turboDynamoDbDataSource.getData({
+        id: testDataId,
+        region: { offset: 2, size: 7 },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      assert.ok(result);
+      assert.equal(result.size, 7);
+      assert.equal(result.sourceContentType, 'text/plain');
+
+      // Verify stream content with region
+      // The test payload is 'test payload data for region'
+      // With payloadStartOffset=5, the payload starts at 'payload data for region'
+      // With region offset=2, size=7, we get 'yload d'
+      let streamData = '';
+      for await (const chunk of result.stream) {
+        streamData += chunk;
+      }
+      assert.equal(streamData, 'yload d');
+    });
+
+    it('should include request attributes', async () => {
+      mockDynamoClient.send = mock.fn(async (command: any) => {
+        const tableName = command.input.TableName;
+        if (tableName === CACHE_TABLE) {
+          return {
+            Item: {
+              D: { B: gzipSync(Buffer.from('test data')) },
+              P: { N: '0' },
+              C: { S: 'text/plain' },
+            },
+          };
+        }
+        return { Item: null };
+      });
+
+      const result = await turboDynamoDbDataSource.getData({
+        id: testDataId,
+        requestAttributes: { hops: 1, origin: 'test-origin' },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      assert.ok(result);
+      assert.deepEqual(result.requestAttributes, {
+        hops: 2,
+        origin: 'test-origin',
+      });
+    });
+
+    it('should handle payload start offset without region', async () => {
+      const testBuffer = 'test payload data';
+      mockDynamoClient.send = mock.fn(async (command: any) => {
+        const tableName = command.input.TableName;
+        if (tableName === CACHE_TABLE) {
+          return {
+            Item: {
+              D: { B: gzipSync(Buffer.from(testBuffer)) },
+              P: { N: '5' }, // payloadStartOffset
+              C: { S: 'text/plain' },
+            },
+          };
+        }
+        return { Item: null };
+      });
+
+      const result = await turboDynamoDbDataSource.getData({ id: testDataId });
+
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      assert.ok(result);
+      assert.equal(result.sourceContentType, 'text/plain');
+      assert.equal(result.size, 12); // "payload data".length
+
+      // Verify stream content starts at offset 5
+      let streamData = '';
+      for await (const chunk of result.stream) {
+        streamData += chunk;
+      }
+      assert.equal(streamData, 'payload data');
+    });
+
+    it('should throw error when data not found even with region specified', async () => {
+      await assert.rejects(
+        turboDynamoDbDataSource.getData({
+          id: testDataId,
+          region: { offset: 0, size: 5 },
+        }),
+        /Data item .* not found in DynamoDB/,
+      );
+    });
+  });
+});

--- a/src/data/turbo-dynamodb-data-source.ts
+++ b/src/data/turbo-dynamodb-data-source.ts
@@ -1,0 +1,422 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {
+  DynamoDBClient,
+  GetItemCommand,
+  GetItemCommandOutput,
+} from '@aws-sdk/client-dynamodb';
+import CircuitBreaker from 'opossum';
+import { gunzipSync } from 'node:zlib';
+import winston from 'winston';
+
+import { bufferToStream, ByteRangeTransform } from '../lib/stream.js';
+import { generateRequestAttributes } from '../lib/request-attributes.js';
+import { setUpCircuitBreakerListenerMetrics } from '../metrics.js';
+import {
+  ContiguousData,
+  ContiguousDataSource,
+  Region,
+  RequestAttributes,
+} from '../types.js';
+
+type TransactionId = string; // Base64URL encoded string
+
+export interface PayloadInfo {
+  payloadDataStart: number;
+  payloadContentType: string;
+}
+
+export interface DataItemOffsetsInfo {
+  dataItemId: TransactionId;
+  parentInfo?: {
+    parentDataItemId: TransactionId;
+    startOffsetInParentPayload: number;
+  };
+  rawContentLength: number;
+  payloadContentType: string;
+  payloadDataStart: number;
+  rootParentInfo?: {
+    rootParentId: TransactionId;
+    startOffsetInRootTx: number;
+  };
+}
+
+// Table names based on reference implementation
+const cacheTableName =
+  process.env.DDB_DATA_ITEM_TABLE ??
+  `upload-service-cache-${process.env.NODE_ENV ?? 'local'}`;
+const offsetsTableName =
+  process.env.DDB_OFFSETS_TABLE ??
+  `upload-service-offsets-${process.env.NODE_ENV ?? 'local'}`;
+
+// DynamoDB circuit breaker types and utilities
+type DynamoTask<T> = () => Promise<T>;
+
+const dynamoBreakers = new WeakMap<
+  DynamoDBClient,
+  {
+    fire<T>(task: DynamoTask<T>): Promise<T>;
+    breaker: CircuitBreaker<[DynamoTask<unknown>], unknown>;
+  }
+>();
+
+// TODO: Move this to a dynamodb utility module when we get more dynamo use cases
+function breakerForDynamo(client: DynamoDBClient): {
+  fire<T>(task: DynamoTask<T>): Promise<T>;
+  breaker: CircuitBreaker<[DynamoTask<unknown>], unknown>;
+} {
+  const existing = dynamoBreakers.get(client);
+  if (existing) return existing;
+
+  const breaker = new CircuitBreaker<[DynamoTask<unknown>], unknown>(
+    async (...args: [DynamoTask<unknown>]) => {
+      const [task] = args;
+      return task();
+    },
+    {
+      timeout: process.env.NODE_ENV === 'local' ? 10_000 : 3000,
+      errorThresholdPercentage: 10,
+      resetTimeout: 30_000,
+    },
+  );
+
+  breaker.on('timeout', () =>
+    console.error('DynamoDB circuit breaker command timed out'),
+  );
+
+  const wrapper = {
+    fire<T>(task: DynamoTask<T>): Promise<T> {
+      return breaker.fire(task) as Promise<T>;
+    },
+    breaker,
+  };
+
+  dynamoBreakers.set(client, wrapper);
+  return wrapper;
+}
+
+function idToBinary(dataItemId: TransactionId): Uint8Array {
+  return Buffer.from(dataItemId, 'base64url');
+}
+
+/**
+ *  Diagram of offsets represented in DynamoDB offsets info
+ *              ┌────────────────────────────────────────────┐ <---- offset 0 in raw parent
+ *              │            Raw Parent Buffer               │
+ *              │  ┌──────────────────────────────────────┐  │
+ *              │  │           Parent Header              │  │
+ *              │  └──────────────────────────────────────┘  │
+ *              │  ┌──────────────────────────────────────┐  │ <---- payloadDataStart in raw parent
+ *              │  │          Parent Payload              │  │
+ *              │  │                                      │  │
+ *              │  │  ┌────────────────────────────────┐  │  │ <---- startOffsetInParentPayload in parent payload
+ *              │  │  │   Raw Nested Item Buffer       │  │  │       offset 0 in raw nested item
+ *              │  │  │                                │  │  │
+ *              │  │  │ ┌────────────────────────────┐ │  │  │
+ *              │  │  │ │    Nested Item Header      │ │  │  │
+ *              │  │  │ └────────────────────────────┘ │  │  │
+ *              │  │  │ ┌────────────────────────────┐ │  │  │ <---- payloadDataStart in raw nested item
+ *              │  │  │ │   Nested Item Payload      │ │  │  │       0 in nested item payload
+ *              │  │  │ │                            │ │  │  │
+ *              │  │  │ └────────────────────────────┘ │  │  │
+ *              │  │  └────────────────────────────────┘  │  │ <---- rawContentLength in raw nested item
+ *              │  └──────────────────────────────────────┘  │
+ *              └────────────────────────────────────────────┘
+ */
+
+export class TurboDynamoDbDataSource implements ContiguousDataSource {
+  private dynamoClient: DynamoDBClient;
+  private log: winston.Logger;
+  private circuitBreakerWrapper: {
+    fire<T>(task: DynamoTask<T>): Promise<T>;
+    breaker: CircuitBreaker<[DynamoTask<unknown>], unknown>;
+  };
+
+  constructor({
+    dynamoClient,
+    endpoint,
+    region,
+    credentials,
+    log,
+  }: {
+    dynamoClient?: DynamoDBClient;
+    endpoint?: string;
+    region?: string;
+    credentials?: {
+      accessKeyId: string;
+      secretAccessKey: string;
+      sessionToken?: string;
+    };
+    log: winston.Logger;
+  }) {
+    this.log = log.child({ class: this.constructor.name });
+
+    // If a client is provided, use it
+    if (dynamoClient) {
+      this.dynamoClient = dynamoClient;
+    }
+    // Otherwise, create a new client from the provided parameters
+    else if (region !== undefined && region.trim() !== '') {
+      this.dynamoClient = new DynamoDBClient({
+        endpoint,
+        region,
+        credentials,
+      });
+    }
+    // If neither client nor region is provided, throw an error
+    else {
+      throw new Error(
+        'TurboDynamoDbDataSource requires either a DynamoDBClient instance or region configuration',
+      );
+    }
+
+    this.circuitBreakerWrapper = breakerForDynamo(this.dynamoClient);
+
+    setUpCircuitBreakerListenerMetrics(
+      'turbo_dynamodb',
+      this.circuitBreakerWrapper.breaker,
+      this.log,
+    );
+  }
+
+  async getData({
+    id,
+    requestAttributes,
+    region,
+  }: {
+    id: string;
+    requestAttributes?: RequestAttributes;
+    region?: Region;
+  }): Promise<ContiguousData> {
+    try {
+      // First try to get offsets info for nested data items
+      // TODO: Move this to an offsets provider once those are worked into the architecture
+      const offsetsInfo = await this.getOffsetsInfo(id);
+      if (offsetsInfo) {
+        this.log.debug(`Turbo DynamoDB: Found offsets for ${id}`, {
+          offsetsInfo,
+        });
+
+        const {
+          parentInfo,
+          payloadContentType,
+          payloadDataStart,
+          rawContentLength,
+        } = offsetsInfo;
+
+        if (!parentInfo) {
+          throw new Error(
+            `Invalid offsets info for ${id}: missing parent info`,
+          );
+        }
+
+        const { parentDataItemId, startOffsetInParentPayload } = parentInfo;
+        const payloadLength = rawContentLength - payloadDataStart;
+
+        // Recursively get parent data with the appropriate offset
+        const nestedDataItemDataStream = await this.getData({
+          id: parentDataItemId,
+          region: {
+            offset:
+              startOffsetInParentPayload +
+              payloadDataStart +
+              (region?.offset ?? 0),
+            size: region?.size ?? payloadLength,
+          },
+        });
+
+        if (nestedDataItemDataStream?.stream === undefined) {
+          const errMsg = `Turbo DynamoDB: Parent ${parentDataItemId} payload data not found for nested data item ${id}`;
+          this.log.debug(errMsg, {
+            offsetsInfo,
+          });
+          throw new Error(errMsg);
+        }
+
+        this.log.debug(
+          `Turbo DynamoDB: Returning stream for nested data item ${id} from offset into data for parent ${parentDataItemId}`,
+          {
+            offsetsInfo,
+          },
+        );
+
+        const requestAttributesHeaders =
+          generateRequestAttributes(requestAttributes);
+
+        return {
+          stream: nestedDataItemDataStream.stream,
+          size: nestedDataItemDataStream.size,
+          sourceContentType: payloadContentType,
+          verified: false,
+          trusted: true,
+          cached: false,
+          requestAttributes: requestAttributesHeaders?.attributes,
+        };
+      }
+
+      // If no offsets info, try to get the raw data item directly
+      const dataItem = await this.getDataItem(id);
+
+      if (dataItem) {
+        this.log.debug(`Turbo DynamoDB: Found raw data for ${id}`, {
+          payloadInfo: dataItem.info,
+        });
+
+        return this.getDataStreamFromRawBuffer({
+          buffer: dataItem.buffer,
+          payloadInfo: dataItem.info,
+          region,
+          requestAttributes,
+        });
+      }
+
+      this.log.debug(`Turbo DynamoDB: No data or offsets found for ${id}`);
+      throw new Error(`Data item ${id} not found in DynamoDB`);
+    } catch (error) {
+      this.log.error(
+        `Turbo DynamoDB error retrieving payload data for ${id}`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  private async getDataItem(
+    dataItemId: TransactionId,
+  ): Promise<{ buffer: Buffer; info: PayloadInfo } | undefined> {
+    try {
+      const res = (await this.circuitBreakerWrapper.fire(async () => {
+        return this.dynamoClient.send(
+          new GetItemCommand({
+            TableName: cacheTableName,
+            Key: {
+              Id: { B: idToBinary(dataItemId) },
+            },
+          }),
+        );
+      })) as GetItemCommandOutput;
+
+      if (!res.Item) {
+        return undefined;
+      }
+
+      const buffer =
+        res.Item.D && res.Item.D.B
+          ? Buffer.from(gunzipSync(res.Item.D.B as Uint8Array))
+          : Buffer.alloc(0);
+      if (!res.Item.P?.N) {
+        throw new Error(`Data item ${dataItemId} has no payload start!`);
+      }
+      const payloadDataStart = +(res.Item.P?.N ?? 0);
+      if (res.Item.C?.S === undefined || res.Item.C.S === '') {
+        this.log.error(`Data item ${dataItemId} has no content type!`);
+      }
+      const payloadContentType = res.Item.C?.S ?? 'application/octet-stream';
+
+      return {
+        buffer,
+        info: { payloadDataStart, payloadContentType },
+      };
+    } catch (error) {
+      this.log.error(`Error retrieving data item ${dataItemId} from DynamoDB`, {
+        error,
+      });
+      return undefined;
+    }
+  }
+
+  private async getOffsetsInfo(
+    dataItemId: TransactionId,
+  ): Promise<DataItemOffsetsInfo | undefined> {
+    try {
+      const res = (await this.circuitBreakerWrapper.fire(async () => {
+        return this.dynamoClient.send(
+          new GetItemCommand({
+            TableName: offsetsTableName,
+            Key: {
+              Id: { B: idToBinary(dataItemId) },
+            },
+          }),
+        );
+      })) as GetItemCommandOutput;
+
+      if (!res.Item) {
+        return undefined;
+      }
+
+      return {
+        dataItemId,
+        ...(res.Item.PId?.B
+          ? {
+              parentInfo: {
+                parentDataItemId: Buffer.from(res.Item.PId.B).toString(
+                  'base64url',
+                ),
+                startOffsetInParentPayload: +(res.Item.SP?.N ?? 0),
+              },
+            }
+          : {}),
+        ...(res.Item.RId?.B
+          ? {
+              rootParentInfo: {
+                rootParentId: Buffer.from(res.Item.RId.B).toString('base64url'),
+                startOffsetInRootTx: +(res.Item.SR?.N ?? 0),
+              },
+            }
+          : {}),
+        rawContentLength: +(res.Item.S?.N ?? 0),
+        payloadContentType: res.Item.C?.S ?? 'application/octet-stream',
+        payloadDataStart: +(res.Item.P?.N ?? 0),
+      };
+    } catch (error) {
+      this.log.error(`Error retrieving offsets for data item ${dataItemId}`, {
+        error,
+      });
+      return undefined;
+    }
+  }
+
+  private getDataStreamFromRawBuffer({
+    buffer,
+    payloadInfo,
+    region,
+    requestAttributes,
+  }: {
+    buffer: Buffer;
+    payloadInfo: { payloadDataStart: number; payloadContentType: string };
+    region?: Region;
+    requestAttributes?: RequestAttributes;
+  }): ContiguousData {
+    const { payloadDataStart, payloadContentType } = payloadInfo;
+
+    let stream = bufferToStream(
+      buffer.subarray(payloadDataStart, buffer.byteLength),
+    );
+
+    if (region) {
+      const byteRangeStream = new ByteRangeTransform(
+        region.offset,
+        region.size,
+      );
+      stream = stream.pipe(byteRangeStream);
+    }
+
+    const requestAttributesHeaders =
+      generateRequestAttributes(requestAttributes);
+
+    return {
+      stream,
+      sourceContentType: payloadContentType,
+      size: region?.size ?? buffer.byteLength - payloadDataStart,
+      cached: false,
+      trusted: true,
+      verified: false,
+      requestAttributes: requestAttributesHeaders?.attributes,
+    };
+  }
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -393,6 +393,7 @@ const breakerSourceNames = [
   'get-data-parent',
   'get-transaction-attributes',
   'turbo_elasticache',
+  'turbo_dynamodb',
 ] as const;
 export type BreakerSource = (typeof breakerSourceNames)[number];
 const breakerSources: BreakerSource[] = [...breakerSourceNames];

--- a/src/system.ts
+++ b/src/system.ts
@@ -87,6 +87,7 @@ import { BlockedNamesCache } from './blocked-names-cache.js';
 import { KvArNSRegistryStore } from './store/kv-arns-base-name-store.js';
 import { CompositeChunkSource } from './data/composite-chunk-source.js';
 import { TurboRedisDataSource } from './data/turbo-redis-data-source.js';
+import { TurboDynamoDbDataSource } from './data/turbo-dynamodb-data-source.js';
 
 process.on('uncaughtException', (error) => {
   metrics.uncaughtExceptionCounter.inc();
@@ -488,6 +489,15 @@ const turboElasticacheDataSource =
       })
     : undefined;
 
+const turboDynamoDBDataSource =
+  config.AWS_DYNAMODB_TURBO_REGION !== undefined
+    ? new TurboDynamoDbDataSource({
+        log,
+        region: config.AWS_DYNAMODB_TURBO_REGION,
+        endpoint: config.AWS_DYNAMODB_TURBO_ENDPOINT,
+      })
+    : undefined;
+
 // Create chunk data cache cleanup worker
 export const chunkDataFsCacheCleanupWorker =
   config.ENABLE_CHUNK_DATA_CACHE_CLEANUP
@@ -531,6 +541,8 @@ function getDataSource(sourceName: string): ContiguousDataSource | undefined {
       return turboS3DataSource;
     case 'turbo-elasticache':
       return turboElasticacheDataSource;
+    case 'turbo-dynamodb':
+      return turboDynamoDBDataSource;
     // ario-peer is for backwards compatibility
     case 'ario-peer':
     case 'ar-io-peers':

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,6 +288,55 @@
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
+"@aws-sdk/client-dynamodb@^3.858.0":
+  version "3.858.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-dynamodb/-/client-dynamodb-3.858.0.tgz#1c23f721c20decf9253035292f54afb69dfb6534"
+  integrity sha512-QB9levGfBBR11WbCMEUInpED9W4wLtnU4LKgheul2z+TX59xHk5l7G0hd9+sW9wWyInZ+MDLRNDhGfSlpqw80g==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "3.858.0"
+    "@aws-sdk/credential-provider-node" "3.858.0"
+    "@aws-sdk/middleware-endpoint-discovery" "3.840.0"
+    "@aws-sdk/middleware-host-header" "3.840.0"
+    "@aws-sdk/middleware-logger" "3.840.0"
+    "@aws-sdk/middleware-recursion-detection" "3.840.0"
+    "@aws-sdk/middleware-user-agent" "3.858.0"
+    "@aws-sdk/region-config-resolver" "3.840.0"
+    "@aws-sdk/types" "3.840.0"
+    "@aws-sdk/util-endpoints" "3.848.0"
+    "@aws-sdk/util-user-agent-browser" "3.840.0"
+    "@aws-sdk/util-user-agent-node" "3.858.0"
+    "@smithy/config-resolver" "^4.1.4"
+    "@smithy/core" "^3.7.2"
+    "@smithy/fetch-http-handler" "^5.1.0"
+    "@smithy/hash-node" "^4.0.4"
+    "@smithy/invalid-dependency" "^4.0.4"
+    "@smithy/middleware-content-length" "^4.0.4"
+    "@smithy/middleware-endpoint" "^4.1.17"
+    "@smithy/middleware-retry" "^4.1.18"
+    "@smithy/middleware-serde" "^4.0.8"
+    "@smithy/middleware-stack" "^4.0.4"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/node-http-handler" "^4.1.0"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/smithy-client" "^4.4.9"
+    "@smithy/types" "^4.3.1"
+    "@smithy/url-parser" "^4.0.4"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.25"
+    "@smithy/util-defaults-mode-node" "^4.0.25"
+    "@smithy/util-endpoints" "^3.0.6"
+    "@smithy/util-middleware" "^4.0.4"
+    "@smithy/util-retry" "^4.0.6"
+    "@smithy/util-utf8" "^4.0.0"
+    "@smithy/util-waiter" "^4.0.6"
+    "@types/uuid" "^9.0.1"
+    tslib "^2.6.2"
+    uuid "^9.0.1"
+
 "@aws-sdk/client-s3@3":
   version "3.743.0"
   resolved "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.743.0.tgz"
@@ -438,6 +487,50 @@
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
+"@aws-sdk/client-sso@3.858.0":
+  version "3.858.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.858.0.tgz#cae074f8bc3cfe276320f54e66ad735cc1551408"
+  integrity sha512-iXuZQs4KH6a3Pwnt0uORalzAZ5EXRPr3lBYAsdNwkP8OYyoUz5/TE3BLyw7ceEh0rj4QKGNnNALYo1cDm0EV8w==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "3.858.0"
+    "@aws-sdk/middleware-host-header" "3.840.0"
+    "@aws-sdk/middleware-logger" "3.840.0"
+    "@aws-sdk/middleware-recursion-detection" "3.840.0"
+    "@aws-sdk/middleware-user-agent" "3.858.0"
+    "@aws-sdk/region-config-resolver" "3.840.0"
+    "@aws-sdk/types" "3.840.0"
+    "@aws-sdk/util-endpoints" "3.848.0"
+    "@aws-sdk/util-user-agent-browser" "3.840.0"
+    "@aws-sdk/util-user-agent-node" "3.858.0"
+    "@smithy/config-resolver" "^4.1.4"
+    "@smithy/core" "^3.7.2"
+    "@smithy/fetch-http-handler" "^5.1.0"
+    "@smithy/hash-node" "^4.0.4"
+    "@smithy/invalid-dependency" "^4.0.4"
+    "@smithy/middleware-content-length" "^4.0.4"
+    "@smithy/middleware-endpoint" "^4.1.17"
+    "@smithy/middleware-retry" "^4.1.18"
+    "@smithy/middleware-serde" "^4.0.8"
+    "@smithy/middleware-stack" "^4.0.4"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/node-http-handler" "^4.1.0"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/smithy-client" "^4.4.9"
+    "@smithy/types" "^4.3.1"
+    "@smithy/url-parser" "^4.0.4"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.25"
+    "@smithy/util-defaults-mode-node" "^4.0.25"
+    "@smithy/util-endpoints" "^3.0.6"
+    "@smithy/util-middleware" "^4.0.4"
+    "@smithy/util-retry" "^4.0.6"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/core@3.734.0":
   version "3.734.0"
   resolved "https://registry.npmjs.org/@aws-sdk/core/-/core-3.734.0.tgz"
@@ -476,6 +569,27 @@
     fast-xml-parser "4.4.1"
     tslib "^2.6.2"
 
+"@aws-sdk/core@3.858.0":
+  version "3.858.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.858.0.tgz#27f7bc3e556bfeb31cbb767fd59377dabaea3d9e"
+  integrity sha512-iWm4QLAS+/XMlnecIU1Y33qbBr1Ju+pmWam3xVCPlY4CSptKpVY+2hXOnmg9SbHAX9C005fWhrIn51oDd00c9A==
+  dependencies:
+    "@aws-sdk/types" "3.840.0"
+    "@aws-sdk/xml-builder" "3.821.0"
+    "@smithy/core" "^3.7.2"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/signature-v4" "^5.1.2"
+    "@smithy/smithy-client" "^4.4.9"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.4"
+    "@smithy/util-utf8" "^4.0.0"
+    fast-xml-parser "5.2.5"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-cognito-identity@3.823.0":
   version "3.823.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.823.0.tgz"
@@ -505,6 +619,17 @@
   dependencies:
     "@aws-sdk/core" "3.823.0"
     "@aws-sdk/types" "3.821.0"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-env@3.858.0":
+  version "3.858.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.858.0.tgz#6dd149bbf7334be11fafdce4cd238db9c32cb6cd"
+  integrity sha512-kZsGyh2BoSRguzlcGtzdLhw/l/n3KYAC+/l/H0SlsOq3RLHF6tO/cRdsLnwoix2bObChHUp03cex63o1gzdx/Q==
+  dependencies:
+    "@aws-sdk/core" "3.858.0"
+    "@aws-sdk/types" "3.840.0"
     "@smithy/property-provider" "^4.0.4"
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
@@ -541,6 +666,22 @@
     "@smithy/util-stream" "^4.2.2"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-http@3.858.0":
+  version "3.858.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.858.0.tgz#b384babaa45814a9f8aff29d88185ef592deabac"
+  integrity sha512-GDnfYl3+NPJQ7WQQYOXEA489B212NinpcIDD7rpsB6IWUPo8yDjT5NceK4uUkIR3MFpNCGt9zd/z6NNLdB2fuQ==
+  dependencies:
+    "@aws-sdk/core" "3.858.0"
+    "@aws-sdk/types" "3.840.0"
+    "@smithy/fetch-http-handler" "^5.1.0"
+    "@smithy/node-http-handler" "^4.1.0"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/smithy-client" "^4.4.9"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-stream" "^4.2.3"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-ini@3.743.0":
   version "3.743.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.743.0.tgz"
@@ -573,6 +714,25 @@
     "@aws-sdk/credential-provider-web-identity" "3.823.0"
     "@aws-sdk/nested-clients" "3.823.0"
     "@aws-sdk/types" "3.821.0"
+    "@smithy/credential-provider-imds" "^4.0.6"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/shared-ini-file-loader" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-ini@3.858.0":
+  version "3.858.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.858.0.tgz#b20a2022f2ff466b0d85bb3defd186b518c103ac"
+  integrity sha512-2ZoVJW2Gg4LjpyZPvzOV+EOJgjuaVN/+mvAxAU6JU5OJJUzqNuW1Mi7VXFdZHcF6weXoKHfzYZVR0uuVapu1lQ==
+  dependencies:
+    "@aws-sdk/core" "3.858.0"
+    "@aws-sdk/credential-provider-env" "3.858.0"
+    "@aws-sdk/credential-provider-http" "3.858.0"
+    "@aws-sdk/credential-provider-process" "3.858.0"
+    "@aws-sdk/credential-provider-sso" "3.858.0"
+    "@aws-sdk/credential-provider-web-identity" "3.858.0"
+    "@aws-sdk/nested-clients" "3.858.0"
+    "@aws-sdk/types" "3.840.0"
     "@smithy/credential-provider-imds" "^4.0.6"
     "@smithy/property-provider" "^4.0.4"
     "@smithy/shared-ini-file-loader" "^4.0.4"
@@ -615,6 +775,24 @@
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-node@3.858.0":
+  version "3.858.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.858.0.tgz#24b4e41ca36a97e22dfab99b77f83c38a6eec4e4"
+  integrity sha512-clHADxFnMH3R3+7E1bKWEWgoHmLMep2VlmUFDYV4Hw17JR563RRQpzlF2QRCTjSNUjH48dd6AVxEDfh7461X6Q==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.858.0"
+    "@aws-sdk/credential-provider-http" "3.858.0"
+    "@aws-sdk/credential-provider-ini" "3.858.0"
+    "@aws-sdk/credential-provider-process" "3.858.0"
+    "@aws-sdk/credential-provider-sso" "3.858.0"
+    "@aws-sdk/credential-provider-web-identity" "3.858.0"
+    "@aws-sdk/types" "3.840.0"
+    "@smithy/credential-provider-imds" "^4.0.6"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/shared-ini-file-loader" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-process@3.734.0":
   version "3.734.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.734.0.tgz"
@@ -634,6 +812,18 @@
   dependencies:
     "@aws-sdk/core" "3.823.0"
     "@aws-sdk/types" "3.821.0"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/shared-ini-file-loader" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@3.858.0":
+  version "3.858.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.858.0.tgz#80583aa76d04643e9ed5c6cb47aab1fc81138dd8"
+  integrity sha512-l5LJWZJMRaZ+LhDjtupFUKEC5hAjgvCRrOvV5T60NCUBOy0Ozxa7Sgx3x+EOwiruuoh3Cn9O+RlbQlJX6IfZIw==
+  dependencies:
+    "@aws-sdk/core" "3.858.0"
+    "@aws-sdk/types" "3.840.0"
     "@smithy/property-provider" "^4.0.4"
     "@smithy/shared-ini-file-loader" "^4.0.4"
     "@smithy/types" "^4.3.1"
@@ -667,6 +857,20 @@
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-sso@3.858.0":
+  version "3.858.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.858.0.tgz#49e6ece2d0f0631bb822bccc0b6e6d69349abdd7"
+  integrity sha512-YPAsEm4dUPCYO5nC/lv6fPhiihm70rh2Zdg/gmjOiD/7TIR+OT622bW+E1qBJ9s+dzOdAmutGSCmVbxp8gTM5Q==
+  dependencies:
+    "@aws-sdk/client-sso" "3.858.0"
+    "@aws-sdk/core" "3.858.0"
+    "@aws-sdk/token-providers" "3.858.0"
+    "@aws-sdk/types" "3.840.0"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/shared-ini-file-loader" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-web-identity@3.743.0":
   version "3.743.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.743.0.tgz"
@@ -687,6 +891,18 @@
     "@aws-sdk/core" "3.823.0"
     "@aws-sdk/nested-clients" "3.823.0"
     "@aws-sdk/types" "3.821.0"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@3.858.0":
+  version "3.858.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.858.0.tgz#9fc99ef87fa0a39f6a87c95c2134b799fc4e54c9"
+  integrity sha512-8iULWsH83iZDdUuiDsRb83M0NqIlXjlDbJUIddVsIrfWp4NmanKw77SV6yOZ66nuJjPsn9j7RDb9bfEPCy5SWA==
+  dependencies:
+    "@aws-sdk/core" "3.858.0"
+    "@aws-sdk/nested-clients" "3.858.0"
+    "@aws-sdk/types" "3.840.0"
     "@smithy/property-provider" "^4.0.4"
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
@@ -716,6 +932,14 @@
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
+"@aws-sdk/endpoint-cache@3.804.0":
+  version "3.804.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/endpoint-cache/-/endpoint-cache-3.804.0.tgz#4192196aa3e9f6cef8b0967a2c493648d38c627c"
+  integrity sha512-TQVDkA/lV6ua75ELZaichMzlp6x7tDa1bqdy/+0ZftmODPtKXuOOEcJxmdN7Ui/YRo1gkRz2D9txYy7IlNg1Og==
+  dependencies:
+    mnemonist "0.38.3"
+    tslib "^2.6.2"
+
 "@aws-sdk/middleware-bucket-endpoint@3.734.0":
   version "3.734.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.734.0.tgz"
@@ -727,6 +951,18 @@
     "@smithy/protocol-http" "^5.0.1"
     "@smithy/types" "^4.1.0"
     "@smithy/util-config-provider" "^4.0.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-endpoint-discovery@3.840.0":
+  version "3.840.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.840.0.tgz#0db23aa407723f839e1b42b4f535ff50dfeaa347"
+  integrity sha512-IJDShY5NOg9luTE8h4o2Bm+gsPnHIU0tVWCjMz8vZMLevYjKdIsatcXiu3huTOjKSnelzC9fBHfU6KKsHmjjBQ==
+  dependencies:
+    "@aws-sdk/endpoint-cache" "3.804.0"
+    "@aws-sdk/types" "3.840.0"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
 "@aws-sdk/middleware-expect-continue@3.734.0":
@@ -778,6 +1014,16 @@
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
+"@aws-sdk/middleware-host-header@3.840.0":
+  version "3.840.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.840.0.tgz#7c8b163fb13d588b87523b53f7d98de73262e83f"
+  integrity sha512-ub+hXJAbAje94+Ya6c6eL7sYujoE8D4Bumu1NUI8TXjUhVVn0HzVWQjpRLshdLsUp1AW7XyeJaxyajRaJQ8+Xg==
+  dependencies:
+    "@aws-sdk/types" "3.840.0"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/middleware-location-constraint@3.734.0":
   version "3.734.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.734.0.tgz"
@@ -805,6 +1051,15 @@
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
+"@aws-sdk/middleware-logger@3.840.0":
+  version "3.840.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.840.0.tgz#d92ade1817ac7dc78a3567c1239bb1a3f3b1b57a"
+  integrity sha512-lSV8FvjpdllpGaRspywss4CtXV8M7NNNH+2/j86vMH+YCOZ6fu2T/TyFd/tHwZ92vDfHctWkRbQxg0bagqwovA==
+  dependencies:
+    "@aws-sdk/types" "3.840.0"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/middleware-recursion-detection@3.734.0":
   version "3.734.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz"
@@ -821,6 +1076,16 @@
   integrity sha512-efmaifbhBoqKG3bAoEfDdcM8hn1psF+4qa7ykWuYmfmah59JBeqHLfz5W9m9JoTwoKPkFcVLWZxnyZzAnVBOIg==
   dependencies:
     "@aws-sdk/types" "3.821.0"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-recursion-detection@3.840.0":
+  version "3.840.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.840.0.tgz#8ea2c00af258db0b64ea394e044cedb6101b5ffd"
+  integrity sha512-Gu7lGDyfddyhIkj1Z1JtrY5NHb5+x/CRiB87GjaSrKxkDaydtX2CU977JIABtt69l9wLbcGDIQ+W0uJ5xPof7g==
+  dependencies:
+    "@aws-sdk/types" "3.840.0"
     "@smithy/protocol-http" "^5.1.2"
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
@@ -876,6 +1141,19 @@
     "@aws-sdk/types" "3.821.0"
     "@aws-sdk/util-endpoints" "3.821.0"
     "@smithy/core" "^3.5.1"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-user-agent@3.858.0":
+  version "3.858.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.858.0.tgz#fee39eb6e5c56e704880f18efaf76ce60be980b0"
+  integrity sha512-pC3FT/sRZ6n5NyXiTVu9dpf1D9j3YbJz3XmeOOwJqO/Mib2PZyIQktvNMPgwaC5KMVB1zWqS5bmCwxpMOnq0UQ==
+  dependencies:
+    "@aws-sdk/core" "3.858.0"
+    "@aws-sdk/types" "3.840.0"
+    "@aws-sdk/util-endpoints" "3.848.0"
+    "@smithy/core" "^3.7.2"
     "@smithy/protocol-http" "^5.1.2"
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
@@ -968,6 +1246,50 @@
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
+"@aws-sdk/nested-clients@3.858.0":
+  version "3.858.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.858.0.tgz#171466f44a65818b6233fd38dae6116344bd4401"
+  integrity sha512-ChdIj80T2whoWbovmO7o8ICmhEB2S9q4Jes9MBnKAPm69PexcJAK2dQC8yI4/iUP8b3+BHZoUPrYLWjBxIProQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "3.858.0"
+    "@aws-sdk/middleware-host-header" "3.840.0"
+    "@aws-sdk/middleware-logger" "3.840.0"
+    "@aws-sdk/middleware-recursion-detection" "3.840.0"
+    "@aws-sdk/middleware-user-agent" "3.858.0"
+    "@aws-sdk/region-config-resolver" "3.840.0"
+    "@aws-sdk/types" "3.840.0"
+    "@aws-sdk/util-endpoints" "3.848.0"
+    "@aws-sdk/util-user-agent-browser" "3.840.0"
+    "@aws-sdk/util-user-agent-node" "3.858.0"
+    "@smithy/config-resolver" "^4.1.4"
+    "@smithy/core" "^3.7.2"
+    "@smithy/fetch-http-handler" "^5.1.0"
+    "@smithy/hash-node" "^4.0.4"
+    "@smithy/invalid-dependency" "^4.0.4"
+    "@smithy/middleware-content-length" "^4.0.4"
+    "@smithy/middleware-endpoint" "^4.1.17"
+    "@smithy/middleware-retry" "^4.1.18"
+    "@smithy/middleware-serde" "^4.0.8"
+    "@smithy/middleware-stack" "^4.0.4"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/node-http-handler" "^4.1.0"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/smithy-client" "^4.4.9"
+    "@smithy/types" "^4.3.1"
+    "@smithy/url-parser" "^4.0.4"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.25"
+    "@smithy/util-defaults-mode-node" "^4.0.25"
+    "@smithy/util-endpoints" "^3.0.6"
+    "@smithy/util-middleware" "^4.0.4"
+    "@smithy/util-retry" "^4.0.6"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/region-config-resolver@3.734.0":
   version "3.734.0"
   resolved "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz"
@@ -986,6 +1308,18 @@
   integrity sha512-t8og+lRCIIy5nlId0bScNpCkif8sc0LhmtaKsbm0ZPm3sCa/WhCbSZibjbZ28FNjVCV+p0D9RYZx0VDDbtWyjw==
   dependencies:
     "@aws-sdk/types" "3.821.0"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-config-provider" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.4"
+    tslib "^2.6.2"
+
+"@aws-sdk/region-config-resolver@3.840.0":
+  version "3.840.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.840.0.tgz#240690ead3131c4c47186b4929776439fe2f6729"
+  integrity sha512-Qjnxd/yDv9KpIMWr90ZDPtRj0v75AqGC92Lm9+oHXZ8p1MjG5JE2CW0HL8JRgK9iKzgKBL7pPQRXI8FkvEVfrA==
+  dependencies:
+    "@aws-sdk/types" "3.840.0"
     "@smithy/node-config-provider" "^4.1.3"
     "@smithy/types" "^4.3.1"
     "@smithy/util-config-provider" "^4.0.0"
@@ -1029,6 +1363,19 @@
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
+"@aws-sdk/token-providers@3.858.0":
+  version "3.858.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.858.0.tgz#6261263342a93a89300de7224ef2580dc716db89"
+  integrity sha512-uQ3cVpqbkaxq3Hd8zip0pcOFsP731g+m0zsobQ7Bmqjq4/PHcehTov8i3W9+7sBHocOM61/qrQksPlW0TPuPAA==
+  dependencies:
+    "@aws-sdk/core" "3.858.0"
+    "@aws-sdk/nested-clients" "3.858.0"
+    "@aws-sdk/types" "3.840.0"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/shared-ini-file-loader" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/types@3.734.0", "@aws-sdk/types@^3.222.0":
   version "3.734.0"
   resolved "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz"
@@ -1041,6 +1388,14 @@
   version "3.821.0"
   resolved "https://registry.npmjs.org/@aws-sdk/types/-/types-3.821.0.tgz"
   integrity sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==
+  dependencies:
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@3.840.0":
+  version "3.840.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.840.0.tgz#aadc6843d5c1f24b3d1d228059e702a355bf07c3"
+  integrity sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==
   dependencies:
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
@@ -1072,6 +1427,17 @@
     "@smithy/util-endpoints" "^3.0.6"
     tslib "^2.6.2"
 
+"@aws-sdk/util-endpoints@3.848.0":
+  version "3.848.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz#dea15ac0949fcbc518426fb4a86d1e9bd53433db"
+  integrity sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==
+  dependencies:
+    "@aws-sdk/types" "3.840.0"
+    "@smithy/types" "^4.3.1"
+    "@smithy/url-parser" "^4.0.4"
+    "@smithy/util-endpoints" "^3.0.6"
+    tslib "^2.6.2"
+
 "@aws-sdk/util-locate-window@^3.0.0":
   version "3.723.0"
   resolved "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.723.0.tgz"
@@ -1099,6 +1465,16 @@
     bowser "^2.11.0"
     tslib "^2.6.2"
 
+"@aws-sdk/util-user-agent-browser@3.840.0":
+  version "3.840.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.840.0.tgz#6c2f55494352a86048c52852b0c357bb21905984"
+  integrity sha512-JdyZM3EhhL4PqwFpttZu1afDpPJCCc3eyZOLi+srpX11LsGj6sThf47TYQN75HT1CarZ7cCdQHGzP2uy3/xHfQ==
+  dependencies:
+    "@aws-sdk/types" "3.840.0"
+    "@smithy/types" "^4.3.1"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/util-user-agent-node@3.743.0":
   version "3.743.0"
   resolved "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.743.0.tgz"
@@ -1117,6 +1493,17 @@
   dependencies:
     "@aws-sdk/middleware-user-agent" "3.823.0"
     "@aws-sdk/types" "3.821.0"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-node@3.858.0":
+  version "3.858.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.858.0.tgz#bdf767443486371f1c7432dd4d1e178f8a45074c"
+  integrity sha512-T1m05QlN8hFpx5/5duMjS8uFSK5e6EXP45HQRkZULVkL3DK+jMaxsnh3KLl5LjUoHn/19M4HM0wNUBhYp4Y2Yw==
+  dependencies:
+    "@aws-sdk/middleware-user-agent" "3.858.0"
+    "@aws-sdk/types" "3.840.0"
     "@smithy/node-config-provider" "^4.1.3"
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
@@ -3196,6 +3583,21 @@
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
+"@smithy/core@^3.7.2":
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.7.2.tgz#ae21591dbb983df7d986cc984123cf43f64e3a5a"
+  integrity sha512-JoLw59sT5Bm8SAjFCYZyuCGxK8y3vovmoVbZWLDPTH5XpPEIwpFd9m90jjVMwoypDuB/SdVgje5Y4T7w50lJaw==
+  dependencies:
+    "@smithy/middleware-serde" "^4.0.8"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.4"
+    "@smithy/util-stream" "^4.2.3"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
 "@smithy/credential-provider-imds@^4.0.1", "@smithy/credential-provider-imds@^4.0.6":
   version "4.0.6"
   resolved "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.6.tgz"
@@ -3256,6 +3658,17 @@
   version "5.0.4"
   resolved "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz"
   integrity sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==
+  dependencies:
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/querystring-builder" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-base64" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/fetch-http-handler@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.0.tgz#387abd9ec6c8ff0af33b268c0f6ccb289c1b1563"
+  integrity sha512-mADw7MS0bYe2OGKkHYMaqarOXuDwRbO6ArD91XhHcl2ynjGCFF+hvqf0LyQcYxkA1zaWjefSkU7Ne9mqgApSgQ==
   dependencies:
     "@smithy/protocol-http" "^5.1.2"
     "@smithy/querystring-builder" "^4.0.4"
@@ -3346,6 +3759,20 @@
     "@smithy/util-middleware" "^4.0.4"
     tslib "^2.6.2"
 
+"@smithy/middleware-endpoint@^4.1.17":
+  version "4.1.17"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.17.tgz#d6a87ccf5fe6a6edc5fe01832338854feaf18a12"
+  integrity sha512-S3hSGLKmHG1m35p/MObQCBCdRsrpbPU8B129BVzRqRfDvQqPMQ14iO4LyRw+7LNizYc605COYAcjqgawqi+6jA==
+  dependencies:
+    "@smithy/core" "^3.7.2"
+    "@smithy/middleware-serde" "^4.0.8"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/shared-ini-file-loader" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    "@smithy/url-parser" "^4.0.4"
+    "@smithy/util-middleware" "^4.0.4"
+    tslib "^2.6.2"
+
 "@smithy/middleware-retry@^4.0.3", "@smithy/middleware-retry@^4.1.10":
   version "4.1.12"
   resolved "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.12.tgz"
@@ -3358,6 +3785,21 @@
     "@smithy/types" "^4.3.1"
     "@smithy/util-middleware" "^4.0.4"
     "@smithy/util-retry" "^4.0.5"
+    tslib "^2.6.2"
+    uuid "^9.0.1"
+
+"@smithy/middleware-retry@^4.1.18":
+  version "4.1.18"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-4.1.18.tgz#4d57587722c341822cf8c58790f843008fef0f8e"
+  integrity sha512-bYLZ4DkoxSsPxpdmeapvAKy7rM5+25gR7PGxq2iMiecmbrRGBHj9s75N74Ylg+aBiw9i5jIowC/cLU2NR0qH8w==
+  dependencies:
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/service-error-classification" "^4.0.6"
+    "@smithy/smithy-client" "^4.4.9"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-middleware" "^4.0.4"
+    "@smithy/util-retry" "^4.0.6"
     tslib "^2.6.2"
     uuid "^9.0.1"
 
@@ -3392,6 +3834,17 @@
   version "4.0.6"
   resolved "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz"
   integrity sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==
+  dependencies:
+    "@smithy/abort-controller" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/querystring-builder" "^4.0.4"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
+"@smithy/node-http-handler@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.1.0.tgz#6b528cd0da0c35755b34afba207b7db972b0eb92"
+  integrity sha512-vqfSiHz2v8b3TTTrdXi03vNz1KLYYS3bhHCDv36FYDqxT7jvTll1mMnCrkD+gOvgwybuunh/2VmvOMqwBegxEg==
   dependencies:
     "@smithy/abort-controller" "^4.0.4"
     "@smithy/protocol-http" "^5.1.2"
@@ -3439,6 +3892,13 @@
   dependencies:
     "@smithy/types" "^4.3.1"
 
+"@smithy/service-error-classification@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@smithy/service-error-classification/-/service-error-classification-4.0.6.tgz#5d4d3017f5b62258fbfc1067e14198e125a8286c"
+  integrity sha512-RRoTDL//7xi4tn5FrN2NzH17jbgmnKidUqd4KvquT0954/i6CXXkh1884jBiunq24g9cGtPBEXlU40W6EpNOOg==
+  dependencies:
+    "@smithy/types" "^4.3.1"
+
 "@smithy/shared-ini-file-loader@^4.0.1", "@smithy/shared-ini-file-loader@^4.0.4":
   version "4.0.4"
   resolved "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.4.tgz"
@@ -3472,6 +3932,19 @@
     "@smithy/protocol-http" "^5.1.2"
     "@smithy/types" "^4.3.1"
     "@smithy/util-stream" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/smithy-client@^4.4.9":
+  version "4.4.9"
+  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-4.4.9.tgz#973875a750908266aaf5f73c0714016b7e883609"
+  integrity sha512-mbMg8mIUAWwMmb74LoYiArP04zWElPzDoA1jVOp3or0cjlDMgoS6WTC3QXK0Vxoc9I4zdrX0tq6qsOmaIoTWEQ==
+  dependencies:
+    "@smithy/core" "^3.7.2"
+    "@smithy/middleware-endpoint" "^4.1.17"
+    "@smithy/middleware-stack" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.2"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-stream" "^4.2.3"
     tslib "^2.6.2"
 
 "@smithy/types@^3.7.2":
@@ -3561,6 +4034,17 @@
     bowser "^2.11.0"
     tslib "^2.6.2"
 
+"@smithy/util-defaults-mode-browser@^4.0.25":
+  version "4.0.25"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.25.tgz#781411de904f616c15900ab0a88b37bd8002c5c5"
+  integrity sha512-pxEWsxIsOPLfKNXvpgFHBGFC3pKYKUFhrud1kyooO9CJai6aaKDHfT10Mi5iiipPXN/JhKAu3qX9o75+X85OdQ==
+  dependencies:
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/smithy-client" "^4.4.9"
+    "@smithy/types" "^4.3.1"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
 "@smithy/util-defaults-mode-node@^4.0.17", "@smithy/util-defaults-mode-node@^4.0.3":
   version "4.0.19"
   resolved "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.19.tgz"
@@ -3571,6 +4055,19 @@
     "@smithy/node-config-provider" "^4.1.3"
     "@smithy/property-provider" "^4.0.4"
     "@smithy/smithy-client" "^4.4.3"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
+"@smithy/util-defaults-mode-node@^4.0.25":
+  version "4.0.25"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.25.tgz#8e307a15a73c56af44674aaa74cd089b3b42b019"
+  integrity sha512-+w4n4hKFayeCyELZLfsSQG5mCC3TwSkmRHv4+el5CzFU8ToQpYGhpV7mrRzqlwKkntlPilT1HJy1TVeEvEjWOQ==
+  dependencies:
+    "@smithy/config-resolver" "^4.1.4"
+    "@smithy/credential-provider-imds" "^4.0.6"
+    "@smithy/node-config-provider" "^4.1.3"
+    "@smithy/property-provider" "^4.0.4"
+    "@smithy/smithy-client" "^4.4.9"
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
@@ -3607,6 +4104,15 @@
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
+"@smithy/util-retry@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-4.0.6.tgz#f931fdd1f01786b21a82711e185c58410e8e41c7"
+  integrity sha512-+YekoF2CaSMv6zKrA6iI/N9yva3Gzn4L6n35Luydweu5MMPYpiGZlWqehPHDHyNbnyaYlz/WJyYAZnC+loBDZg==
+  dependencies:
+    "@smithy/service-error-classification" "^4.0.6"
+    "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
 "@smithy/util-stream@^4.0.2", "@smithy/util-stream@^4.2.2":
   version "4.2.2"
   resolved "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.2.tgz"
@@ -3614,6 +4120,20 @@
   dependencies:
     "@smithy/fetch-http-handler" "^5.0.4"
     "@smithy/node-http-handler" "^4.0.6"
+    "@smithy/types" "^4.3.1"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-buffer-from" "^4.0.0"
+    "@smithy/util-hex-encoding" "^4.0.0"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/util-stream@^4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-4.2.3.tgz#7980fb94dbee96301b0b2610de8ae1700c7daab1"
+  integrity sha512-cQn412DWHHFNKrQfbHY8vSFI3nTROY1aIKji9N0tpp8gUABRilr7wdf8fqBbSlXresobM+tQFNk6I+0LXK/YZg==
+  dependencies:
+    "@smithy/fetch-http-handler" "^5.1.0"
+    "@smithy/node-http-handler" "^4.1.0"
     "@smithy/types" "^4.3.1"
     "@smithy/util-base64" "^4.0.0"
     "@smithy/util-buffer-from" "^4.0.0"
@@ -3651,6 +4171,15 @@
   dependencies:
     "@smithy/abort-controller" "^4.0.1"
     "@smithy/types" "^4.1.0"
+    tslib "^2.6.2"
+
+"@smithy/util-waiter@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@smithy/util-waiter/-/util-waiter-4.0.6.tgz#38044da5053f0d9118df05f55cd8fbec14ecf9da"
+  integrity sha512-slcr1wdRbX7NFphXZOxtxRNA7hXAAtJAXJDE/wdoMAos27SIquVCKiSqfB6/28YzQ8FCsB5NKkhdM5gMADbqxg==
+  dependencies:
+    "@smithy/abort-controller" "^4.0.4"
+    "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
 "@swc/core-darwin-arm64@1.10.14":
@@ -4230,6 +4759,11 @@
   version "10.0.0"
   resolved "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz"
   integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
+
+"@types/uuid@^9.0.1":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
+  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
 
 "@typescript-eslint/eslint-plugin@^8.22.0":
   version "8.23.0"
@@ -6240,6 +6774,13 @@ fast-xml-parser@4.4.1:
   dependencies:
     strnum "^1.0.5"
 
+fast-xml-parser@5.2.5:
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz#4809fdfb1310494e341098c25cb1341a01a9144a"
+  integrity sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==
+  dependencies:
+    strnum "^2.1.0"
+
 fastq@^1.18.0, fastq@^1.6.0:
   version "1.19.0"
   resolved "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz"
@@ -7789,6 +8330,13 @@ mkdirp@^2.1.5:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz"
   integrity sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==
 
+mnemonist@0.38.3:
+  version "0.38.3"
+  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.38.3.tgz#35ec79c1c1f4357cfda2fe264659c2775ccd7d9d"
+  integrity sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==
+  dependencies:
+    obliterator "^1.6.1"
+
 mnemonist@^0.39.8:
   version "0.39.8"
   resolved "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.8.tgz"
@@ -8201,6 +8749,11 @@ object-inspect@^1.13.3:
   version "1.13.4"
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz"
   integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
+
+obliterator@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-1.6.1.tgz#dea03e8ab821f6c4d96a299e17aef6a3af994ef3"
+  integrity sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==
 
 obliterator@^2.0.1:
   version "2.0.5"
@@ -9606,6 +10159,11 @@ strnum@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz"
   integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
+
+strnum@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.1.1.tgz#cf2a6e0cf903728b8b2c4b971b7e36b4e82d46ab"
+  integrity sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==
 
 structured-headers@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- Adds data source for vertical integration with a Turbo-style DynamoDB cache.
- Adds AI-generated unit tests for the class

General Notes:
- Turbo stores the data items it receives in DynamoDB if they are up to 10KiB in size
- Nested data items (only 1 level deep) within BDIs sent to Turbo are not stored in raw form; instead they are stored in offsets-parent-and-content-type form relative to their BDI parent data item
- Opossum is used for circuit breaking against DynamoDB and circuit breaker metrics are collected in the same manner as the other breakers around the app