### PR TITLE
chore(hb): add optional hypberbeam sidecar

### DIFF
--- a/.env.hb.example
+++ b/.env.hb.example
@@ -3,4 +3,4 @@ HB_PORT=
 HB_STORE=
 HB_PRINT='<some setting>'
 HB_CONFIG_LOCATION='./config.flat'
-HB_KEY='./wallets/<some-key.json>
+HB_KEY=./wallets/<some-key.json>

--- a/.env.hb.example
+++ b/.env.hb.example
@@ -1,0 +1,6 @@
+# Reference: https://hyperbeam.ar.io/run/configuring-your-machine.html
+HB_PORT=
+HB_STORE=
+HB_PRINT='<some setting>'
+HB_CONFIG_LOCATION='./config.flat'
+HB_KEY='./wallets/<some-key.json>

--- a/docker-compose.hb.yaml
+++ b/docker-compose.hb.yaml
@@ -1,0 +1,20 @@
+services:
+  hyperbeam:
+    image: ghcr.io/dtfiedler/hyperbeam:latest
+    restart: unless-stopped
+    command: 'foreground'
+    ports:
+      - ${HB_PORT:-10000}:10000
+    environment:
+      HB_STORE: ${HB_STORE:-}
+      HB_PRINT: ${HB_PRINT:-}
+      HB_KEY: ${HB_KEY:-}
+    volumes:
+      - ${HB_CACHE_MAINNET_PATH:-./data/hyperbeam/cache-mainnet}:/opt/_build/genesis_wasm/rel/hb/cache-mainnet
+      - ${WALLETS_PATH:-./wallets}:/opt/_build/genesis_wasm/rel/hb/wallets
+    networks:
+      - ar-io-network
+
+networks:
+  ar-io-network:
+    external: true


### PR DESCRIPTION
To use it, enable the following in the `.env`:

```bash
ARNS_RESOLVER_PRIORITY_ORDER=on-demand
AO_ANT_HYPERBEAM_URL=hyperbeam:10000
```

and run:

`docker compose up -d && docker compose -f docker-compose.hb.yaml up -d`