### PR TITLE
fix: apply chunk rate limits before expensive txResult lookup (PE-8685)

### DIFF
--- a/src/handlers/data-handler-utils.ts
+++ b/src/handlers/data-handler-utils.ts
@@ -29,7 +29,7 @@ import {
 export interface CheckPaymentAndRateLimitsParams {
   req: Request;
   res: Response;
-  id: string;
+  id?: string;
   contentSize: number;
   contentType?: string;
   requestAttributes: RequestAttributes;
@@ -88,7 +88,7 @@ export async function checkPaymentAndRateLimits({
     'checkPaymentAndRateLimits',
     {
       attributes: {
-        'data.id': id,
+        ...(id !== undefined && { 'data.id': id }),
         'content.size': contentSize,
       },
     },
@@ -140,7 +140,7 @@ export async function checkPaymentAndRateLimits({
         'verifyPayment',
         {
           attributes: {
-            'data.id': id,
+            ...(id !== undefined && { 'data.id': id }),
             'content.size': contentSize,
           },
         },
@@ -279,7 +279,7 @@ export async function checkPaymentAndRateLimits({
         'checkRateLimits',
         {
           attributes: {
-            'data.id': id,
+            ...(id !== undefined && { 'data.id': id }),
             'content.size': contentSize,
             'payment.verified': paymentVerified,
           },


### PR DESCRIPTION
## Summary

Reorders chunk handler operations to check rate limits **before** fetching transaction metadata from database/chain. This protects database resources from rate-limited requests and improves DoS resistance.

## Problem

Currently, the chunk handler performs an expensive database/chain lookup (`getTxByOffset()`) before applying rate limits. This creates a DoS vulnerability where rate-limited requests waste database resources unnecessarily.

Rate limiting is based on **IP address and resource path**, NOT transaction ID. The transaction ID is only used for logging/observability purposes.

## Solution

Simple reordering of operations:
1. ✅ Check rate limits first (no expensive lookup yet)
2. ✅ Only fetch txResult for allowed requests
3. ✅ Transaction ID still available for all subsequent logs/operations

## Changes

- Update `CheckPaymentAndRateLimitsParams` interface to make `id` optional (`id?: string`)
- Handle optional `id` in span attributes with explicit `undefined` checks
- Reorder chunk handler to check rate limits before `getTxByOffset()` call
- Add comments explaining why `id` is omitted during initial rate limit check

## Benefits

- ✅ Rate-limited requests no longer trigger expensive database lookups
- ✅ Better DoS resistance and reduced database load under attack
- ✅ Aligns chunk handler with data handler design pattern
- ✅ No functional changes to rate limiting behavior (still IP + path based)
- ⚠️ Minor trade-off: Transaction ID not in initial rate limit logs (but available in all subsequent logs)

## Test plan

- [x] All 19 chunk handler tests pass
- [x] ESLint checks pass
- [x] Verified rate limit check occurs before database lookup in code flow

## References

- **Jira Ticket**: [PE-8685](https://ardrive.atlassian.net/browse/PE-8685)
- **GitHub Issue**: Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PE-8685]: https://ardrive.atlassian.net/browse/PE-8685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ