### PR TITLE
fix: URL-decode manifest paths in ArNS middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **ArNS Manifest Path Encoding**: Fixed manifest paths with URL-encoded
+  characters (e.g., spaces as `%20`) failing when accessed via ArNS subdomain
+  - Direct TX ID access worked because Express auto-decodes `req.params`
+  - ArNS subdomain access failed because `req.path` is not auto-decoded
+  - Now decodes manifest paths in the ArNS middleware for consistent behavior
 - **TurboDynamoDB Data Source**: Fixed nested bundle data items having incorrect
   `rootDataItemOffset` values when retrieved from Turbo's DynamoDB
   - The raw data path was overwriting correct absolute offsets cached from the

--- a/src/middleware/arns.ts
+++ b/src/middleware/arns.ts
@@ -33,6 +33,19 @@ export const createArnsMiddleware = ({
       return;
     }
 
+    // Extract and decode manifest path once (req.path is URL-encoded,
+    // but req.params['*'] is auto-decoded by Express, so we decode here for parity)
+    let manifestPath: string | undefined;
+    if (req.path) {
+      try {
+        manifestPath = decodeURIComponent(req.path.slice(1));
+      } catch {
+        // Match Express behavior: return 400 for malformed URL encoding
+        res.status(400).send('Bad Request: Invalid URL encoding');
+        return;
+      }
+    }
+
     let arnsSubdomain: string | undefined;
     const hostNameIsArNSRoot = req.hostname === config.ARNS_ROOT_HOST;
     if (
@@ -60,9 +73,7 @@ export const createArnsMiddleware = ({
       // Use apex ID as ArNS root data if it's set.
       if (config.APEX_TX_ID !== undefined) {
         req.dataId = config.APEX_TX_ID;
-        if (req.path) {
-          req.manifestPath = req.path.slice(1);
-        }
+        req.manifestPath = manifestPath;
         // Note: Not setting req.arns or headers for apex ID
         dataHandler(req, res, next);
         return;
@@ -122,9 +133,7 @@ export const createArnsMiddleware = ({
       // Successful ArNS resolution
       // Set request context
       req.dataId = resolvedId;
-      if (req.path) {
-        req.manifestPath = req.path.slice(1);
-      }
+      req.manifestPath = manifestPath;
 
       // Parse ArNS name components
       const parts = arnsSubdomain.split('_');
@@ -202,9 +211,7 @@ export const createArnsMiddleware = ({
       } else if (config.ARNS_NOT_FOUND_TX_ID !== undefined) {
         // Use custom 404 transaction ID
         req.dataId = config.ARNS_NOT_FOUND_TX_ID;
-        if (req.path) {
-          req.manifestPath = req.path.slice(1);
-        }
+        req.manifestPath = manifestPath;
       } else if (config.ARNS_NOT_FOUND_ARNS_NAME !== undefined) {
         // Resolve custom 404 ArNS name
         const custom404Resolution = await nameResolver.resolve({
@@ -212,9 +219,7 @@ export const createArnsMiddleware = ({
         });
         if (custom404Resolution.resolvedId !== undefined) {
           req.dataId = custom404Resolution.resolvedId;
-          if (req.path) {
-            req.manifestPath = req.path.slice(1);
-          }
+          req.manifestPath = manifestPath;
         } else {
           sendNotFound(res);
           return;


### PR DESCRIPTION
## Summary

- URL-decode manifest paths extracted from `req.path` in ArNS middleware to fix path mismatch for URLs with encoded characters (e.g., spaces as `%20`)
- Extract and decode manifest path once at the top of the middleware for cleaner code
- Ensures parity between ArNS subdomain access and direct TX ID access

Fixes #551 (PE-8726)

## Test plan

- [ ] Verify ArNS subdomain access works for manifest paths with URL-encoded spaces
- [ ] Verify ArNS subdomain access works for manifest paths with other URL-encoded characters (e.g., `%2F`, `%3A`)
- [ ] Verify existing manifest path resolution continues to work
- [ ] Verify direct TX ID access still works for encoded paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)