### PR TITLE
refactor: replace wait npm package with local implementation

### DIFF
--- a/src/arweave/composite-client.ts
+++ b/src/arweave/composite-client.ts
@@ -11,7 +11,7 @@ import { default as fastq } from 'fastq';
 import { default as NodeCache } from 'node-cache';
 import { Readable } from 'node:stream';
 import * as rax from 'retry-axios';
-import { default as wait } from 'wait';
+import wait from '../lib/wait.js';
 import * as winston from 'winston';
 import pLimit from 'p-limit';
 import memoize from 'memoizee';

--- a/src/data/full-chunk-source.ts
+++ b/src/data/full-chunk-source.ts
@@ -14,7 +14,7 @@ import {
   Chunk,
   ChunkData,
   ChunkMetadata,
-} from '../types';
+} from '../types.js';
 
 export class FullChunkSource
   implements ChunkByAnySource, ChunkMetadataByAnySource, ChunkDataByAnySource

--- a/src/database/standalone-sqlite.test.ts
+++ b/src/database/standalone-sqlite.test.ts
@@ -35,7 +35,7 @@ import { normalizeAns104DataItem } from '../lib/ans-104.js';
 import log from '../log.js';
 import { BundleRecord } from '../types.js';
 import { processBundleStream } from '../lib/bundles.js';
-import wait from 'wait';
+import wait from '../lib/wait.js';
 
 const HEIGHT = 1138;
 const BLOCK_TX_INDEX = 42;

--- a/src/lib/wait.ts
+++ b/src/lib/wait.ts
@@ -1,0 +1,9 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+export default function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/store/kv-debounce-store.ts
+++ b/src/store/kv-debounce-store.ts
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { KVBufferStore } from '../types';
+import { KVBufferStore } from '../types.js';
 import { tracer } from '../tracing.js';
 import * as metrics from '../metrics.js';
 import { Span } from '@opentelemetry/api';

--- a/src/workers/block-importer.test.ts
+++ b/src/workers/block-importer.test.ts
@@ -15,7 +15,7 @@ import {
   mock,
 } from 'node:test';
 import { EventEmitter } from 'node:events';
-import { default as wait } from 'wait';
+import wait from '../lib/wait.js';
 
 import { StandaloneSqliteDatabase } from '../../src/database/standalone-sqlite.js';
 import { BlockImporter } from '../../src/workers/block-importer.js';

--- a/src/workers/block-importer.ts
+++ b/src/workers/block-importer.ts
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import * as EventEmitter from 'node:events';
-import { default as wait } from 'wait';
+import wait from '../lib/wait.js';
 import * as winston from 'winston';
 
 import { MAX_FORK_DEPTH } from '../arweave/constants.js';

--- a/src/workers/mempool-watcher.test.ts
+++ b/src/workers/mempool-watcher.test.ts
@@ -9,7 +9,7 @@ import { afterEach, before, beforeEach, describe, it, mock } from 'node:test';
 import winston from 'winston';
 import { MempoolWatcher } from './mempool-watcher.js';
 import { ArweaveChainSourceStub } from '../../test/stubs.js';
-import { default as wait } from 'wait';
+import wait from '../lib/wait.js';
 
 describe('MempoolWatcher', () => {
   let log: winston.Logger;

--- a/src/workers/mempool-watcher.ts
+++ b/src/workers/mempool-watcher.ts
@@ -4,7 +4,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { default as wait } from 'wait';
+import wait from '../lib/wait.js';
 import * as winston from 'winston';
 import { ChainSource } from '../types.js';
 import { TransactionFetcher } from './transaction-fetcher.js';

--- a/src/workers/transaction-fetcher.ts
+++ b/src/workers/transaction-fetcher.ts
@@ -7,7 +7,7 @@
 import { default as fastq } from 'fastq';
 import type { queueAsPromised } from 'fastq';
 import * as EventEmitter from 'node:events';
-import { default as wait } from 'wait';
+import wait from '../lib/wait.js';
 import * as winston from 'winston';
 
 import * as events from '../events.js';

--- a/src/workers/webhook-emitter.test.ts
+++ b/src/workers/webhook-emitter.test.ts
@@ -12,7 +12,7 @@ import axios from 'axios';
 
 import { WebhookEmitter } from '../../src/workers/webhook-emitter.js';
 import { AlwaysMatch, NeverMatch } from '../filters.js';
-import wait from 'wait';
+import wait from '../lib/wait.js';
 
 describe('WebhookEmitter', () => {
   let log: winston.Logger;

--- a/test/end-to-end/bundler-sidecar.test.ts
+++ b/test/end-to-end/bundler-sidecar.test.ts
@@ -13,7 +13,7 @@ import {
   StartedDockerComposeEnvironment,
   Wait,
 } from 'testcontainers';
-import wait from 'wait';
+import wait from '../../src/lib/wait.js';
 import axios from 'axios';
 import Sqlite, { Database } from 'better-sqlite3';
 import { fromB64Url, sha256B64Url, toB64Url } from '../../src/lib/encoding.js';

--- a/test/end-to-end/indexing.test.ts
+++ b/test/end-to-end/indexing.test.ts
@@ -8,7 +8,7 @@ import { strict as assert } from 'node:assert';
 import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 import { StartedDockerComposeEnvironment } from 'testcontainers';
 import axios from 'axios';
-import { default as wait } from 'wait';
+import wait from '../../src/lib/wait.js';
 import Sqlite, { Database } from 'better-sqlite3';
 import crypto from 'node:crypto';
 import { b64UrlToUtf8, toB64Url, fromB64Url } from '../../src/lib/encoding.js';

--- a/test/end-to-end/moderation.test.ts
+++ b/test/end-to-end/moderation.test.ts
@@ -8,7 +8,7 @@ import assert from 'node:assert';
 import axios from 'axios';
 import { describe, before, after, it } from 'node:test';
 import { StartedDockerComposeEnvironment } from 'testcontainers';
-import { default as wait } from 'wait';
+import wait from '../../src/lib/wait.js';
 import { cleanDb, composeUp } from './utils.js';
 import { isTestFiltered } from '../utils.js';
 

--- a/test/end-to-end/webhook.test.ts
+++ b/test/end-to-end/webhook.test.ts
@@ -14,7 +14,7 @@ import {
   Wait,
 } from 'testcontainers';
 import { createServer } from 'node:http';
-import wait from 'wait';
+import wait from '../../src/lib/wait.js';
 import axios from 'axios';
 import { cleanDb } from './utils.js';
 import { isTestFiltered } from '../utils.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2021",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "declaration": true,
     "outDir": "./dist",
     "strict": true,


### PR DESCRIPTION
- Create local wait utility function to reduce external dependencies
- Update all imports from 'wait' package to use new local implementation
- Update TypeScript config to use NodeNext module resolution for better ESM compatibility
- Change module from 'esnext' to 'NodeNext' and moduleResolution from 'node' to 'NodeNext' to properly support explicit .js extensions in imports, which is required for ES modules in Node.js and improves compatibility with modern JavaScript tooling
- Fix import paths to use explicit .js extensions as required by ESM standards

🤖 Generated with [Claude Code](https://claude.ai/code)