### PR TITLE
feat: allow DynamoDB assume role

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -875,6 +875,10 @@ export const AWS_DYNAMODB_TURBO_ENDPOINT = env.varOrUndefined(
   'AWS_DYNAMODB_TURBO_ENDPOINT',
 );
 
+export const AWS_DYNAMODB_TURBO_ASSUME_ROLE_ARN = env.varOrUndefined(
+  'AWS_DYNAMODB_TURBO_ASSUME_ROLE_ARN',
+);
+
 // Chunk data source specifically set-up for interoperability with
 // the legacy arweave gateways
 export const LEGACY_AWS_S3_CHUNK_DATA_BUCKET = env.varOrUndefined(

--- a/src/system.ts
+++ b/src/system.ts
@@ -495,6 +495,7 @@ const turboDynamoDBDataSource =
         log,
         region: config.AWS_DYNAMODB_TURBO_REGION,
         endpoint: config.AWS_DYNAMODB_TURBO_ENDPOINT,
+        assumeRoleArn: config.AWS_DYNAMODB_TURBO_ASSUME_ROLE_ARN,
       })
     : undefined;
 


### PR DESCRIPTION
## Summary
- allow TurboDynamoDbDataSource to assume a role via AWS STS
- wire optional AWS_DYNAMODB_TURBO_ASSUME_ROLE_ARN env var through config

------
https://chatgpt.com/codex/tasks/task_b_68922cd70904832897bebcb6d9a6f8e6