### PR TITLE
feat: add defense-in-depth loop protection improvements (PE-8947)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1093,6 +1093,23 @@ export const ARNS_ROOT_HOST = env.varOrUndefined('ARNS_ROOT_HOST');
 export const ROOT_HOST_SUBDOMAIN_LENGTH =
   ARNS_ROOT_HOST !== undefined ? ARNS_ROOT_HOST.split('.').length - 2 : 0;
 
+// Warn if TRUSTED_GATEWAYS_URLS contains this gateway's own hostname
+if (ARNS_ROOT_HOST !== undefined) {
+  for (const url of Object.keys(TRUSTED_GATEWAYS_URLS)) {
+    try {
+      const hostname = new URL(url).hostname;
+      if (hostname === ARNS_ROOT_HOST) {
+        logger.warn(
+          `TRUSTED_GATEWAYS_URLS contains this gateway's own ARNS_ROOT_HOST (${ARNS_ROOT_HOST}). ` +
+            'This creates a self-forwarding loop. Remove it from TRUSTED_GATEWAYS_URLS.',
+        );
+      }
+    } catch {
+      /* URL already validated above */
+    }
+  }
+}
+
 // The protocol to use for sandboxing redirects (defaults to https)
 export const SANDBOX_PROTOCOL = env.varOrUndefined('SANDBOX_PROTOCOL');
 

--- a/src/system.ts
+++ b/src/system.ts
@@ -545,10 +545,18 @@ export const arIOPeerManager = new ArIOPeerManager({
   nodeWallet: config.AR_IO_WALLET,
 });
 
-export const arIODataSource = new ArIODataSource({
+const baseArIODataSource = new ArIODataSource({
   log,
   peerManager: arIOPeerManager,
   dataAttributesStore,
+});
+
+// Wrap with filtering for peer forwarding (same blocked lists as gateway forwarding)
+export const arIODataSource = new FilteredContiguousDataSource({
+  log,
+  dataSource: baseArIODataSource,
+  blockedOrigins: config.TRUSTED_GATEWAYS_BLOCKED_ORIGINS,
+  blockedIpsAndCidrs: config.TRUSTED_GATEWAYS_BLOCKED_IPS_AND_CIDRS,
 });
 
 export const arIOChunkSource = new ArIOChunkSource({


### PR DESCRIPTION
## Summary

- Add hop count validation to `GatewaysDataSource` (matching existing `ArIODataSource` pattern) to prevent excessive forwarding hops through trusted gateways
- Wrap `arIODataSource` with `FilteredContiguousDataSource` so `TRUSTED_GATEWAYS_BLOCKED_ORIGINS` and `TRUSTED_GATEWAYS_BLOCKED_IPS_AND_CIDRS` apply to AR.IO peer forwarding path
- Add startup warning when `TRUSTED_GATEWAYS_URLS` contains this gateway's own `ARNS_ROOT_HOST`, catching self-loop misconfigurations early

## Test plan

- [x] `yarn lint:check` passes
- [x] All 1400 tests pass (`yarn test`)
- [x] New hop count validation tests added (5 cases: at limit, exceeds limit, below limit, no requestAttributes, custom maxHopsAllowed)
- [ ] Manual verification: confirm `arIODataSource` consumers only use `ContiguousDataSource` interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)