### PR TITLE
feat: RFC 9421 HTTP Message Signatures for gateway responses (PE-9049)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -393,7 +393,7 @@ services:
       - HTTPSIG_BIND_REQUEST=${HTTPSIG_BIND_REQUEST:-}
       - HTTPSIG_UPLOAD_ATTESTATION=${HTTPSIG_UPLOAD_ATTESTATION:-}
       - OBSERVER_WALLET=${OBSERVER_WALLET:-}
-      - WALLETS_PATH=${WALLETS_PATH:-}
+      - WALLETS_PATH=/app/wallets
     ulimits:
       nofile:
         soft: 65536

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,6 +59,8 @@ services:
       - ${DATASETS_PATH:-./data/datasets}:/app/data/datasets
       - ${ETL_STAGING_PATH:-./data/etl/staging}:/app/data/etl/staging
       - ${CDB64_ROOT_TX_INDEX_DATA_PATH:-./data/cdb64-root-tx-index}:/app/data/cdb64-root-tx-index
+      - ${KEYS_DATA_PATH:-./data/keys}:/app/data/keys
+      - ${WALLETS_PATH:-./wallets}:/app/wallets
       - ${SECRETS_PATH:-./secrets}:/app/secrets:ro
       - envoy-eds-data:/app/data/envoy-eds
     environment:
@@ -386,6 +388,12 @@ services:
       - ARWEAVE_TAG_RESPONSE_HEADERS_ENABLED=${ARWEAVE_TAG_RESPONSE_HEADERS_ENABLED:-}
       - ARWEAVE_TAG_RESPONSE_HEADERS_MAX=${ARWEAVE_TAG_RESPONSE_HEADERS_MAX:-}
       - ARWEAVE_TAG_RESPONSE_HEADERS_MAX_BYTES=${ARWEAVE_TAG_RESPONSE_HEADERS_MAX_BYTES:-}
+      - HTTPSIG_ENABLED=${HTTPSIG_ENABLED:-}
+      - HTTPSIG_KEY_FILE=${HTTPSIG_KEY_FILE:-}
+      - HTTPSIG_BIND_REQUEST=${HTTPSIG_BIND_REQUEST:-}
+      - HTTPSIG_UPLOAD_ATTESTATION=${HTTPSIG_UPLOAD_ATTESTATION:-}
+      - OBSERVER_WALLET=${OBSERVER_WALLET:-}
+      - WALLETS_PATH=${WALLETS_PATH:-}
     ulimits:
       nofile:
         soft: 65536

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,7 +60,7 @@ services:
       - ${ETL_STAGING_PATH:-./data/etl/staging}:/app/data/etl/staging
       - ${CDB64_ROOT_TX_INDEX_DATA_PATH:-./data/cdb64-root-tx-index}:/app/data/cdb64-root-tx-index
       - ${KEYS_DATA_PATH:-./data/keys}:/app/data/keys
-      - ${WALLETS_PATH:-./wallets}:/app/wallets
+      - ${WALLETS_PATH:-./wallets}:/app/wallets:ro
       - ${SECRETS_PATH:-./secrets}:/app/secrets:ro
       - envoy-eds-data:/app/data/envoy-eds
     environment:

--- a/docs/envs.md
+++ b/docs/envs.md
@@ -315,3 +315,18 @@ When enabled, the `transaction(id)` GraphQL query can resolve unindexed data ite
 | GRAPHQL_ON_DEMAND_RESOLUTION_ENABLED             | Boolean              | true                                          | If true, enables on-demand data item resolution as a fallback when `transaction(id)` returns null from the local database                                           |
 | GRAPHQL_ON_DEMAND_RESOLUTION_TIMEOUT_MS          | Number               | 5000                                          | Maximum time in milliseconds to wait for on-demand resolution before returning null. Background resolution continues and persists for future queries                 |
 | GRAPHQL_ON_DEMAND_RESOLUTION_MAX_CONCURRENT      | Number               | 1                                             | Maximum number of concurrent on-demand resolution operations. When at capacity, requests return null immediately                                                     |
+
+## HTTPSIG Response Signing
+
+Signs gateway responses with an Ed25519 key per [RFC 9421](https://www.rfc-editor.org/rfc/rfc9421) (HTTP Message Signatures). Every qualifying response gets `Signature` and `Signature-Input` headers that cryptographically bind the gateway's trust claims (verification status, ArNS resolution, data item tags) to a staked on-chain identity.
+
+When `OBSERVER_WALLET` is set, the gateway also creates an RSA attestation linking the Ed25519 signing key to the observer wallet (which is registered to the gateway on-chain), and uploads it permanently to Arweave.
+
+| ENV_NAME                    | TYPE    | DEFAULT_VALUE          | DESCRIPTION                                                                                                          |
+| --------------------------- | ------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| HTTPSIG_ENABLED             | Boolean | false                  | Enable RFC 9421 HTTP Message Signature signing on gateway responses                                                  |
+| HTTPSIG_KEY_FILE            | String  | data/keys/httpsig.pem  | Path to Ed25519 private key PEM file. Auto-generated on first startup if missing                                     |
+| HTTPSIG_BIND_REQUEST        | Boolean | true                   | Include `@method;req` and `@path;req` in signatures, binding each response to the specific request that triggered it |
+| HTTPSIG_UPLOAD_ATTESTATION  | Boolean | true                   | Upload the attestation to Arweave at startup (requires `OBSERVER_WALLET`). Set to false to skip upload               |
+| OBSERVER_WALLET             | String  | -                      | Arweave wallet address for attestation signing. Key file must exist at `<WALLETS_PATH>/<OBSERVER_WALLET>.json`       |
+| WALLETS_PATH                | String  | wallets                | Directory containing wallet JWK files                                                                                |

--- a/docs/envs.md
+++ b/docs/envs.md
@@ -326,6 +326,7 @@ When `OBSERVER_WALLET` is set, the gateway also creates an RSA attestation linki
 | --------------------------- | ------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | HTTPSIG_ENABLED             | Boolean | false                  | Enable RFC 9421 HTTP Message Signature signing on gateway responses                                                  |
 | HTTPSIG_KEY_FILE            | String  | data/keys/httpsig.pem  | Path to Ed25519 private key PEM file. Auto-generated on first startup if missing                                     |
+| KEYS_DATA_PATH              | String  | ./data/keys            | Host path for the keys volume mount (docker-compose only). Maps to `/app/data/keys` inside the container             |
 | HTTPSIG_BIND_REQUEST        | Boolean | true                   | Include `@method;req` and `@path;req` in signatures, binding each response to the specific request that triggered it |
 | HTTPSIG_UPLOAD_ATTESTATION  | Boolean | true                   | Upload the attestation to Arweave at startup (requires `OBSERVER_WALLET`). Set to false to skip upload               |
 | OBSERVER_WALLET             | String  | -                      | Arweave wallet address for attestation signing. Key file must exist at `<WALLETS_PATH>/<OBSERVER_WALLET>.json`       |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -548,6 +548,7 @@ paths:
         - Bundler service URLs for data upload service discovery
         - Rate limiter configuration (if enabled)
         - x402 payment protocol configuration (if enabled)
+        - HTTPSIG response signing configuration (if enabled)
       responses:
         '200':
           description: Gateway information response
@@ -755,6 +756,62 @@ paths:
                       - walletAddress
                       - facilitatorUrl
                       - dataEgress
+                  httpsig:
+                    type: object
+                    description: RFC 9421 HTTP Message Signature configuration (only present when HTTPSIG is enabled)
+                    properties:
+                      enabled:
+                        type: boolean
+                        description: Whether HTTPSIG response signing is enabled
+                        example: true
+                      algorithm:
+                        type: string
+                        description: Signature algorithm
+                        enum: ['ed25519']
+                        example: 'ed25519'
+                      publicKey:
+                        type: string
+                        description: Base64url-encoded 32-byte Ed25519 public key
+                        example: '1Jw2EpGba2umSMoCNEQh-QKaYA_GztxaoWTpcsyfyxk'
+                      keyId:
+                        type: string
+                        description: Self-contained key identifier (ed25519:<base64url-pubkey>)
+                        example: 'ed25519:1Jw2EpGba2umSMoCNEQh-QKaYA_GztxaoWTpcsyfyxk'
+                      solanaAddress:
+                        type: string
+                        description: Solana address derived from the Ed25519 public key
+                        example: 'FJwaz3DWJ2TuDRDaBRsE7t29LDm1wB8txPHcBNoCDwkt'
+                      attestation:
+                        type: object
+                        description: RSA-signed attestation linking the Ed25519 key to the on-chain gateway identity
+                        properties:
+                          txId:
+                            type: string
+                            description: Arweave transaction ID where attestation is permanently stored
+                            example: '4w-39da6R7eklq9d3sMhEx7tc-t4p4PZD6cTZIG3f3c'
+                          observerAddress:
+                            type: string
+                            description: Arweave address of the observer wallet that signed the attestation
+                            example: '7p90oVDWv8euAJsHHuz8tVw9OBrQdIB8qrOn5YEjiVc'
+                          payload:
+                            type: string
+                            description: Canonical JSON attestation payload
+                          signature:
+                            type: string
+                            description: RSA-PSS-SHA256 signature over the payload (base64url)
+                          rsaPublicKey:
+                            type: string
+                            description: RSA public key in SPKI DER format (base64url)
+                        required:
+                          - observerAddress
+                          - payload
+                          - signature
+                          - rsaPublicKey
+                    required:
+                      - enabled
+                      - algorithm
+                      - publicKey
+                      - keyId
                 required:
                   - processId
                   - supportedManifestVersions
@@ -1032,6 +1089,16 @@ paths:
                 type: integer
               description: Signature algorithm (1 = RSA-4096/Arweave)
               example: 1
+            Signature:
+              schema:
+                type: string
+              description: RFC 9421 HTTP Message Signature (opt-in via HTTPSIG_ENABLED)
+              example: 'sig1=:oU151iAt3RBEvThMpQvCiJzjkFhXDVpDFSUg43vxZsIoTFSqkSDyLbshT2tBWAcWIq1mc3AAXLhEdUqN+ifbBw==:'
+            Signature-Input:
+              schema:
+                type: string
+              description: RFC 9421 Signature-Input listing signed components, algorithm, and key ID (opt-in via HTTPSIG_ENABLED)
+              example: 'sig1=("@status" "content-type" "x-ar-io-data-id" "x-ar-io-verified");created=1712505600;keyid="ed25519:...";alg="ed25519"'
         '206':
           description: Partial content for range requests
           headers:
@@ -1367,6 +1434,16 @@ paths:
                 type: integer
               description: Signature algorithm (1 = RSA-4096/Arweave)
               example: 1
+            Signature:
+              schema:
+                type: string
+              description: RFC 9421 HTTP Message Signature (opt-in via HTTPSIG_ENABLED)
+              example: 'sig1=:oU151iAt3RBEvThMpQvCiJzjkFhXDVpDFSUg43vxZsIoTFSqkSDyLbshT2tBWAcWIq1mc3AAXLhEdUqN+ifbBw==:'
+            Signature-Input:
+              schema:
+                type: string
+              description: RFC 9421 Signature-Input listing signed components, algorithm, and key ID (opt-in via HTTPSIG_ENABLED)
+              example: 'sig1=("@status" "content-type" "x-ar-io-data-id" "x-ar-io-verified");created=1712505600;keyid="ed25519:...";alg="ed25519"'
         '206':
           description: Partial content for range requests
           headers:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1545,6 +1545,14 @@ paths:
                 type: integer
               description: Total size of data item including headers and payload in bytes (ANS-104 bundles only)
               example: 2092
+            Signature:
+              schema:
+                type: string
+              description: RFC 9421 HTTP Message Signature (opt-in via HTTPSIG_ENABLED)
+            Signature-Input:
+              schema:
+                type: string
+              description: RFC 9421 Signature-Input listing signed components, algorithm, and key ID (opt-in via HTTPSIG_ENABLED)
         '404':
           description: Data not found or blocked
         '416':
@@ -1667,6 +1675,14 @@ paths:
                 type: integer
               description: Total size of data item including headers and payload in bytes (ANS-104 bundles only)
               example: 2092
+            Signature:
+              schema:
+                type: string
+              description: RFC 9421 HTTP Message Signature (opt-in via HTTPSIG_ENABLED)
+            Signature-Input:
+              schema:
+                type: string
+              description: RFC 9421 Signature-Input listing signed components, algorithm, and key ID (opt-in via HTTPSIG_ENABLED)
         '404':
           description: Data not found or blocked
         '416':

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "arweave": "^2.0.0-ec.0",
     "axios": "^1.15.0",
     "better-sqlite3": "^9.4.5",
+    "bs58": "^4.0.1",
     "change-case": "^5.4.4",
     "chokidar": "^5.0.0",
     "cors": "^2.8.5",

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,8 @@ import log from './log.js';
 import { createAbortSignalMiddleware } from './middleware/abort-signal.js';
 import { createRequestIdMiddleware } from './middleware/request-id.js';
 import { createDefaultCacheControlMiddleware } from './middleware/cache-control.js';
+import { createHttpSigMiddleware } from './middleware/httpsig.js';
+import { uploadAttestation } from './lib/httpsig-upload.js';
 import { rootRouter } from './routes/root.js';
 import { arIoRouter } from './routes/ar-io.js';
 import { arnsRouter } from './routes/arns.js';
@@ -44,6 +46,33 @@ system.contiguousDataFsCacheCleanupWorker?.start();
 
 system.chunkDataFsCacheCleanupWorker?.start();
 
+// Upload HTTPSIG attestation to Arweave (non-blocking, non-fatal)
+if (
+  config.HTTPSIG_ENABLED &&
+  config.HTTPSIG_ATTESTATION !== undefined &&
+  config.HTTPSIG_OBSERVER_JWK !== undefined &&
+  config.HTTPSIG_UPLOAD_ATTESTATION &&
+  !config.HTTPSIG_ATTESTATION_CACHED
+) {
+  uploadAttestation({
+    jwk: config.HTTPSIG_OBSERVER_JWK,
+    attestation: config.HTTPSIG_ATTESTATION,
+    gatewayAddress: config.AR_IO_WALLET,
+    observerAddress: config.HTTPSIG_OBSERVER_ADDRESS!,
+    ed25519PublicKey: config.HTTPSIG_PUBLIC_KEY_B64URL!,
+    keyId: config.HTTPSIG_KEY_ID!,
+    log,
+  })
+    .then((txId) => {
+      config.setHttpSigAttestationTxId(txId);
+    })
+    .catch((error: any) => {
+      log.warn('HTTPSIG attestation upload failed', {
+        error: error?.message,
+      });
+    });
+}
+
 // Allow starting without writers to support SQLite replication
 if (config.START_WRITERS) {
   system.blockImporter.start();
@@ -72,6 +101,18 @@ app.use(createRequestIdMiddleware());
 
 // Attach AbortSignal to all requests for client disconnect handling
 app.use(createAbortSignalMiddleware());
+
+// HTTPSIG response signing — must be before cache-control so the writeHead
+// LIFO order ensures signing runs AFTER cache-control has set default headers.
+if (config.HTTPSIG_ENABLED && config.HTTPSIG_PRIVATE_KEY !== undefined) {
+  app.use(
+    createHttpSigMiddleware({
+      privateKey: config.HTTPSIG_PRIVATE_KEY,
+      keyId: config.HTTPSIG_KEY_ID!,
+      bindRequest: config.HTTPSIG_BIND_REQUEST,
+    }),
+  );
+}
 
 // Set default Cache-Control when no handler sets one
 app.use(createDefaultCacheControlMiddleware(config.CACHE_DEFAULT_MAX_AGE));

--- a/src/app.ts
+++ b/src/app.ts
@@ -50,18 +50,20 @@ system.chunkDataFsCacheCleanupWorker?.start();
 // Skip if the txId is already persisted from a prior successful upload.
 if (
   config.HTTPSIG_ENABLED &&
-  config.HTTPSIG_ATTESTATION !== undefined &&
-  config.HTTPSIG_OBSERVER_JWK !== undefined &&
   config.HTTPSIG_UPLOAD_ATTESTATION &&
-  config.getHttpSigAttestationTxId() === undefined
+  config.HTTPSIG_SIGNER !== undefined &&
+  config.HTTPSIG_OBSERVER !== undefined &&
+  config.HTTPSIG_OBSERVER.attestationTxId === undefined
 ) {
+  const signer = config.HTTPSIG_SIGNER;
+  const observer = config.HTTPSIG_OBSERVER;
   uploadAttestation({
-    jwk: config.HTTPSIG_OBSERVER_JWK,
-    attestation: config.HTTPSIG_ATTESTATION,
+    jwk: observer.jwk,
+    attestation: observer.attestation,
     gatewayAddress: config.AR_IO_WALLET,
-    observerAddress: config.HTTPSIG_OBSERVER_ADDRESS!,
-    ed25519PublicKey: config.HTTPSIG_PUBLIC_KEY_B64URL!,
-    keyId: config.HTTPSIG_KEY_ID!,
+    observerAddress: observer.address,
+    ed25519PublicKey: signer.publicKeyB64Url,
+    keyId: signer.keyId,
     log,
   })
     .then((txId) => {
@@ -105,11 +107,11 @@ app.use(createAbortSignalMiddleware());
 
 // HTTPSIG response signing — must be before cache-control so the writeHead
 // LIFO order ensures signing runs AFTER cache-control has set default headers.
-if (config.HTTPSIG_ENABLED && config.HTTPSIG_PRIVATE_KEY !== undefined) {
+if (config.HTTPSIG_ENABLED && config.HTTPSIG_SIGNER !== undefined) {
   app.use(
     createHttpSigMiddleware({
-      privateKey: config.HTTPSIG_PRIVATE_KEY,
-      keyId: config.HTTPSIG_KEY_ID!,
+      privateKey: config.HTTPSIG_SIGNER.privateKey,
+      keyId: config.HTTPSIG_SIGNER.keyId,
       bindRequest: config.HTTPSIG_BIND_REQUEST,
     }),
   );

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,13 +46,14 @@ system.contiguousDataFsCacheCleanupWorker?.start();
 
 system.chunkDataFsCacheCleanupWorker?.start();
 
-// Upload HTTPSIG attestation to Arweave (non-blocking, non-fatal)
+// Upload HTTPSIG attestation to Arweave (non-blocking, non-fatal).
+// Skip if the txId is already persisted from a prior successful upload.
 if (
   config.HTTPSIG_ENABLED &&
   config.HTTPSIG_ATTESTATION !== undefined &&
   config.HTTPSIG_OBSERVER_JWK !== undefined &&
   config.HTTPSIG_UPLOAD_ATTESTATION &&
-  !config.HTTPSIG_ATTESTATION_CACHED
+  config.getHttpSigAttestationTxId() === undefined
 ) {
   uploadAttestation({
     jwk: config.HTTPSIG_OBSERVER_JWK,

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,11 +5,23 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { canonicalize } from 'json-canonicalize';
+import crypto from 'node:crypto';
 import { isMainThread } from 'node:worker_threads';
 import { existsSync, readFileSync } from 'node:fs';
 
 import { createFilter } from './filters.js';
 import * as env from './lib/env.js';
+import {
+  loadOrGenerateKey,
+  deriveKeyId,
+  getPublicKeyBase64Url,
+  getSolanaAddress,
+  loadWalletJwk,
+  loadOrCreateAttestation,
+  jwkToArweaveAddress,
+  resolveWalletPath,
+} from './lib/httpsig.js';
+import type { Attestation } from './lib/httpsig.js';
 import { release } from './version.js';
 import logger from './log.js';
 import { verificationPriorities } from './constants.js';
@@ -958,6 +970,108 @@ export const TX_METADATA_RESOLVE_CONCURRENCY = env.positiveIntOrDefault(
   'TX_METADATA_RESOLVE_CONCURRENCY',
   1,
 );
+
+//
+// HTTPSIG response signing (RFC 9421)
+//
+
+export const HTTPSIG_ENABLED =
+  env.varOrDefault('HTTPSIG_ENABLED', 'false') === 'true';
+
+export const HTTPSIG_KEY_FILE = env.varOrDefault(
+  'HTTPSIG_KEY_FILE',
+  'data/keys/httpsig.pem',
+);
+
+export const HTTPSIG_BIND_REQUEST =
+  env.varOrDefault('HTTPSIG_BIND_REQUEST', 'true') === 'true';
+
+// Observer wallet for attestation signing
+export const OBSERVER_WALLET = env.varOrUndefined('OBSERVER_WALLET');
+export const WALLETS_PATH = env.varOrDefault('WALLETS_PATH', 'wallets');
+export const HTTPSIG_UPLOAD_ATTESTATION =
+  env.varOrDefault('HTTPSIG_UPLOAD_ATTESTATION', 'true') === 'true';
+
+let _httpSigPrivateKey: crypto.KeyObject | undefined;
+let _httpSigPublicKey: crypto.KeyObject | undefined;
+let _httpSigKeyId: string | undefined;
+let _httpSigPublicKeyB64Url: string | undefined;
+let _httpSigSolanaAddress: string | undefined;
+let _httpSigAttestation: Attestation | undefined;
+let _httpSigAttestationCached = false;
+let _httpSigObserverAddress: string | undefined;
+let _httpSigObserverJwk: crypto.JsonWebKey | undefined;
+
+if (isMainThread && HTTPSIG_ENABLED) {
+  _httpSigPrivateKey = loadOrGenerateKey(HTTPSIG_KEY_FILE);
+  _httpSigPublicKey = crypto.createPublicKey(_httpSigPrivateKey);
+  _httpSigKeyId = deriveKeyId(_httpSigPublicKey);
+  _httpSigPublicKeyB64Url = getPublicKeyBase64Url(_httpSigPublicKey);
+  _httpSigSolanaAddress = getSolanaAddress(_httpSigPublicKey);
+
+  logger.info('HTTPSIG response signing enabled', {
+    keyId: _httpSigKeyId,
+    publicKey: _httpSigPublicKeyB64Url,
+    solanaAddress: _httpSigSolanaAddress,
+    keyFile: HTTPSIG_KEY_FILE,
+    bindRequest: HTTPSIG_BIND_REQUEST,
+  });
+
+  // Create attestation if observer wallet is available
+  if (OBSERVER_WALLET !== undefined) {
+    try {
+      const walletPath = resolveWalletPath(WALLETS_PATH, OBSERVER_WALLET);
+      _httpSigObserverJwk = loadWalletJwk(walletPath);
+      _httpSigObserverAddress = jwkToArweaveAddress(_httpSigObserverJwk);
+
+      const keysDir =
+        HTTPSIG_KEY_FILE.substring(0, HTTPSIG_KEY_FILE.lastIndexOf('/')) ||
+        'data/keys';
+
+      const result = loadOrCreateAttestation({
+        keysDir,
+        observerJwk: _httpSigObserverJwk,
+        ed25519PublicKey: _httpSigPublicKey,
+        gatewayAddress: env.varOrUndefined('AR_IO_WALLET'),
+      });
+
+      _httpSigAttestation = {
+        payload: result.payload,
+        signature: result.signature,
+        rsaPublicKey: result.rsaPublicKey,
+      };
+      _httpSigAttestationCached = result.cached;
+
+      logger.info('HTTPSIG attestation ready', {
+        observerAddress: _httpSigObserverAddress,
+        cached: result.cached,
+      });
+    } catch (error: any) {
+      logger.warn('HTTPSIG attestation creation failed', {
+        error: error?.message,
+      });
+    }
+  }
+}
+
+export const HTTPSIG_PRIVATE_KEY = _httpSigPrivateKey;
+export const HTTPSIG_PUBLIC_KEY = _httpSigPublicKey;
+export const HTTPSIG_KEY_ID = _httpSigKeyId;
+export const HTTPSIG_PUBLIC_KEY_B64URL = _httpSigPublicKeyB64Url;
+export const HTTPSIG_SOLANA_ADDRESS = _httpSigSolanaAddress;
+export const HTTPSIG_ATTESTATION = _httpSigAttestation;
+export const HTTPSIG_ATTESTATION_CACHED = _httpSigAttestationCached;
+export const HTTPSIG_OBSERVER_ADDRESS = _httpSigObserverAddress;
+export const HTTPSIG_OBSERVER_JWK = _httpSigObserverJwk;
+
+// Set by app.ts after async upload completes
+let _httpSigAttestationTxId: string | undefined;
+export function getHttpSigAttestationTxId(): string | undefined {
+  return _httpSigAttestationTxId;
+}
+export function setHttpSigAttestationTxId(txId: string): void {
+  _httpSigAttestationTxId = txId;
+}
 
 //
 // Indexing

--- a/src/config.ts
+++ b/src/config.ts
@@ -1000,7 +1000,6 @@ let _httpSigKeyId: string | undefined;
 let _httpSigPublicKeyB64Url: string | undefined;
 let _httpSigSolanaAddress: string | undefined;
 let _httpSigAttestation: Attestation | undefined;
-let _httpSigAttestationCached = false;
 let _httpSigAttestationTxId: string | undefined;
 let _httpSigObserverAddress: string | undefined;
 let _httpSigObserverJwk: crypto.JsonWebKey | undefined;
@@ -1041,7 +1040,6 @@ if (isMainThread && HTTPSIG_ENABLED) {
         signature: result.signature,
         rsaPublicKey: result.rsaPublicKey,
       };
-      _httpSigAttestationCached = result.cached;
       _httpSigAttestationTxId = result.txId;
 
       logger.info('HTTPSIG attestation ready', {
@@ -1062,7 +1060,6 @@ export const HTTPSIG_KEY_ID = _httpSigKeyId;
 export const HTTPSIG_PUBLIC_KEY_B64URL = _httpSigPublicKeyB64Url;
 export const HTTPSIG_SOLANA_ADDRESS = _httpSigSolanaAddress;
 export const HTTPSIG_ATTESTATION = _httpSigAttestation;
-export const HTTPSIG_ATTESTATION_CACHED = _httpSigAttestationCached;
 export const HTTPSIG_OBSERVER_ADDRESS = _httpSigObserverAddress;
 export const HTTPSIG_OBSERVER_JWK = _httpSigObserverJwk;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@
  */
 import { canonicalize } from 'json-canonicalize';
 import crypto from 'node:crypto';
+import path from 'node:path';
 import { isMainThread } from 'node:worker_threads';
 import { existsSync, readFileSync } from 'node:fs';
 
@@ -18,6 +19,7 @@ import {
   getSolanaAddress,
   loadWalletJwk,
   loadOrCreateAttestation,
+  saveAttestationTxId,
   jwkToArweaveAddress,
   resolveWalletPath,
 } from './lib/httpsig.js';
@@ -999,6 +1001,7 @@ let _httpSigPublicKeyB64Url: string | undefined;
 let _httpSigSolanaAddress: string | undefined;
 let _httpSigAttestation: Attestation | undefined;
 let _httpSigAttestationCached = false;
+let _httpSigAttestationTxId: string | undefined;
 let _httpSigObserverAddress: string | undefined;
 let _httpSigObserverJwk: crypto.JsonWebKey | undefined;
 
@@ -1024,9 +1027,7 @@ if (isMainThread && HTTPSIG_ENABLED) {
       _httpSigObserverJwk = loadWalletJwk(walletPath);
       _httpSigObserverAddress = jwkToArweaveAddress(_httpSigObserverJwk);
 
-      const keysDir =
-        HTTPSIG_KEY_FILE.substring(0, HTTPSIG_KEY_FILE.lastIndexOf('/')) ||
-        'data/keys';
+      const keysDir = path.dirname(HTTPSIG_KEY_FILE) || 'data/keys';
 
       const result = loadOrCreateAttestation({
         keysDir,
@@ -1041,6 +1042,7 @@ if (isMainThread && HTTPSIG_ENABLED) {
         rsaPublicKey: result.rsaPublicKey,
       };
       _httpSigAttestationCached = result.cached;
+      _httpSigAttestationTxId = result.txId;
 
       logger.info('HTTPSIG attestation ready', {
         observerAddress: _httpSigObserverAddress,
@@ -1064,13 +1066,15 @@ export const HTTPSIG_ATTESTATION_CACHED = _httpSigAttestationCached;
 export const HTTPSIG_OBSERVER_ADDRESS = _httpSigObserverAddress;
 export const HTTPSIG_OBSERVER_JWK = _httpSigObserverJwk;
 
-// Set by app.ts after async upload completes
-let _httpSigAttestationTxId: string | undefined;
+export const HTTPSIG_KEYS_DIR = path.dirname(HTTPSIG_KEY_FILE) || 'data/keys';
+
 export function getHttpSigAttestationTxId(): string | undefined {
   return _httpSigAttestationTxId;
 }
 export function setHttpSigAttestationTxId(txId: string): void {
   _httpSigAttestationTxId = txId;
+  // Persist txId to cache file so it survives restarts
+  saveAttestationTxId(HTTPSIG_KEYS_DIR, txId);
 }
 
 //

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,25 +5,16 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { canonicalize } from 'json-canonicalize';
-import crypto from 'node:crypto';
-import path from 'node:path';
 import { isMainThread } from 'node:worker_threads';
 import { existsSync, readFileSync } from 'node:fs';
 
 import { createFilter } from './filters.js';
 import * as env from './lib/env.js';
-import {
-  loadOrGenerateKey,
-  deriveKeyId,
-  getPublicKeyBase64Url,
-  getSolanaAddress,
-  loadWalletJwk,
-  loadOrCreateAttestation,
-  saveAttestationTxId,
-  jwkToArweaveAddress,
-  resolveWalletPath,
+import { initHttpSig, saveAttestationTxId } from './lib/httpsig.js';
+import type {
+  HttpSigObserverContext,
+  HttpSigSignerContext,
 } from './lib/httpsig.js';
-import type { Attestation } from './lib/httpsig.js';
 import { release } from './version.js';
 import logger from './log.js';
 import { verificationPriorities } from './constants.js';
@@ -994,84 +985,34 @@ export const WALLETS_PATH = env.varOrDefault('WALLETS_PATH', 'wallets');
 export const HTTPSIG_UPLOAD_ATTESTATION =
   env.varOrDefault('HTTPSIG_UPLOAD_ATTESTATION', 'true') === 'true';
 
-let _httpSigPrivateKey: crypto.KeyObject | undefined;
-let _httpSigPublicKey: crypto.KeyObject | undefined;
-let _httpSigKeyId: string | undefined;
-let _httpSigPublicKeyB64Url: string | undefined;
-let _httpSigSolanaAddress: string | undefined;
-let _httpSigAttestation: Attestation | undefined;
-let _httpSigAttestationTxId: string | undefined;
-let _httpSigObserverAddress: string | undefined;
-let _httpSigObserverJwk: crypto.JsonWebKey | undefined;
+let _httpSigSigner: HttpSigSignerContext | undefined;
+let _httpSigObserver: HttpSigObserverContext | undefined;
 
 if (isMainThread && HTTPSIG_ENABLED) {
-  _httpSigPrivateKey = loadOrGenerateKey(HTTPSIG_KEY_FILE);
-  _httpSigPublicKey = crypto.createPublicKey(_httpSigPrivateKey);
-  _httpSigKeyId = deriveKeyId(_httpSigPublicKey);
-  _httpSigPublicKeyB64Url = getPublicKeyBase64Url(_httpSigPublicKey);
-  _httpSigSolanaAddress = getSolanaAddress(_httpSigPublicKey);
-
-  logger.info('HTTPSIG response signing enabled', {
-    keyId: _httpSigKeyId,
-    publicKey: _httpSigPublicKeyB64Url,
-    solanaAddress: _httpSigSolanaAddress,
+  const result = initHttpSig({
     keyFile: HTTPSIG_KEY_FILE,
     bindRequest: HTTPSIG_BIND_REQUEST,
+    observerWallet: OBSERVER_WALLET,
+    walletsPath: WALLETS_PATH,
+    gatewayAddress: env.varOrUndefined('AR_IO_WALLET'),
+    log: logger,
   });
-
-  // Create attestation if observer wallet is available
-  if (OBSERVER_WALLET !== undefined) {
-    try {
-      const walletPath = resolveWalletPath(WALLETS_PATH, OBSERVER_WALLET);
-      _httpSigObserverJwk = loadWalletJwk(walletPath);
-      _httpSigObserverAddress = jwkToArweaveAddress(_httpSigObserverJwk);
-
-      const keysDir = path.dirname(HTTPSIG_KEY_FILE) || 'data/keys';
-
-      const result = loadOrCreateAttestation({
-        keysDir,
-        observerJwk: _httpSigObserverJwk,
-        ed25519PublicKey: _httpSigPublicKey,
-        gatewayAddress: env.varOrUndefined('AR_IO_WALLET'),
-      });
-
-      _httpSigAttestation = {
-        payload: result.payload,
-        signature: result.signature,
-        rsaPublicKey: result.rsaPublicKey,
-      };
-      _httpSigAttestationTxId = result.txId;
-
-      logger.info('HTTPSIG attestation ready', {
-        observerAddress: _httpSigObserverAddress,
-        cached: result.cached,
-      });
-    } catch (error: any) {
-      logger.warn('HTTPSIG attestation creation failed', {
-        error: error?.message,
-      });
-    }
-  }
+  _httpSigSigner = result.signer;
+  _httpSigObserver = result.observer;
 }
 
-export const HTTPSIG_PRIVATE_KEY = _httpSigPrivateKey;
-export const HTTPSIG_PUBLIC_KEY = _httpSigPublicKey;
-export const HTTPSIG_KEY_ID = _httpSigKeyId;
-export const HTTPSIG_PUBLIC_KEY_B64URL = _httpSigPublicKeyB64Url;
-export const HTTPSIG_SOLANA_ADDRESS = _httpSigSolanaAddress;
-export const HTTPSIG_ATTESTATION = _httpSigAttestation;
-export const HTTPSIG_OBSERVER_ADDRESS = _httpSigObserverAddress;
-export const HTTPSIG_OBSERVER_JWK = _httpSigObserverJwk;
+export const HTTPSIG_SIGNER = _httpSigSigner;
+export const HTTPSIG_OBSERVER = _httpSigObserver;
 
-export const HTTPSIG_KEYS_DIR = path.dirname(HTTPSIG_KEY_FILE) || 'data/keys';
-
-export function getHttpSigAttestationTxId(): string | undefined {
-  return _httpSigAttestationTxId;
-}
+/**
+ * Record the Arweave TX ID of a successfully uploaded attestation. Mutates
+ * `HTTPSIG_OBSERVER.attestationTxId` and persists it to the cache file so
+ * subsequent restarts skip re-uploading.
+ */
 export function setHttpSigAttestationTxId(txId: string): void {
-  _httpSigAttestationTxId = txId;
-  // Persist txId to cache file so it survives restarts
-  saveAttestationTxId(HTTPSIG_KEYS_DIR, txId);
+  if (_httpSigObserver === undefined) return;
+  _httpSigObserver.attestationTxId = txId;
+  saveAttestationTxId(_httpSigObserver.keysDir, txId);
 }
 
 //

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,6 +74,10 @@ export const headerNames = {
   arweaveTagsTruncated: 'X-Arweave-Tags-Truncated',
   // Per-tag headers are emitted dynamically as X-Arweave-Tag-{Name}
   // by setDataHeaders in src/routes/data/handlers.ts.
+
+  // RFC 9421 HTTP Message Signatures
+  signature: 'Signature',
+  signatureInput: 'Signature-Input',
 };
 
 export const verificationPriorities = {

--- a/src/lib/httpsig-upload.test.ts
+++ b/src/lib/httpsig-upload.test.ts
@@ -1,0 +1,65 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { buildAttestationTags } from './httpsig-upload.js';
+
+describe('httpsig-upload', () => {
+  describe('buildAttestationTags', () => {
+    it('includes all required tags', () => {
+      const tags = buildAttestationTags({
+        gatewayAddress: 'gw-addr',
+        observerAddress: 'obs-addr',
+        ed25519PublicKey: 'pubkey-b64url',
+        keyId: 'ed25519:pubkey-b64url',
+      });
+
+      const names = tags.map((t) => t.name);
+      assert.ok(names.includes('App-Name'));
+      assert.ok(names.includes('Type'));
+      assert.ok(names.includes('Content-Type'));
+      assert.ok(names.includes('Gateway-Address'));
+      assert.ok(names.includes('Observer-Address'));
+      assert.ok(names.includes('Ed25519-Public-Key'));
+      assert.ok(names.includes('Key-Id'));
+    });
+
+    it('sets correct values', () => {
+      const tags = buildAttestationTags({
+        gatewayAddress: 'gw-addr',
+        observerAddress: 'obs-addr',
+        ed25519PublicKey: 'pubkey',
+        keyId: 'ed25519:pubkey',
+      });
+
+      const find = (name: string) => tags.find((t) => t.name === name)?.value;
+      assert.equal(find('App-Name'), 'AR-IO-Gateway');
+      assert.equal(find('Type'), 'HTTPSIG-Key-Attestation');
+      assert.equal(find('Content-Type'), 'application/json');
+      assert.equal(find('Gateway-Address'), 'gw-addr');
+      assert.equal(find('Observer-Address'), 'obs-addr');
+      assert.equal(find('Ed25519-Public-Key'), 'pubkey');
+      assert.equal(find('Key-Id'), 'ed25519:pubkey');
+    });
+
+    it('omits Gateway-Address when undefined', () => {
+      const tags = buildAttestationTags({
+        gatewayAddress: undefined,
+        observerAddress: 'obs-addr',
+        ed25519PublicKey: 'pubkey',
+        keyId: 'ed25519:pubkey',
+      });
+
+      const names = tags.map((t) => t.name);
+      assert.ok(!names.includes('Gateway-Address'));
+      // Other required tags still present
+      assert.ok(names.includes('App-Name'));
+      assert.ok(names.includes('Observer-Address'));
+    });
+  });
+});

--- a/src/lib/httpsig-upload.test.ts
+++ b/src/lib/httpsig-upload.test.ts
@@ -57,9 +57,28 @@ describe('httpsig-upload', () => {
 
       const names = tags.map((t) => t.name);
       assert.ok(!names.includes('Gateway-Address'));
-      // Other required tags still present
       assert.ok(names.includes('App-Name'));
       assert.ok(names.includes('Observer-Address'));
+    });
+
+    it('returns correct number of tags with gateway address', () => {
+      const tags = buildAttestationTags({
+        gatewayAddress: 'gw',
+        observerAddress: 'obs',
+        ed25519PublicKey: 'pk',
+        keyId: 'kid',
+      });
+      assert.equal(tags.length, 7);
+    });
+
+    it('returns correct number of tags without gateway address', () => {
+      const tags = buildAttestationTags({
+        gatewayAddress: undefined,
+        observerAddress: 'obs',
+        ed25519PublicKey: 'pk',
+        keyId: 'kid',
+      });
+      assert.equal(tags.length, 6);
     });
   });
 });

--- a/src/lib/httpsig-upload.ts
+++ b/src/lib/httpsig-upload.ts
@@ -48,7 +48,7 @@ export function buildAttestationTags(opts: {
 
 /**
  * Try to upload via Turbo SDK. Returns the data item ID on success, or
- * undefined if the SDK is not installed (production builds strip devDeps).
+ * undefined if the SDK module cannot be resolved.
  *
  * Any error other than "module not found" is rethrown — we don't want a
  * transient Turbo failure (auth, network, etc.) to silently fall through to
@@ -59,7 +59,6 @@ async function tryTurboUpload(
   attestationJson: string,
   tags: { name: string; value: string }[],
 ): Promise<string | undefined> {
-  // Load SDK lazily — devDependency may not be present in production builds
   let TurboFactory: any;
   let ArweaveSigner: any;
   try {

--- a/src/lib/httpsig-upload.ts
+++ b/src/lib/httpsig-upload.ts
@@ -1,0 +1,147 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import crypto from 'node:crypto';
+import { Readable } from 'node:stream';
+import { createRequire } from 'node:module';
+
+import Arweave from 'arweave';
+import winston from 'winston';
+
+import { Attestation } from './httpsig.js';
+
+export interface AttestationUploadOpts {
+  jwk: crypto.JsonWebKey;
+  attestation: Attestation;
+  gatewayAddress: string | undefined;
+  observerAddress: string;
+  ed25519PublicKey: string;
+  keyId: string;
+  log: winston.Logger;
+}
+
+/**
+ * Build the Arweave transaction tags for an HTTPSIG attestation upload.
+ */
+export function buildAttestationTags(opts: {
+  gatewayAddress: string | undefined;
+  observerAddress: string;
+  ed25519PublicKey: string;
+  keyId: string;
+}): { name: string; value: string }[] {
+  const tags: { name: string; value: string }[] = [
+    { name: 'App-Name', value: 'AR-IO-Gateway' },
+    { name: 'Type', value: 'HTTPSIG-Key-Attestation' },
+    { name: 'Content-Type', value: 'application/json' },
+    { name: 'Observer-Address', value: opts.observerAddress },
+    { name: 'Ed25519-Public-Key', value: opts.ed25519PublicKey },
+    { name: 'Key-Id', value: opts.keyId },
+  ];
+  if (opts.gatewayAddress !== undefined) {
+    tags.push({ name: 'Gateway-Address', value: opts.gatewayAddress });
+  }
+  return tags;
+}
+
+/**
+ * Try to upload via Turbo SDK. Returns the data item ID on success, or
+ * undefined if the SDK is not installed (production builds strip devDeps).
+ */
+async function tryTurboUpload(
+  jwk: crypto.JsonWebKey,
+  attestationJson: string,
+  tags: { name: string; value: string }[],
+): Promise<string | undefined> {
+  try {
+    // turbo-sdk is a devDependency — may not be present in production.
+    // Use createRequire to load via CJS (same pattern as
+    // tools/lib/upload-cdb64-to-arweave.ts).
+    const require = createRequire(import.meta.url);
+    const { TurboFactory, ArweaveSigner } = require('@ardrive/turbo-sdk');
+
+    const signer = new ArweaveSigner(jwk);
+    const turbo = TurboFactory.authenticated({ signer });
+
+    const result = await turbo.uploadFile({
+      fileStreamFactory: () => Readable.from(Buffer.from(attestationJson)),
+      fileSizeFactory: () => Buffer.byteLength(attestationJson),
+      dataItemOpts: { tags },
+    });
+
+    return result.id;
+  } catch {
+    // SDK not available or upload failed — caller will fall back to L1
+    return undefined;
+  }
+}
+
+/**
+ * Upload an HTTPSIG attestation to Arweave. Tries Turbo SDK first (if
+ * available), then falls back to direct L1 posting via arweave.js.
+ *
+ * @returns The Arweave transaction/data-item ID.
+ */
+export async function uploadAttestation(
+  opts: AttestationUploadOpts,
+): Promise<string> {
+  const {
+    jwk,
+    attestation,
+    gatewayAddress,
+    observerAddress,
+    ed25519PublicKey,
+    keyId,
+    log,
+  } = opts;
+
+  const tags = buildAttestationTags({
+    gatewayAddress,
+    observerAddress,
+    ed25519PublicKey,
+    keyId,
+  });
+
+  const attestationJson = JSON.stringify(attestation);
+
+  // Try Turbo SDK first (subsidized bundled upload)
+  const turboId = await tryTurboUpload(jwk, attestationJson, tags);
+  if (turboId !== undefined) {
+    log.info('HTTPSIG attestation uploaded via Turbo', { txId: turboId });
+    return turboId;
+  }
+
+  log.info('Turbo SDK not available, uploading attestation via L1');
+
+  // Fallback: direct L1 transaction via arweave.js
+  const arweave = Arweave.init({
+    host: 'arweave.net',
+    port: 443,
+    protocol: 'https',
+  });
+
+  // Cast to any — the JWK has been validated by loadWalletJwk() upstream.
+  // arweave.js expects its own JWKInterface type which is structurally
+  // identical but not assignable from crypto.JsonWebKey.
+  const jwkAny = jwk as any;
+  const tx = await arweave.createTransaction({ data: attestationJson }, jwkAny);
+  for (const tag of tags) {
+    tx.addTag(tag.name, tag.value);
+  }
+
+  await arweave.transactions.sign(tx, jwkAny);
+  const response = await arweave.transactions.post(tx);
+
+  // Arweave POST /tx returns 200 (accepted) or 202 (accepted for mempool)
+  if (response.status !== 200 && response.status !== 202) {
+    throw new Error(
+      `Failed to post attestation L1 transaction: ${response.status}`,
+    );
+  }
+
+  log.info('HTTPSIG attestation uploaded via L1', { txId: tx.id });
+
+  return tx.id;
+}

--- a/src/lib/httpsig-upload.ts
+++ b/src/lib/httpsig-upload.ts
@@ -72,7 +72,6 @@ async function tryTurboUpload(
     throw err;
   }
 
-  // SDK is available — upload failures propagate to the caller
   const signer = new ArweaveSigner(jwk);
   const turbo = TurboFactory.authenticated({ signer });
 
@@ -113,7 +112,6 @@ export async function uploadAttestation(
 
   const attestationJson = JSON.stringify(attestation);
 
-  // Try Turbo SDK first (subsidized bundled upload)
   const turboId = await tryTurboUpload(jwk, attestationJson, tags);
   if (turboId !== undefined) {
     log.info('HTTPSIG attestation uploaded via Turbo', { txId: turboId });
@@ -122,7 +120,6 @@ export async function uploadAttestation(
 
   log.info('Turbo SDK not available, uploading attestation via L1');
 
-  // Fallback: direct L1 transaction via arweave.js
   const arweave = Arweave.init({
     host: 'arweave.net',
     port: 443,

--- a/src/lib/httpsig-upload.ts
+++ b/src/lib/httpsig-upload.ts
@@ -49,33 +49,40 @@ export function buildAttestationTags(opts: {
 /**
  * Try to upload via Turbo SDK. Returns the data item ID on success, or
  * undefined if the SDK is not installed (production builds strip devDeps).
+ *
+ * Any error other than "module not found" is rethrown — we don't want a
+ * transient Turbo failure (auth, network, etc.) to silently fall through to
+ * an L1 post that burns AR tokens.
  */
 async function tryTurboUpload(
   jwk: crypto.JsonWebKey,
   attestationJson: string,
   tags: { name: string; value: string }[],
 ): Promise<string | undefined> {
+  // Load SDK lazily — devDependency may not be present in production builds
+  let TurboFactory: any;
+  let ArweaveSigner: any;
   try {
-    // turbo-sdk is a devDependency — may not be present in production.
-    // Use createRequire to load via CJS (same pattern as
-    // tools/lib/upload-cdb64-to-arweave.ts).
     const require = createRequire(import.meta.url);
-    const { TurboFactory, ArweaveSigner } = require('@ardrive/turbo-sdk');
-
-    const signer = new ArweaveSigner(jwk);
-    const turbo = TurboFactory.authenticated({ signer });
-
-    const result = await turbo.uploadFile({
-      fileStreamFactory: () => Readable.from(Buffer.from(attestationJson)),
-      fileSizeFactory: () => Buffer.byteLength(attestationJson),
-      dataItemOpts: { tags },
-    });
-
-    return result.id;
-  } catch {
-    // SDK not available or upload failed — caller will fall back to L1
-    return undefined;
+    ({ TurboFactory, ArweaveSigner } = require('@ardrive/turbo-sdk'));
+  } catch (err: any) {
+    if (err?.code === 'MODULE_NOT_FOUND') {
+      return undefined;
+    }
+    throw err;
   }
+
+  // SDK is available — upload failures propagate to the caller
+  const signer = new ArweaveSigner(jwk);
+  const turbo = TurboFactory.authenticated({ signer });
+
+  const result = await turbo.uploadFile({
+    fileStreamFactory: () => Readable.from(Buffer.from(attestationJson)),
+    fileSizeFactory: () => Buffer.byteLength(attestationJson),
+    dataItemOpts: { tags },
+  });
+
+  return result.id;
 }
 
 /**

--- a/src/lib/httpsig.test.ts
+++ b/src/lib/httpsig.test.ts
@@ -14,7 +14,6 @@ import path from 'node:path';
 import {
   TRIGGER_HEADERS,
   CO_SIGNABLE_HEADERS,
-  SIGNABLE_PREFIXES,
   isSignableHeader,
   isTriggerHeader,
   loadOrGenerateKey,
@@ -79,7 +78,6 @@ describe('httpsig lib', () => {
     it('has consistent sets', () => {
       assert.ok(TRIGGER_HEADERS.size > 0);
       assert.ok(CO_SIGNABLE_HEADERS.size > 0);
-      assert.ok(SIGNABLE_PREFIXES.length > 0);
     });
   });
 
@@ -231,9 +229,9 @@ describe('httpsig lib', () => {
         'x-ar-io-data-id': 'abc123',
       };
 
-      const base = buildSignatureBase(
+      const { base } = buildSignatureBase(
         200,
-        (name) => headers[name.toLowerCase()],
+        (name) => headers[name],
         ['content-type', 'x-ar-io-data-id'],
         'GET',
         '/raw/abc123',
@@ -250,7 +248,7 @@ describe('httpsig lib', () => {
     });
 
     it('includes request-bound components when bindRequest is true', () => {
-      const base = buildSignatureBase(
+      const { base } = buildSignatureBase(
         200,
         () => 'value',
         ['content-type'],
@@ -266,7 +264,7 @@ describe('httpsig lib', () => {
     });
 
     it('omits request-bound components when bindRequest is false', () => {
-      const base = buildSignatureBase(
+      const { base } = buildSignatureBase(
         200,
         () => 'value',
         ['content-type'],
@@ -286,9 +284,9 @@ describe('httpsig lib', () => {
         'x-ar-io-data-id': 'abc',
       };
 
-      const base = buildSignatureBase(
+      const { base } = buildSignatureBase(
         200,
-        (name) => headers[name.toLowerCase()],
+        (name) => headers[name],
         ['x-ar-io-data-id'],
         'GET',
         '/',
@@ -308,9 +306,9 @@ describe('httpsig lib', () => {
         'x-ar-io-data-id': 'abc',
       };
 
-      const base = buildSignatureBase(
+      const { base } = buildSignatureBase(
         200,
-        (name) => headers[name.toLowerCase()],
+        (name) => headers[name],
         ['x-arweave-tag-content-type', 'x-ar-io-data-id'],
         'GET',
         '/',
@@ -325,7 +323,7 @@ describe('httpsig lib', () => {
     });
 
     it('has no trailing newline', () => {
-      const base = buildSignatureBase(
+      const { base } = buildSignatureBase(
         200,
         () => 'v',
         ['content-type'],
@@ -339,6 +337,47 @@ describe('httpsig lib', () => {
       assert.ok(!base.endsWith('\n'));
     });
 
+    it('returns paramStr matching formatSignatureInput output', () => {
+      const { paramStr } = buildSignatureBase(
+        200,
+        () => 'v',
+        ['content-type'],
+        'GET',
+        '/',
+        false,
+        1712505600,
+        'k1',
+      );
+
+      assert.equal(
+        paramStr,
+        formatSignatureInput(['content-type'], 1712505600, 'k1', false),
+      );
+    });
+
+    it('canonicalizes covered header names to lowercase', () => {
+      const headers: Record<string, string> = {
+        'content-type': 'application/octet-stream',
+        'x-ar-io-data-id': 'abc123',
+      };
+
+      const { base, paramStr } = buildSignatureBase(
+        200,
+        (name) => headers[name.toLowerCase()],
+        ['Content-Type', 'X-AR-IO-Data-Id'],
+        'GET',
+        '/raw/abc123',
+        false,
+        1712505600,
+        'testkey1',
+      );
+
+      assert.ok(base.includes('"content-type": application/octet-stream'));
+      assert.ok(base.includes('"x-ar-io-data-id": abc123'));
+      assert.ok(paramStr.includes('"content-type"'));
+      assert.ok(paramStr.includes('"x-ar-io-data-id"'));
+    });
+
     it('produces a signable base that can be verified end-to-end', () => {
       const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519');
       const keyId = deriveKeyId(publicKey);
@@ -348,9 +387,9 @@ describe('httpsig lib', () => {
         'x-ar-io-verified': 'true',
       };
 
-      const base = buildSignatureBase(
+      const { base } = buildSignatureBase(
         200,
-        (name) => headers[name.toLowerCase()],
+        (name) => headers[name],
         ['content-type', 'x-ar-io-verified'],
         'GET',
         '/test',

--- a/src/lib/httpsig.test.ts
+++ b/src/lib/httpsig.test.ts
@@ -24,6 +24,7 @@ import {
   loadWalletJwk,
   createAttestation,
   loadOrCreateAttestation,
+  saveAttestationTxId,
   jwkToArweaveAddress,
 } from './httpsig.js';
 
@@ -569,6 +570,34 @@ describe('httpsig lib', () => {
       assert.equal(first.cached, false);
       assert.equal(second.cached, false);
       assert.notEqual(first.signature, second.signature);
+    });
+
+    it('returns persisted txId from cache', () => {
+      const dir = makeTmpDir();
+      const observerJwk = generateTestRsaJwk();
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      // Create attestation
+      loadOrCreateAttestation({
+        keysDir: dir,
+        observerJwk,
+        ed25519PublicKey: publicKey,
+        gatewayAddress: undefined,
+      });
+
+      // Persist txId
+      saveAttestationTxId(dir, 'arweave-tx-123');
+
+      // Reload — should return the txId
+      const result = loadOrCreateAttestation({
+        keysDir: dir,
+        observerJwk,
+        ed25519PublicKey: publicKey,
+        gatewayAddress: undefined,
+      });
+
+      assert.equal(result.cached, true);
+      assert.equal(result.txId, 'arweave-tx-123');
     });
   });
 });

--- a/src/lib/httpsig.test.ts
+++ b/src/lib/httpsig.test.ts
@@ -12,9 +12,11 @@ import os from 'node:os';
 import path from 'node:path';
 
 import {
-  SIGNABLE_HEADERS,
+  TRIGGER_HEADERS,
+  CO_SIGNABLE_HEADERS,
   SIGNABLE_PREFIXES,
   isSignableHeader,
+  isTriggerHeader,
   loadOrGenerateKey,
   deriveKeyId,
   getPublicKeyBase64Url,
@@ -44,13 +46,16 @@ describe('httpsig lib', () => {
   }
 
   describe('isSignableHeader', () => {
-    it('matches exact headers in SIGNABLE_HEADERS', () => {
+    it('matches trigger headers', () => {
       assert.equal(isSignableHeader('x-ar-io-data-id'), true);
       assert.equal(isSignableHeader('x-ar-io-verified'), true);
-      assert.equal(isSignableHeader('content-type'), true);
-      assert.equal(isSignableHeader('content-digest'), true);
       assert.equal(isSignableHeader('x-arns-name'), true);
       assert.equal(isSignableHeader('x-arweave-chunk-data-root'), true);
+    });
+
+    it('matches co-signable headers', () => {
+      assert.equal(isSignableHeader('content-type'), true);
+      assert.equal(isSignableHeader('content-digest'), true);
     });
 
     it('matches x-arweave-tag-* prefix', () => {
@@ -72,8 +77,35 @@ describe('httpsig lib', () => {
     });
 
     it('has consistent sets', () => {
-      assert.ok(SIGNABLE_HEADERS.size > 0);
+      assert.ok(TRIGGER_HEADERS.size > 0);
+      assert.ok(CO_SIGNABLE_HEADERS.size > 0);
       assert.ok(SIGNABLE_PREFIXES.length > 0);
+    });
+  });
+
+  describe('isTriggerHeader', () => {
+    it('returns true for trust-relevant headers', () => {
+      assert.equal(isTriggerHeader('x-ar-io-data-id'), true);
+      assert.equal(isTriggerHeader('x-arns-name'), true);
+      assert.equal(isTriggerHeader('x-arweave-chunk-data-root'), true);
+    });
+
+    it('returns false for content-type (not a trigger, only co-signable)', () => {
+      assert.equal(isTriggerHeader('content-type'), false);
+      assert.equal(isTriggerHeader('content-digest'), false);
+    });
+
+    it('returns false for operational headers', () => {
+      assert.equal(isTriggerHeader('cache-control'), false);
+      assert.equal(isTriggerHeader('x-request-id'), false);
+    });
+
+    it('returns false for tag headers (co-signable via prefix, not trigger)', () => {
+      assert.equal(isTriggerHeader('x-arweave-tag-content-type'), false);
+    });
+
+    it('is case-insensitive', () => {
+      assert.equal(isTriggerHeader('X-AR-IO-Data-Id'), true);
     });
   });
 

--- a/src/lib/httpsig.test.ts
+++ b/src/lib/httpsig.test.ts
@@ -1,0 +1,574 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { afterEach, describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  SIGNABLE_HEADERS,
+  SIGNABLE_PREFIXES,
+  isSignableHeader,
+  loadOrGenerateKey,
+  deriveKeyId,
+  getPublicKeyBase64Url,
+  buildSignatureBase,
+  formatSignatureInput,
+  getSolanaAddress,
+  loadWalletJwk,
+  createAttestation,
+  loadOrCreateAttestation,
+  jwkToArweaveAddress,
+} from './httpsig.js';
+
+describe('httpsig lib', () => {
+  // Temp directory for key file tests
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir !== undefined) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  function makeTmpDir(): string {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'httpsig-test-'));
+    return tmpDir;
+  }
+
+  describe('isSignableHeader', () => {
+    it('matches exact headers in SIGNABLE_HEADERS', () => {
+      assert.equal(isSignableHeader('x-ar-io-data-id'), true);
+      assert.equal(isSignableHeader('x-ar-io-verified'), true);
+      assert.equal(isSignableHeader('content-type'), true);
+      assert.equal(isSignableHeader('content-digest'), true);
+      assert.equal(isSignableHeader('x-arns-name'), true);
+      assert.equal(isSignableHeader('x-arweave-chunk-data-root'), true);
+    });
+
+    it('matches x-arweave-tag-* prefix', () => {
+      assert.equal(isSignableHeader('x-arweave-tag-content-type'), true);
+      assert.equal(isSignableHeader('x-arweave-tag-app-name'), true);
+      assert.equal(isSignableHeader('x-arweave-tag-'), true);
+    });
+
+    it('rejects non-signable headers', () => {
+      assert.equal(isSignableHeader('cache-control'), false);
+      assert.equal(isSignableHeader('x-request-id'), false);
+      assert.equal(isSignableHeader('x-ar-io-hops'), false);
+      assert.equal(isSignableHeader('x-ar-io-via'), false);
+    });
+
+    it('is case-insensitive', () => {
+      assert.equal(isSignableHeader('X-AR-IO-Data-Id'), true);
+      assert.equal(isSignableHeader('X-Arweave-Tag-App-Name'), true);
+    });
+
+    it('has consistent sets', () => {
+      assert.ok(SIGNABLE_HEADERS.size > 0);
+      assert.ok(SIGNABLE_PREFIXES.length > 0);
+    });
+  });
+
+  describe('loadOrGenerateKey', () => {
+    it('generates a new Ed25519 key when file does not exist', () => {
+      const dir = makeTmpDir();
+      const keyFile = path.join(dir, 'subdir', 'test.pem');
+
+      const key = loadOrGenerateKey(keyFile);
+
+      assert.equal(key.type, 'private');
+      assert.equal(key.asymmetricKeyType, 'ed25519');
+      assert.ok(fs.existsSync(keyFile));
+    });
+
+    it('loads an existing key from PEM file', () => {
+      const dir = makeTmpDir();
+      const keyFile = path.join(dir, 'test.pem');
+
+      // Generate and save
+      const key1 = loadOrGenerateKey(keyFile);
+      const pub1 = crypto.createPublicKey(key1);
+      const id1 = deriveKeyId(pub1);
+
+      // Load existing
+      const key2 = loadOrGenerateKey(keyFile);
+      const pub2 = crypto.createPublicKey(key2);
+      const id2 = deriveKeyId(pub2);
+
+      assert.equal(id1, id2);
+    });
+
+    it('creates parent directories recursively', () => {
+      const dir = makeTmpDir();
+      const keyFile = path.join(dir, 'a', 'b', 'c', 'test.pem');
+
+      loadOrGenerateKey(keyFile);
+
+      assert.ok(fs.existsSync(keyFile));
+    });
+  });
+
+  describe('deriveKeyId', () => {
+    it('produces a self-contained ed25519:<base64url> key ID', () => {
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      const id = deriveKeyId(publicKey);
+
+      assert.ok(id.startsWith('ed25519:'));
+      // "ed25519:" (8 chars) + 43-char base64url = 51 chars
+      assert.equal(id.length, 51);
+      assert.match(id, /^ed25519:[A-Za-z0-9_-]{43}$/);
+    });
+
+    it('is stable across calls', () => {
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      assert.equal(deriveKeyId(publicKey), deriveKeyId(publicKey));
+    });
+
+    it('produces different IDs for different keys', () => {
+      const { publicKey: pub1 } = crypto.generateKeyPairSync('ed25519');
+      const { publicKey: pub2 } = crypto.generateKeyPairSync('ed25519');
+
+      assert.notEqual(deriveKeyId(pub1), deriveKeyId(pub2));
+    });
+
+    it('contains the same key as getPublicKeyBase64Url', () => {
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      const keyId = deriveKeyId(publicKey);
+      const pubB64 = getPublicKeyBase64Url(publicKey);
+
+      assert.equal(keyId, `ed25519:${pubB64}`);
+    });
+  });
+
+  describe('getPublicKeyBase64Url', () => {
+    it('returns a 43-char base64url string for 32-byte key', () => {
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      const b64 = getPublicKeyBase64Url(publicKey);
+
+      assert.equal(b64.length, 43);
+      assert.match(b64, /^[A-Za-z0-9_-]+$/);
+    });
+  });
+
+  describe('formatSignatureInput', () => {
+    it('produces correct structured field syntax', () => {
+      const result = formatSignatureInput(
+        ['content-type', 'x-ar-io-data-id'],
+        1712505600,
+        'testkey1',
+        false,
+      );
+
+      assert.equal(
+        result,
+        '("@status" "content-type" "x-ar-io-data-id");created=1712505600;keyid="testkey1";alg="ed25519"',
+      );
+    });
+
+    it('includes request-bound components when bindRequest is true', () => {
+      const result = formatSignatureInput([], 1000, 'k1', true);
+
+      assert.ok(result.includes('"@method";req'));
+      assert.ok(result.includes('"@path";req'));
+    });
+
+    it('omits request-bound components when bindRequest is false', () => {
+      const result = formatSignatureInput([], 1000, 'k1', false);
+
+      assert.ok(!result.includes('@method'));
+      assert.ok(!result.includes('@path'));
+    });
+  });
+
+  describe('buildSignatureBase', () => {
+    it('produces correct RFC 9421 signature base format', () => {
+      const headers: Record<string, string> = {
+        'content-type': 'application/octet-stream',
+        'x-ar-io-data-id': 'abc123',
+      };
+
+      const base = buildSignatureBase(
+        200,
+        (name) => headers[name.toLowerCase()],
+        ['content-type', 'x-ar-io-data-id'],
+        'GET',
+        '/raw/abc123',
+        false,
+        1712505600,
+        'testkey1',
+      );
+
+      const lines = base.split('\n');
+      assert.equal(lines[0], '"@status": 200');
+      assert.equal(lines[1], '"content-type": application/octet-stream');
+      assert.equal(lines[2], '"x-ar-io-data-id": abc123');
+      assert.ok(lines[3].startsWith('"@signature-params":'));
+    });
+
+    it('includes request-bound components when bindRequest is true', () => {
+      const base = buildSignatureBase(
+        200,
+        () => 'value',
+        ['content-type'],
+        'GET',
+        '/raw/abc123',
+        true,
+        1000,
+        'k1',
+      );
+
+      assert.ok(base.includes('"@method";req: GET'));
+      assert.ok(base.includes('"@path";req: /raw/abc123'));
+    });
+
+    it('omits request-bound components when bindRequest is false', () => {
+      const base = buildSignatureBase(
+        200,
+        () => 'value',
+        ['content-type'],
+        'GET',
+        '/raw/abc123',
+        false,
+        1000,
+        'k1',
+      );
+
+      assert.ok(!base.includes('@method'));
+      assert.ok(!base.includes('@path'));
+    });
+
+    it('only includes provided covered headers', () => {
+      const headers: Record<string, string> = {
+        'x-ar-io-data-id': 'abc',
+      };
+
+      const base = buildSignatureBase(
+        200,
+        (name) => headers[name.toLowerCase()],
+        ['x-ar-io-data-id'],
+        'GET',
+        '/',
+        false,
+        1000,
+        'k1',
+      );
+
+      const lines = base.split('\n');
+      // @status + one header + @signature-params = 3 lines
+      assert.equal(lines.length, 3);
+    });
+
+    it('serializes multi-value (array) headers with comma separation', () => {
+      const headers: Record<string, string | string[]> = {
+        'x-arweave-tag-content-type': ['image/png', 'text/html'],
+        'x-ar-io-data-id': 'abc',
+      };
+
+      const base = buildSignatureBase(
+        200,
+        (name) => headers[name.toLowerCase()],
+        ['x-arweave-tag-content-type', 'x-ar-io-data-id'],
+        'GET',
+        '/',
+        false,
+        1000,
+        'k1',
+      );
+
+      assert.ok(
+        base.includes('"x-arweave-tag-content-type": image/png, text/html'),
+      );
+    });
+
+    it('has no trailing newline', () => {
+      const base = buildSignatureBase(
+        200,
+        () => 'v',
+        ['content-type'],
+        'GET',
+        '/',
+        false,
+        1000,
+        'k1',
+      );
+
+      assert.ok(!base.endsWith('\n'));
+    });
+
+    it('produces a signable base that can be verified end-to-end', () => {
+      const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519');
+      const keyId = deriveKeyId(publicKey);
+
+      const headers: Record<string, string> = {
+        'content-type': 'text/plain',
+        'x-ar-io-verified': 'true',
+      };
+
+      const base = buildSignatureBase(
+        200,
+        (name) => headers[name.toLowerCase()],
+        ['content-type', 'x-ar-io-verified'],
+        'GET',
+        '/test',
+        true,
+        1712505600,
+        keyId,
+      );
+
+      const sig = crypto.sign(null, Buffer.from(base, 'ascii'), privateKey);
+      const valid = crypto.verify(
+        null,
+        Buffer.from(base, 'ascii'),
+        publicKey,
+        sig,
+      );
+
+      assert.equal(valid, true);
+    });
+  });
+
+  // --- Phase 2: Attestation tests ---
+
+  /** Generate a test RSA-4096 JWK (Arweave wallet format). */
+  function generateTestRsaJwk(): crypto.JsonWebKey {
+    const { privateKey } = crypto.generateKeyPairSync('rsa', {
+      modulusLength: 4096,
+      publicExponent: 65537,
+    });
+    return privateKey.export({ format: 'jwk' }) as crypto.JsonWebKey;
+  }
+
+  describe('getSolanaAddress', () => {
+    it('returns a base58 string', () => {
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+      const addr = getSolanaAddress(publicKey);
+
+      // Solana addresses are 32-44 chars base58
+      assert.ok(addr.length >= 32 && addr.length <= 44);
+      assert.match(addr, /^[1-9A-HJ-NP-Za-km-z]+$/);
+    });
+
+    it('is stable across calls', () => {
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+      assert.equal(getSolanaAddress(publicKey), getSolanaAddress(publicKey));
+    });
+  });
+
+  describe('loadWalletJwk', () => {
+    it('loads a valid RSA JWK from file', () => {
+      const dir = makeTmpDir();
+      const walletFile = path.join(dir, 'test-wallet.json');
+      const jwk = generateTestRsaJwk();
+      fs.writeFileSync(walletFile, JSON.stringify(jwk));
+
+      const loaded = loadWalletJwk(walletFile);
+      assert.equal(loaded.kty, 'RSA');
+      assert.ok(loaded.n !== undefined);
+      assert.ok(loaded.d !== undefined);
+    });
+
+    it('throws on missing file', () => {
+      assert.throws(() => loadWalletJwk('/nonexistent/wallet.json'), {
+        message: /not found/,
+      });
+    });
+
+    it('throws on invalid JSON', () => {
+      const dir = makeTmpDir();
+      const walletFile = path.join(dir, 'bad.json');
+      fs.writeFileSync(walletFile, 'not json');
+
+      assert.throws(() => loadWalletJwk(walletFile), {
+        message: /Invalid wallet JSON/,
+      });
+    });
+
+    it('throws on missing required RSA fields', () => {
+      const dir = makeTmpDir();
+      const walletFile = path.join(dir, 'incomplete.json');
+      fs.writeFileSync(walletFile, JSON.stringify({ kty: 'RSA', n: 'abc' }));
+
+      assert.throws(() => loadWalletJwk(walletFile), {
+        message: /missing required field/,
+      });
+    });
+  });
+
+  describe('jwkToArweaveAddress', () => {
+    it('returns a base64url string', () => {
+      const jwk = generateTestRsaJwk();
+      const addr = jwkToArweaveAddress(jwk);
+      assert.match(addr, /^[A-Za-z0-9_-]+$/);
+      assert.equal(addr.length, 43); // SHA-256 = 32 bytes = 43 base64url chars
+    });
+
+    it('is stable across calls', () => {
+      const jwk = generateTestRsaJwk();
+      assert.equal(jwkToArweaveAddress(jwk), jwkToArweaveAddress(jwk));
+    });
+  });
+
+  describe('createAttestation', () => {
+    it('returns payload, signature, and rsaPublicKey', () => {
+      const observerJwk = generateTestRsaJwk();
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      const att = createAttestation({
+        observerJwk,
+        ed25519PublicKey: publicKey,
+        gatewayAddress: 'test-gateway-address',
+      });
+
+      assert.ok(att.payload.length > 0);
+      assert.ok(att.signature.length > 0);
+      assert.ok(att.rsaPublicKey.length > 0);
+    });
+
+    it('payload is valid canonical JSON with expected fields', () => {
+      const observerJwk = generateTestRsaJwk();
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      const att = createAttestation({
+        observerJwk,
+        ed25519PublicKey: publicKey,
+        gatewayAddress: 'gw-addr',
+      });
+
+      const parsed = JSON.parse(att.payload);
+      assert.equal(parsed.type, 'ar-io-gateway-key-attestation');
+      assert.equal(parsed.version, 1);
+      assert.equal(parsed.purpose, 'http-response-signing');
+      assert.equal(parsed.gatewayAddress, 'gw-addr');
+      assert.equal(parsed.ed25519PublicKey, getPublicKeyBase64Url(publicKey));
+      assert.equal(parsed.solanaAddress, getSolanaAddress(publicKey));
+      assert.equal(parsed.keyId, deriveKeyId(publicKey));
+      assert.ok(parsed.observerAddress !== undefined);
+      assert.ok(parsed.issuedAt !== undefined);
+    });
+
+    it('signature is verifiable with the RSA public key', () => {
+      const observerJwk = generateTestRsaJwk();
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      const att = createAttestation({
+        observerJwk,
+        ed25519PublicKey: publicKey,
+        gatewayAddress: undefined,
+      });
+
+      // Reconstruct RSA public key from exported DER
+      const rsaPubKey = crypto.createPublicKey({
+        key: Buffer.from(att.rsaPublicKey, 'base64url'),
+        format: 'der',
+        type: 'spki',
+      });
+
+      const valid = crypto.verify(
+        'sha256',
+        Buffer.from(att.payload, 'utf8'),
+        {
+          key: rsaPubKey,
+          padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+          saltLength: 0,
+        },
+        Buffer.from(att.signature, 'base64url'),
+      );
+
+      assert.equal(valid, true);
+    });
+
+    it('observerAddress matches SHA-256 of RSA public key modulus', () => {
+      const observerJwk = generateTestRsaJwk();
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      const att = createAttestation({
+        observerJwk,
+        ed25519PublicKey: publicKey,
+        gatewayAddress: undefined,
+      });
+
+      const parsed = JSON.parse(att.payload);
+      const expectedAddress = jwkToArweaveAddress(observerJwk);
+      assert.equal(parsed.observerAddress, expectedAddress);
+    });
+  });
+
+  describe('loadOrCreateAttestation', () => {
+    it('creates and caches a new attestation', () => {
+      const dir = makeTmpDir();
+      const observerJwk = generateTestRsaJwk();
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      const result = loadOrCreateAttestation({
+        keysDir: dir,
+        observerJwk,
+        ed25519PublicKey: publicKey,
+        gatewayAddress: undefined,
+      });
+
+      assert.equal(result.cached, false);
+      assert.ok(result.payload.length > 0);
+      assert.ok(fs.existsSync(path.join(dir, 'httpsig-attestation.json')));
+    });
+
+    it('loads cached attestation when Ed25519 key unchanged', () => {
+      const dir = makeTmpDir();
+      const observerJwk = generateTestRsaJwk();
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      const first = loadOrCreateAttestation({
+        keysDir: dir,
+        observerJwk,
+        ed25519PublicKey: publicKey,
+        gatewayAddress: undefined,
+      });
+
+      const second = loadOrCreateAttestation({
+        keysDir: dir,
+        observerJwk,
+        ed25519PublicKey: publicKey,
+        gatewayAddress: undefined,
+      });
+
+      assert.equal(first.cached, false);
+      assert.equal(second.cached, true);
+      assert.equal(first.signature, second.signature);
+    });
+
+    it('recreates attestation when Ed25519 key changes', () => {
+      const dir = makeTmpDir();
+      const observerJwk = generateTestRsaJwk();
+      const { publicKey: pub1 } = crypto.generateKeyPairSync('ed25519');
+      const { publicKey: pub2 } = crypto.generateKeyPairSync('ed25519');
+
+      const first = loadOrCreateAttestation({
+        keysDir: dir,
+        observerJwk,
+        ed25519PublicKey: pub1,
+        gatewayAddress: undefined,
+      });
+
+      const second = loadOrCreateAttestation({
+        keysDir: dir,
+        observerJwk,
+        ed25519PublicKey: pub2,
+        gatewayAddress: undefined,
+      });
+
+      assert.equal(first.cached, false);
+      assert.equal(second.cached, false);
+      assert.notEqual(first.signature, second.signature);
+    });
+  });
+});

--- a/src/lib/httpsig.test.ts
+++ b/src/lib/httpsig.test.ts
@@ -599,5 +599,82 @@ describe('httpsig lib', () => {
       assert.equal(result.cached, true);
       assert.equal(result.txId, 'arweave-tx-123');
     });
+
+    it('recreates attestation when observer wallet changes', () => {
+      const dir = makeTmpDir();
+      const observerJwk1 = generateTestRsaJwk();
+      const observerJwk2 = generateTestRsaJwk();
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      const first = loadOrCreateAttestation({
+        keysDir: dir,
+        observerJwk: observerJwk1,
+        ed25519PublicKey: publicKey,
+        gatewayAddress: undefined,
+      });
+
+      const second = loadOrCreateAttestation({
+        keysDir: dir,
+        observerJwk: observerJwk2,
+        ed25519PublicKey: publicKey,
+        gatewayAddress: undefined,
+      });
+
+      assert.equal(first.cached, false);
+      assert.equal(second.cached, false);
+      assert.notEqual(first.signature, second.signature);
+    });
+
+    it('recreates attestation when gateway address changes', () => {
+      const dir = makeTmpDir();
+      const observerJwk = generateTestRsaJwk();
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      const first = loadOrCreateAttestation({
+        keysDir: dir,
+        observerJwk,
+        ed25519PublicKey: publicKey,
+        gatewayAddress: 'gateway-1',
+      });
+
+      const second = loadOrCreateAttestation({
+        keysDir: dir,
+        observerJwk,
+        ed25519PublicKey: publicKey,
+        gatewayAddress: 'gateway-2',
+      });
+
+      assert.equal(first.cached, false);
+      assert.equal(second.cached, false);
+    });
+
+    it('handles corrupt cache file gracefully', () => {
+      const dir = makeTmpDir();
+      const observerJwk = generateTestRsaJwk();
+      const { publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      // Write corrupt cache
+      fs.writeFileSync(
+        path.join(dir, 'httpsig-attestation.json'),
+        'not valid json{{{',
+      );
+
+      // Should recreate without throwing
+      const result = loadOrCreateAttestation({
+        keysDir: dir,
+        observerJwk,
+        ed25519PublicKey: publicKey,
+        gatewayAddress: undefined,
+      });
+
+      assert.equal(result.cached, false);
+      assert.ok(result.payload.length > 0);
+    });
+
+    it('saveAttestationTxId is no-op when cache file missing', () => {
+      const dir = makeTmpDir();
+      // Should not throw
+      saveAttestationTxId(dir, 'some-tx-id');
+    });
   });
 });

--- a/src/lib/httpsig.test.ts
+++ b/src/lib/httpsig.test.ts
@@ -398,10 +398,10 @@ describe('httpsig lib', () => {
         keyId,
       );
 
-      const sig = crypto.sign(null, Buffer.from(base, 'ascii'), privateKey);
+      const sig = crypto.sign(null, Buffer.from(base, 'latin1'), privateKey);
       const valid = crypto.verify(
         null,
-        Buffer.from(base, 'ascii'),
+        Buffer.from(base, 'latin1'),
         publicKey,
         sig,
       );

--- a/src/lib/httpsig.ts
+++ b/src/lib/httpsig.ts
@@ -326,11 +326,20 @@ export interface Attestation {
   rsaPublicKey: string;
 }
 
-/** Disk-persisted attestation with identity fields for cache invalidation. */
+/**
+ * Disk-persisted attestation with identity fields for cache invalidation.
+ * All three identity fields (`ed25519PublicKey`, `observerAddress`,
+ * `gatewayAddress`) must match current runtime values for the cache to be
+ * considered valid — any change recreates the attestation.
+ */
 export interface CachedAttestation extends Attestation {
+  /** Base64url 32-byte Ed25519 public key (gateway's signing key). */
   ed25519PublicKey: string;
+  /** Base64url Arweave address of observer wallet that signed. */
   observerAddress?: string;
+  /** Base64url Arweave address of staked gateway wallet (may be undefined). */
   gatewayAddress?: string;
+  /** Arweave TX ID from successful upload (undefined until upload completes). */
   txId?: string;
 }
 

--- a/src/lib/httpsig.ts
+++ b/src/lib/httpsig.ts
@@ -16,7 +16,7 @@ import {
   writeFileSync,
   constants as fsConstants,
 } from 'node:fs';
-import { dirname, join, normalize, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 
 // @ts-expect-error bs58 v4 has no type declarations
 import bs58 from 'bs58';
@@ -80,12 +80,13 @@ export function loadOrGenerateKey(keyFile: string): crypto.KeyObject {
 
   mkdirSync(dirname(keyFile), { recursive: true });
 
-  // Use O_CREAT|O_EXCL for atomic creation — if another process created the
-  // file between our existsSync check and now, openSync throws EEXIST and we
-  // load their key instead of overwriting it.
+  // Write to temp file then rename for atomicity — prevents partial PEM on
+  // crash. O_CREAT|O_EXCL on the temp file prevents collisions; EEXIST on
+  // the final rename means another process won the race.
+  const tmpFile = `${keyFile}.tmp.${process.pid}`;
   try {
     const fd = openSync(
-      keyFile,
+      tmpFile,
       fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL,
       0o600,
     );
@@ -94,8 +95,16 @@ export function loadOrGenerateKey(keyFile: string): crypto.KeyObject {
     } finally {
       closeSync(fd);
     }
+    renameSync(tmpFile, keyFile);
   } catch (err: any) {
-    if (err.code === 'EEXIST') {
+    // Clean up temp file on any failure
+    try {
+      unlinkSync(tmpFile);
+    } catch {
+      // Ignore
+    }
+    // Another process may have created the key file — try loading it
+    if (existsSync(keyFile)) {
       return crypto.createPrivateKey(readFileSync(keyFile, 'utf8'));
     }
     throw err;
@@ -240,7 +249,10 @@ export function resolveWalletPath(
 ): string {
   const resolved = resolve(walletsPath, `${observerWallet}.json`);
   const normalizedBase = resolve(walletsPath);
-  if (!normalize(resolved).startsWith(normalizedBase)) {
+  // Use path.relative to check containment — startsWith can be fooled by
+  // sibling directories (e.g., "wallets-evil" starts with "wallets").
+  const rel = relative(normalizedBase, resolved);
+  if (rel.startsWith('..') || isAbsolute(rel)) {
     throw new Error(
       `OBSERVER_WALLET contains path traversal: ${observerWallet}`,
     );
@@ -261,26 +273,45 @@ export function jwkToArweaveAddress(jwk: crypto.JsonWebKey): string {
   return crypto.createHash('sha256').update(nBuffer).digest('base64url');
 }
 
+/**
+ * Canonical attestation payload fields. Serialized via json-canonicalize
+ * before signing. `gatewayAddress` is undefined when the operator has not
+ * set `AR_IO_WALLET`.
+ */
 export interface AttestationPayload {
   type: 'ar-io-gateway-key-attestation';
   version: 1;
+  /** Base64url Arweave address of the observer wallet. */
   observerAddress: string;
+  /** Base64url Arweave address of the staked gateway wallet (may be undefined). */
   gatewayAddress: string | undefined;
+  /** Base64url 32-byte Ed25519 public key. */
   ed25519PublicKey: string;
+  /** Base58 Solana address derived from the Ed25519 key. */
   solanaAddress: string;
+  /** Self-contained key ID: `ed25519:<base64url-pubkey>`. */
   keyId: string;
   purpose: 'http-response-signing';
+  /** ISO 8601 timestamp of attestation creation. */
   issuedAt: string;
 }
 
+/**
+ * Signed attestation ready for publication. `payload` is the canonical JSON
+ * string, `signature` is the RSA-PSS-SHA256 signature (base64url), and
+ * `rsaPublicKey` is the signer's public key in SPKI DER format (base64url).
+ */
 export interface Attestation {
   payload: string;
   signature: string;
   rsaPublicKey: string;
 }
 
+/** Disk-persisted attestation with identity fields for cache invalidation. */
 export interface CachedAttestation extends Attestation {
   ed25519PublicKey: string;
+  observerAddress?: string;
+  gatewayAddress?: string;
   txId?: string;
 }
 
@@ -352,14 +383,19 @@ export function loadOrCreateAttestation(opts: {
   const { keysDir, observerJwk, ed25519PublicKey, gatewayAddress } = opts;
   const cachePath = join(keysDir, ATTESTATION_CACHE_FILE);
   const currentPubKey = getPublicKeyBase64Url(ed25519PublicKey);
+  const currentObserverAddr = jwkToArweaveAddress(observerJwk);
 
-  // Try to load cached attestation
+  // Try to load cached attestation — validate all identity fields
   if (existsSync(cachePath)) {
     try {
       const cached: CachedAttestation = JSON.parse(
         readFileSync(cachePath, 'utf8'),
       );
-      if (cached.ed25519PublicKey === currentPubKey) {
+      if (
+        cached.ed25519PublicKey === currentPubKey &&
+        cached.observerAddress === currentObserverAddr &&
+        cached.gatewayAddress === gatewayAddress
+      ) {
         return {
           payload: cached.payload,
           signature: cached.signature,
@@ -389,6 +425,8 @@ export function loadOrCreateAttestation(opts: {
   const cacheData: CachedAttestation = {
     ...attestation,
     ed25519PublicKey: currentPubKey,
+    observerAddress: currentObserverAddr,
+    gatewayAddress,
   };
   mkdirSync(keysDir, { recursive: true });
   const tmpPath = `${cachePath}.tmp`;

--- a/src/lib/httpsig.ts
+++ b/src/lib/httpsig.ts
@@ -11,6 +11,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  renameSync,
   unlinkSync,
   writeFileSync,
   constants as fsConstants,
@@ -280,6 +281,7 @@ export interface Attestation {
 
 export interface CachedAttestation extends Attestation {
   ed25519PublicKey: string;
+  txId?: string;
 }
 
 /**
@@ -346,7 +348,7 @@ export function loadOrCreateAttestation(opts: {
   observerJwk: crypto.JsonWebKey;
   ed25519PublicKey: crypto.KeyObject;
   gatewayAddress: string | undefined;
-}): Attestation & { cached: boolean } {
+}): Attestation & { cached: boolean; txId?: string } {
   const { keysDir, observerJwk, ed25519PublicKey, gatewayAddress } = opts;
   const cachePath = join(keysDir, ATTESTATION_CACHE_FILE);
   const currentPubKey = getPublicKeyBase64Url(ed25519PublicKey);
@@ -362,6 +364,7 @@ export function loadOrCreateAttestation(opts: {
           payload: cached.payload,
           signature: cached.signature,
           rsaPublicKey: cached.rsaPublicKey,
+          txId: cached.txId,
           cached: true,
         };
       }
@@ -382,13 +385,36 @@ export function loadOrCreateAttestation(opts: {
     gatewayAddress,
   });
 
-  // Cache to disk
+  // Cache to disk atomically (write to temp, then rename)
   const cacheData: CachedAttestation = {
     ...attestation,
     ed25519PublicKey: currentPubKey,
   };
   mkdirSync(keysDir, { recursive: true });
-  writeFileSync(cachePath, JSON.stringify(cacheData, null, 2));
+  const tmpPath = `${cachePath}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(cacheData, null, 2));
+  renameSync(tmpPath, cachePath);
 
   return { ...attestation, cached: false };
+}
+
+/**
+ * Persist the Arweave TX ID of a successfully uploaded attestation into the
+ * cache file so it survives restarts.
+ */
+export function saveAttestationTxId(keysDir: string, txId: string): void {
+  const cachePath = join(keysDir, ATTESTATION_CACHE_FILE);
+  if (!existsSync(cachePath)) return;
+
+  try {
+    const cached: CachedAttestation = JSON.parse(
+      readFileSync(cachePath, 'utf8'),
+    );
+    cached.txId = txId;
+    const tmpPath = `${cachePath}.tmp`;
+    writeFileSync(tmpPath, JSON.stringify(cached, null, 2));
+    renameSync(tmpPath, cachePath);
+  } catch {
+    // Non-fatal — txId will be re-uploaded next restart
+  }
 }

--- a/src/lib/httpsig.ts
+++ b/src/lib/httpsig.ts
@@ -23,6 +23,8 @@ import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import bs58 from 'bs58';
 import { canonicalize } from 'json-canonicalize';
 
+import { fromB64Url, sha256B64Url } from './encoding.js';
+
 /**
  * Trust-triggering headers (lowercase). Presence of at least one of these on
  * a response indicates the response is trust-relevant and should be signed.
@@ -53,11 +55,9 @@ export const TRIGGER_HEADERS = new Set([
  */
 export const CO_SIGNABLE_HEADERS = new Set(['content-type', 'content-digest']);
 
-/**
- * Prefix patterns for dynamic headers that should be signed when a trigger
- * header is present. Data item tags (`x-arweave-tag-*`) are co-signable.
- */
-export const SIGNABLE_PREFIXES = ['x-arweave-tag-'];
+// Header predicates normalize case defensively, but callers should pass
+// lowercase where possible. Express's `res.getHeaders()` keys are already
+// lowercase, so the hot-path middleware avoids redundant work.
 
 /**
  * Returns true if the given header name should be included in the signature
@@ -68,7 +68,7 @@ export function isSignableHeader(name: string): boolean {
   return (
     TRIGGER_HEADERS.has(lower) ||
     CO_SIGNABLE_HEADERS.has(lower) ||
-    SIGNABLE_PREFIXES.some((p) => lower.startsWith(p))
+    lower.startsWith('x-arweave-tag-')
   );
 }
 
@@ -159,7 +159,7 @@ export function getPublicKeyBase64Url(publicKey: crypto.KeyObject): string {
 
 /**
  * Build the covered components list and the Signature-Input structured field
- * value per RFC 9421.
+ * value per RFC 9421. `coveredHeaders` names are normalized to lowercase.
  *
  * @returns The Signature-Input value (without the "sig1=" prefix).
  */
@@ -186,10 +186,15 @@ export function formatSignatureInput(
 
 /**
  * Construct the signature base string per RFC 9421 Section 2.5.
+ * `coveredHeaders` names are normalized to lowercase.
  *
  * Each covered component becomes a line: `"component": value`
  * The final line is: `"@signature-params": <params>`
  * Lines are joined by a single newline (0x0A) with no trailing newline.
+ *
+ * @returns `{ base, paramStr }` — `paramStr` is the Signature-Input value
+ *   (without the "sig1=" prefix), reused by the middleware to avoid a second
+ *   call to `formatSignatureInput`.
  */
 export function buildSignatureBase(
   statusCode: number,
@@ -200,7 +205,7 @@ export function buildSignatureBase(
   bindRequest: boolean,
   created: number,
   keyId: string,
-): string {
+): { base: string; paramStr: string } {
   const paramStr = formatSignatureInput(
     coveredHeaders,
     created,
@@ -222,7 +227,7 @@ export function buildSignatureBase(
   }
   lines.push(`"@signature-params": ${paramStr}`);
 
-  return lines.join('\n');
+  return { base: lines.join('\n'), paramStr };
 }
 
 // --- Attestation utilities (Phase 2) ---
@@ -241,10 +246,15 @@ export function getSolanaAddress(publicKey: crypto.KeyObject): string {
  * Load and validate an Arweave wallet JWK from a file path.
  */
 export function loadWalletJwk(walletFile: string): crypto.JsonWebKey {
-  if (!existsSync(walletFile)) {
-    throw new Error(`Wallet file not found: ${walletFile}`);
+  let raw: string;
+  try {
+    raw = readFileSync(walletFile, 'utf8');
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      throw new Error(`Wallet file not found: ${walletFile}`);
+    }
+    throw err;
   }
-  const raw = readFileSync(walletFile, 'utf8');
   let jwk: Record<string, unknown>;
   try {
     jwk = JSON.parse(raw);
@@ -288,8 +298,7 @@ export function jwkToArweaveAddress(jwk: crypto.JsonWebKey): string {
   if (jwk.n === undefined) {
     throw new Error('JWK missing RSA modulus (n) field');
   }
-  const nBuffer = Buffer.from(jwk.n, 'base64url');
-  return crypto.createHash('sha256').update(nBuffer).digest('base64url');
+  return sha256B64Url(fromB64Url(jwk.n));
 }
 
 /**
@@ -371,7 +380,6 @@ export function createAttestation(opts: {
     issuedAt: new Date().toISOString(),
   };
 
-  // Canonicalize for deterministic signing/verification
   const payload = canonicalize(attestationObj) as string;
 
   // Sign with RSA-PSS-SHA256 (salt length 0 for broadest Arweave compat)
@@ -387,13 +395,23 @@ export function createAttestation(opts: {
     })
     .toString('base64url');
 
-  // Export RSA public key as base64url DER for verifiers
   const rsaPublicKey = crypto
     .createPublicKey(rsaPrivateKey)
     .export({ type: 'spki', format: 'der' })
     .toString('base64url');
 
   return { payload, signature, rsaPublicKey };
+}
+
+/**
+ * Write JSON to `path` atomically: write to a pid-suffixed temp file, then
+ * renameSync over the destination. A unique suffix prevents startup-race
+ * ENOENT failures when two processes write the same cache concurrently.
+ */
+function writeJsonAtomic(path: string, data: unknown): void {
+  const tmpPath = `${path}.tmp.${process.pid}`;
+  writeFileSync(tmpPath, JSON.stringify(data, null, 2));
+  renameSync(tmpPath, path);
 }
 
 const ATTESTATION_CACHE_FILE = 'httpsig-attestation.json';
@@ -414,11 +432,15 @@ export function loadOrCreateAttestation(opts: {
   const currentObserverAddr = jwkToArweaveAddress(observerJwk);
 
   // Try to load cached attestation — validate all identity fields
-  if (existsSync(cachePath)) {
+  let raw: string | undefined;
+  try {
+    raw = readFileSync(cachePath, 'utf8');
+  } catch (err: any) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+  if (raw !== undefined) {
     try {
-      const cached: CachedAttestation = JSON.parse(
-        readFileSync(cachePath, 'utf8'),
-      );
+      const cached: CachedAttestation = JSON.parse(raw);
       if (
         cached.ed25519PublicKey === currentPubKey &&
         cached.observerAddress === currentObserverAddr &&
@@ -436,20 +458,18 @@ export function loadOrCreateAttestation(opts: {
       // Corrupt cache — delete before recreating
       try {
         unlinkSync(cachePath);
-      } catch {
-        // Ignore delete failure
+      } catch (err: any) {
+        if (err.code !== 'ENOENT') throw err;
       }
     }
   }
 
-  // Create new attestation
   const attestation = createAttestation({
     observerJwk,
     ed25519PublicKey,
     gatewayAddress,
   });
 
-  // Cache to disk atomically (write to temp, then rename)
   const cacheData: CachedAttestation = {
     ...attestation,
     ed25519PublicKey: currentPubKey,
@@ -457,9 +477,7 @@ export function loadOrCreateAttestation(opts: {
     gatewayAddress,
   };
   mkdirSync(keysDir, { recursive: true });
-  const tmpPath = `${cachePath}.tmp.${process.pid}`;
-  writeFileSync(tmpPath, JSON.stringify(cacheData, null, 2));
-  renameSync(tmpPath, cachePath);
+  writeJsonAtomic(cachePath, cacheData);
 
   return { ...attestation, cached: false };
 }
@@ -470,17 +488,125 @@ export function loadOrCreateAttestation(opts: {
  */
 export function saveAttestationTxId(keysDir: string, txId: string): void {
   const cachePath = join(keysDir, ATTESTATION_CACHE_FILE);
-  if (!existsSync(cachePath)) return;
-
   try {
     const cached: CachedAttestation = JSON.parse(
       readFileSync(cachePath, 'utf8'),
     );
     cached.txId = txId;
-    const tmpPath = `${cachePath}.tmp.${process.pid}`;
-    writeFileSync(tmpPath, JSON.stringify(cached, null, 2));
-    renameSync(tmpPath, cachePath);
+    writeJsonAtomic(cachePath, cached);
   } catch {
     // Non-fatal — txId will be re-uploaded next restart
+  }
+}
+
+// --- Startup init (called from config.ts) ---
+
+/**
+ * Ed25519 signing-side state. Always populated together when HTTPSIG is
+ * enabled, so consumers can narrow through a single `if (signer)` check.
+ */
+export interface HttpSigSignerContext {
+  privateKey: crypto.KeyObject;
+  keyId: string;
+  publicKeyB64Url: string;
+  solanaAddress: string;
+}
+
+/**
+ * Observer-wallet-side state. Populated only when `OBSERVER_WALLET` is set
+ * and the attestation loaded/created successfully. `attestationTxId` is the
+ * one mutable field — updated after a successful Arweave upload.
+ */
+export interface HttpSigObserverContext {
+  jwk: crypto.JsonWebKey;
+  address: string;
+  attestation: Attestation;
+  attestationTxId: string | undefined;
+  keysDir: string;
+}
+
+/**
+ * Initialize HTTPSIG signing state from resolved configuration. Returns the
+ * signer and (optionally) observer context to be exported by config. Logs
+ * at info/warn levels via the supplied logger.
+ */
+export function initHttpSig(opts: {
+  keyFile: string;
+  bindRequest: boolean;
+  observerWallet: string | undefined;
+  walletsPath: string;
+  gatewayAddress: string | undefined;
+  log: {
+    info: (msg: string, meta?: Record<string, unknown>) => void;
+    warn: (msg: string, meta?: Record<string, unknown>) => void;
+  };
+}): { signer: HttpSigSignerContext; observer?: HttpSigObserverContext } {
+  const {
+    keyFile,
+    bindRequest,
+    observerWallet,
+    walletsPath,
+    gatewayAddress,
+    log,
+  } = opts;
+
+  const privateKey = loadOrGenerateKey(keyFile);
+  const publicKey = crypto.createPublicKey(privateKey);
+  const signer: HttpSigSignerContext = {
+    privateKey,
+    keyId: deriveKeyId(publicKey),
+    publicKeyB64Url: getPublicKeyBase64Url(publicKey),
+    solanaAddress: getSolanaAddress(publicKey),
+  };
+
+  log.info('HTTPSIG response signing enabled', {
+    keyId: signer.keyId,
+    publicKey: signer.publicKeyB64Url,
+    solanaAddress: signer.solanaAddress,
+    keyFile,
+    bindRequest,
+  });
+
+  if (observerWallet === undefined) {
+    return { signer };
+  }
+
+  try {
+    const walletPath = resolveWalletPath(walletsPath, observerWallet);
+    const jwk = loadWalletJwk(walletPath);
+    const address = jwkToArweaveAddress(jwk);
+    const keysDir = dirname(keyFile);
+
+    const result = loadOrCreateAttestation({
+      keysDir,
+      observerJwk: jwk,
+      ed25519PublicKey: publicKey,
+      gatewayAddress,
+    });
+
+    log.info('HTTPSIG attestation ready', {
+      observerAddress: address,
+      cached: result.cached,
+    });
+
+    return {
+      signer,
+      observer: {
+        jwk,
+        address,
+        attestation: {
+          payload: result.payload,
+          signature: result.signature,
+          rsaPublicKey: result.rsaPublicKey,
+        },
+        attestationTxId: result.txId,
+        keysDir,
+      },
+    };
+  } catch (error: any) {
+    log.warn('HTTPSIG attestation creation failed', {
+      error: error?.message,
+    });
+    return { signer };
   }
 }

--- a/src/lib/httpsig.ts
+++ b/src/lib/httpsig.ts
@@ -8,6 +8,7 @@ import crypto from 'node:crypto';
 import {
   closeSync,
   existsSync,
+  linkSync,
   mkdirSync,
   openSync,
   readFileSync,
@@ -80,9 +81,10 @@ export function loadOrGenerateKey(keyFile: string): crypto.KeyObject {
 
   mkdirSync(dirname(keyFile), { recursive: true });
 
-  // Write to temp file then rename for atomicity — prevents partial PEM on
-  // crash. O_CREAT|O_EXCL on the temp file prevents collisions; EEXIST on
-  // the final rename means another process won the race.
+  // Write to temp file then hard-link into place for atomicity. linkSync
+  // fails with EEXIST if another process already installed the key file,
+  // preventing overwrites. This is safer than renameSync which silently
+  // replaces the target.
   const tmpFile = `${keyFile}.tmp.${process.pid}`;
   try {
     const fd = openSync(
@@ -95,19 +97,20 @@ export function loadOrGenerateKey(keyFile: string): crypto.KeyObject {
     } finally {
       closeSync(fd);
     }
-    renameSync(tmpFile, keyFile);
+    linkSync(tmpFile, keyFile);
   } catch (err: any) {
-    // Clean up temp file on any failure
+    if (err.code === 'EEXIST' && existsSync(keyFile)) {
+      // Another process won the race — load their key
+      return crypto.createPrivateKey(readFileSync(keyFile, 'utf8'));
+    }
+    throw err;
+  } finally {
+    // Always clean up temp file
     try {
       unlinkSync(tmpFile);
     } catch {
       // Ignore
     }
-    // Another process may have created the key file — try loading it
-    if (existsSync(keyFile)) {
-      return crypto.createPrivateKey(readFileSync(keyFile, 'utf8'));
-    }
-    throw err;
   }
 
   return privateKey;

--- a/src/lib/httpsig.ts
+++ b/src/lib/httpsig.ts
@@ -24,12 +24,12 @@ import bs58 from 'bs58';
 import { canonicalize } from 'json-canonicalize';
 
 /**
- * Exact-match header names (lowercase) that are trust-relevant and should be
- * included in HTTP message signatures when present on a response.
+ * Trust-triggering headers (lowercase). Presence of at least one of these on
+ * a response indicates the response is trust-relevant and should be signed.
+ * Endpoints that emit none of these (admin, /ar-io/info, GraphQL, health
+ * checks, generic errors) are auto-excluded from signing.
  */
-export const SIGNABLE_HEADERS = new Set([
-  'content-type',
-  'content-digest',
+export const TRIGGER_HEADERS = new Set([
   'x-ar-io-data-id',
   'x-ar-io-verified',
   'x-ar-io-stable',
@@ -47,21 +47,37 @@ export const SIGNABLE_HEADERS = new Set([
 ]);
 
 /**
- * Prefix patterns for dynamic headers that should be signed. Any header whose
- * lowercase name starts with one of these prefixes is signable.
+ * Co-signable headers (lowercase). These are included in the signature ONLY
+ * when at least one TRIGGER_HEADER is also present. Signing them alone is too
+ * broad — nearly every response has a Content-Type.
+ */
+export const CO_SIGNABLE_HEADERS = new Set(['content-type', 'content-digest']);
+
+/**
+ * Prefix patterns for dynamic headers that should be signed when a trigger
+ * header is present. Data item tags (`x-arweave-tag-*`) are co-signable.
  */
 export const SIGNABLE_PREFIXES = ['x-arweave-tag-'];
 
 /**
- * Returns true if the given header name (lowercase) should be included in an
- * HTTP message signature.
+ * Returns true if the given header name should be included in the signature
+ * base when a trigger header is already known to be present on the response.
  */
 export function isSignableHeader(name: string): boolean {
   const lower = name.toLowerCase();
   return (
-    SIGNABLE_HEADERS.has(lower) ||
+    TRIGGER_HEADERS.has(lower) ||
+    CO_SIGNABLE_HEADERS.has(lower) ||
     SIGNABLE_PREFIXES.some((p) => lower.startsWith(p))
   );
+}
+
+/**
+ * Returns true if the header is a trust-trigger — its presence means the
+ * response is trust-relevant and should be signed.
+ */
+export function isTriggerHeader(name: string): boolean {
+  return TRIGGER_HEADERS.has(name.toLowerCase());
 }
 
 // Ed25519 SPKI DER has a fixed 12-byte prefix before the raw 32-byte public key.

--- a/src/lib/httpsig.ts
+++ b/src/lib/httpsig.ts
@@ -1,0 +1,394 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import crypto from 'node:crypto';
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+  constants as fsConstants,
+} from 'node:fs';
+import { dirname, join, normalize, resolve } from 'node:path';
+
+// @ts-expect-error bs58 v4 has no type declarations
+import bs58 from 'bs58';
+import { canonicalize } from 'json-canonicalize';
+
+/**
+ * Exact-match header names (lowercase) that are trust-relevant and should be
+ * included in HTTP message signatures when present on a response.
+ */
+export const SIGNABLE_HEADERS = new Set([
+  'content-type',
+  'content-digest',
+  'x-ar-io-data-id',
+  'x-ar-io-verified',
+  'x-ar-io-stable',
+  'x-ar-io-trusted',
+  'x-ar-io-root-transaction-id',
+  'x-arweave-owner-address',
+  'x-arweave-tags-truncated',
+  'x-arns-name',
+  'x-arns-resolved-id',
+  'x-arns-ttl-seconds',
+  'x-arns-process-id',
+  'x-arweave-chunk-data-root',
+  'x-arweave-chunk-tx-id',
+  'x-ar-io-chunk-source-type',
+]);
+
+/**
+ * Prefix patterns for dynamic headers that should be signed. Any header whose
+ * lowercase name starts with one of these prefixes is signable.
+ */
+export const SIGNABLE_PREFIXES = ['x-arweave-tag-'];
+
+/**
+ * Returns true if the given header name (lowercase) should be included in an
+ * HTTP message signature.
+ */
+export function isSignableHeader(name: string): boolean {
+  const lower = name.toLowerCase();
+  return (
+    SIGNABLE_HEADERS.has(lower) ||
+    SIGNABLE_PREFIXES.some((p) => lower.startsWith(p))
+  );
+}
+
+// Ed25519 SPKI DER has a fixed 12-byte prefix before the raw 32-byte public key.
+const SPKI_ED25519_PREFIX_LENGTH = 12;
+
+/**
+ * Load an Ed25519 private key from a PEM file, or generate a new keypair and
+ * persist it if the file does not exist.
+ */
+export function loadOrGenerateKey(keyFile: string): crypto.KeyObject {
+  if (existsSync(keyFile)) {
+    return crypto.createPrivateKey(readFileSync(keyFile, 'utf8'));
+  }
+
+  const { privateKey } = crypto.generateKeyPairSync('ed25519');
+  const pem = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+
+  mkdirSync(dirname(keyFile), { recursive: true });
+
+  // Use O_CREAT|O_EXCL for atomic creation — if another process created the
+  // file between our existsSync check and now, openSync throws EEXIST and we
+  // load their key instead of overwriting it.
+  try {
+    const fd = openSync(
+      keyFile,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL,
+      0o600,
+    );
+    try {
+      writeFileSync(fd, pem);
+    } finally {
+      closeSync(fd);
+    }
+  } catch (err: any) {
+    if (err.code === 'EEXIST') {
+      return crypto.createPrivateKey(readFileSync(keyFile, 'utf8'));
+    }
+    throw err;
+  }
+
+  return privateKey;
+}
+
+/**
+ * Extract the raw 32-byte Ed25519 public key from a KeyObject.
+ */
+function getRawPublicKey(publicKey: crypto.KeyObject): Buffer {
+  const spkiDer = publicKey.export({ type: 'spki', format: 'der' });
+  return spkiDer.subarray(SPKI_ED25519_PREFIX_LENGTH);
+}
+
+/**
+ * Derive a self-contained key identifier from an Ed25519 public key.
+ * Returns `ed25519:<base64url-encoded-32-byte-public-key>` so that verifiers
+ * can extract the public key directly from the Signature-Input header without
+ * needing to fetch /ar-io/info.
+ */
+export function deriveKeyId(publicKey: crypto.KeyObject): string {
+  return `ed25519:${getPublicKeyBase64Url(publicKey)}`;
+}
+
+/**
+ * Export the raw 32-byte Ed25519 public key as a base64url string (43 chars).
+ */
+export function getPublicKeyBase64Url(publicKey: crypto.KeyObject): string {
+  return getRawPublicKey(publicKey).toString('base64url');
+}
+
+/**
+ * Build the covered components list and the Signature-Input structured field
+ * value per RFC 9421.
+ *
+ * @returns The Signature-Input value (without the "sig1=" prefix).
+ */
+export function formatSignatureInput(
+  coveredHeaders: string[],
+  created: number,
+  keyId: string,
+  bindRequest: boolean,
+): string {
+  const components: string[] = ['"@status"'];
+  for (const h of coveredHeaders) {
+    components.push(`"${h.toLowerCase()}"`);
+  }
+  if (bindRequest) {
+    components.push('"@method";req');
+    components.push('"@path";req');
+  }
+
+  return (
+    `(${components.join(' ')});created=${created}` +
+    `;keyid="${keyId}";alg="ed25519"`
+  );
+}
+
+/**
+ * Construct the signature base string per RFC 9421 Section 2.5.
+ *
+ * Each covered component becomes a line: `"component": value`
+ * The final line is: `"@signature-params": <params>`
+ * Lines are joined by a single newline (0x0A) with no trailing newline.
+ */
+export function buildSignatureBase(
+  statusCode: number,
+  getHeader: (name: string) => string | number | string[] | undefined,
+  coveredHeaders: string[],
+  method: string,
+  path: string,
+  bindRequest: boolean,
+  created: number,
+  keyId: string,
+): string {
+  const paramStr = formatSignatureInput(
+    coveredHeaders,
+    created,
+    keyId,
+    bindRequest,
+  );
+
+  const lines: string[] = [`"@status": ${statusCode}`];
+  for (const h of coveredHeaders) {
+    const value = getHeader(h);
+    // Multi-value headers (from res.append) are arrays; RFC 9421 Section 2.1
+    // requires the comma-separated field value representation.
+    const serialized = Array.isArray(value) ? value.join(', ') : String(value);
+    lines.push(`"${h.toLowerCase()}": ${serialized}`);
+  }
+  if (bindRequest) {
+    lines.push(`"@method";req: ${method}`);
+    lines.push(`"@path";req: ${path}`);
+  }
+  lines.push(`"@signature-params": ${paramStr}`);
+
+  return lines.join('\n');
+}
+
+// --- Attestation utilities (Phase 2) ---
+
+const REQUIRED_JWK_FIELDS = ['n', 'e', 'd', 'p', 'q', 'dp', 'dq', 'qi'];
+
+/**
+ * Derive the Solana address from an Ed25519 public key.
+ * A Solana address is the base58 encoding of the raw 32-byte public key.
+ */
+export function getSolanaAddress(publicKey: crypto.KeyObject): string {
+  return bs58.encode(getRawPublicKey(publicKey));
+}
+
+/**
+ * Load and validate an Arweave wallet JWK from a file path.
+ */
+export function loadWalletJwk(walletFile: string): crypto.JsonWebKey {
+  if (!existsSync(walletFile)) {
+    throw new Error(`Wallet file not found: ${walletFile}`);
+  }
+  const raw = readFileSync(walletFile, 'utf8');
+  let jwk: Record<string, unknown>;
+  try {
+    jwk = JSON.parse(raw);
+  } catch {
+    throw new Error(`Invalid wallet JSON: ${walletFile}`);
+  }
+  for (const field of REQUIRED_JWK_FIELDS) {
+    if (!(field in jwk)) {
+      throw new Error(`Wallet JWK missing required field: ${field}`);
+    }
+  }
+  return jwk as crypto.JsonWebKey;
+}
+
+/**
+ * Resolve the wallet file path for a given observer wallet address.
+ */
+export function resolveWalletPath(
+  walletsPath: string,
+  observerWallet: string,
+): string {
+  const resolved = resolve(walletsPath, `${observerWallet}.json`);
+  const normalizedBase = resolve(walletsPath);
+  if (!normalize(resolved).startsWith(normalizedBase)) {
+    throw new Error(
+      `OBSERVER_WALLET contains path traversal: ${observerWallet}`,
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Derive an Arweave address from an RSA JWK.
+ * An Arweave address is the base64url-encoded SHA-256 hash of the raw RSA
+ * public key modulus (the 'n' value decoded from base64url).
+ */
+export function jwkToArweaveAddress(jwk: crypto.JsonWebKey): string {
+  if (jwk.n === undefined) {
+    throw new Error('JWK missing RSA modulus (n) field');
+  }
+  const nBuffer = Buffer.from(jwk.n, 'base64url');
+  return crypto.createHash('sha256').update(nBuffer).digest('base64url');
+}
+
+export interface AttestationPayload {
+  type: 'ar-io-gateway-key-attestation';
+  version: 1;
+  observerAddress: string;
+  gatewayAddress: string | undefined;
+  ed25519PublicKey: string;
+  solanaAddress: string;
+  keyId: string;
+  purpose: 'http-response-signing';
+  issuedAt: string;
+}
+
+export interface Attestation {
+  payload: string;
+  signature: string;
+  rsaPublicKey: string;
+}
+
+export interface CachedAttestation extends Attestation {
+  ed25519PublicKey: string;
+}
+
+/**
+ * Create an attestation document binding an Ed25519 signing key to an Arweave
+ * observer wallet identity. The attestation is signed with RSA-PSS-SHA256.
+ */
+export function createAttestation(opts: {
+  observerJwk: crypto.JsonWebKey;
+  ed25519PublicKey: crypto.KeyObject;
+  gatewayAddress: string | undefined;
+}): Attestation {
+  const { observerJwk, ed25519PublicKey, gatewayAddress } = opts;
+
+  const observerAddress = jwkToArweaveAddress(observerJwk);
+  const pubKeyB64Url = getPublicKeyBase64Url(ed25519PublicKey);
+  const solanaAddress = getSolanaAddress(ed25519PublicKey);
+  const keyId = deriveKeyId(ed25519PublicKey);
+
+  const attestationObj: AttestationPayload = {
+    type: 'ar-io-gateway-key-attestation',
+    version: 1,
+    observerAddress,
+    gatewayAddress,
+    ed25519PublicKey: pubKeyB64Url,
+    solanaAddress,
+    keyId,
+    purpose: 'http-response-signing',
+    issuedAt: new Date().toISOString(),
+  };
+
+  // Canonicalize for deterministic signing/verification
+  const payload = canonicalize(attestationObj) as string;
+
+  // Sign with RSA-PSS-SHA256 (salt length 0 for broadest Arweave compat)
+  const rsaPrivateKey = crypto.createPrivateKey({
+    key: observerJwk,
+    format: 'jwk',
+  });
+  const signature = crypto
+    .sign('sha256', Buffer.from(payload, 'utf8'), {
+      key: rsaPrivateKey,
+      padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+      saltLength: 0,
+    })
+    .toString('base64url');
+
+  // Export RSA public key as base64url DER for verifiers
+  const rsaPublicKey = crypto
+    .createPublicKey(rsaPrivateKey)
+    .export({ type: 'spki', format: 'der' })
+    .toString('base64url');
+
+  return { payload, signature, rsaPublicKey };
+}
+
+const ATTESTATION_CACHE_FILE = 'httpsig-attestation.json';
+
+/**
+ * Load a cached attestation if it matches the current Ed25519 key, otherwise
+ * create a new one and cache it to disk.
+ */
+export function loadOrCreateAttestation(opts: {
+  keysDir: string;
+  observerJwk: crypto.JsonWebKey;
+  ed25519PublicKey: crypto.KeyObject;
+  gatewayAddress: string | undefined;
+}): Attestation & { cached: boolean } {
+  const { keysDir, observerJwk, ed25519PublicKey, gatewayAddress } = opts;
+  const cachePath = join(keysDir, ATTESTATION_CACHE_FILE);
+  const currentPubKey = getPublicKeyBase64Url(ed25519PublicKey);
+
+  // Try to load cached attestation
+  if (existsSync(cachePath)) {
+    try {
+      const cached: CachedAttestation = JSON.parse(
+        readFileSync(cachePath, 'utf8'),
+      );
+      if (cached.ed25519PublicKey === currentPubKey) {
+        return {
+          payload: cached.payload,
+          signature: cached.signature,
+          rsaPublicKey: cached.rsaPublicKey,
+          cached: true,
+        };
+      }
+    } catch {
+      // Corrupt cache — delete before recreating
+      try {
+        unlinkSync(cachePath);
+      } catch {
+        // Ignore delete failure
+      }
+    }
+  }
+
+  // Create new attestation
+  const attestation = createAttestation({
+    observerJwk,
+    ed25519PublicKey,
+    gatewayAddress,
+  });
+
+  // Cache to disk
+  const cacheData: CachedAttestation = {
+    ...attestation,
+    ed25519PublicKey: currentPubKey,
+  };
+  mkdirSync(keysDir, { recursive: true });
+  writeFileSync(cachePath, JSON.stringify(cacheData, null, 2));
+
+  return { ...attestation, cached: false };
+}

--- a/src/lib/httpsig.ts
+++ b/src/lib/httpsig.ts
@@ -432,7 +432,7 @@ export function loadOrCreateAttestation(opts: {
     gatewayAddress,
   };
   mkdirSync(keysDir, { recursive: true });
-  const tmpPath = `${cachePath}.tmp`;
+  const tmpPath = `${cachePath}.tmp.${process.pid}`;
   writeFileSync(tmpPath, JSON.stringify(cacheData, null, 2));
   renameSync(tmpPath, cachePath);
 
@@ -452,7 +452,7 @@ export function saveAttestationTxId(keysDir: string, txId: string): void {
       readFileSync(cachePath, 'utf8'),
     );
     cached.txId = txId;
-    const tmpPath = `${cachePath}.tmp`;
+    const tmpPath = `${cachePath}.tmp.${process.pid}`;
     writeFileSync(tmpPath, JSON.stringify(cached, null, 2));
     renameSync(tmpPath, cachePath);
   } catch {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -909,3 +909,23 @@ export const envoyEdsFileWritesTotal = new promClient.Counter({
   help: 'Total number of EDS file writes',
   labelNames: ['cluster'] as const,
 });
+
+//
+// HTTPSIG response signing
+//
+
+export const httpSigResponsesSignedTotal = new promClient.Counter({
+  name: 'httpsig_responses_signed_total',
+  help: 'Total HTTP responses signed with HTTPSIG',
+});
+
+export const httpSigSigningDuration = new promClient.Histogram({
+  name: 'httpsig_signing_duration_seconds',
+  help: 'Time to sign HTTP responses',
+  buckets: [0.00001, 0.00005, 0.0001, 0.0005, 0.001],
+});
+
+export const httpSigErrorsTotal = new promClient.Counter({
+  name: 'httpsig_errors_total',
+  help: 'Total HTTPSIG signing errors',
+});

--- a/src/middleware/httpsig.test.ts
+++ b/src/middleware/httpsig.test.ts
@@ -229,4 +229,29 @@ describe('createHttpSigMiddleware', () => {
     assert.equal(res.headers['signature'], undefined);
     assert.equal(res.headers['signature-input'], undefined);
   });
+
+  it('falls through unsigned when signing fails (invalid key)', async () => {
+    // Pass a public key (not private) to trigger a signing error
+    const { publicKey } = crypto.generateKeyPairSync('ed25519');
+    const { keyId } = generateTestKeyPair();
+
+    const app = express();
+    app.use(
+      createHttpSigMiddleware({
+        privateKey: publicKey as any,
+        keyId,
+        bindRequest: false,
+      }),
+    );
+    app.get('/test', (_req, res) => {
+      res.header('X-AR-IO-Data-Id', 'abc123');
+      res.send('ok');
+    });
+
+    // Should still return 200 — signing error caught, response sent unsigned
+    const res = await request(app).get('/test');
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['signature'], undefined);
+    assert.equal(res.headers['signature-input'], undefined);
+  });
 });

--- a/src/middleware/httpsig.test.ts
+++ b/src/middleware/httpsig.test.ts
@@ -245,7 +245,7 @@ describe('createHttpSigMiddleware', () => {
     // Verify the signature
     const valid = crypto.verify(
       null,
-      Buffer.from(base, 'ascii'),
+      Buffer.from(base, 'latin1'),
       publicKey,
       sigBytes,
     );

--- a/src/middleware/httpsig.test.ts
+++ b/src/middleware/httpsig.test.ts
@@ -112,6 +112,26 @@ describe('createHttpSigMiddleware', () => {
     assert.ok(!input.includes('upstream'));
   });
 
+  it('strips upstream Signature/Signature-Input even when not signing', async () => {
+    const { privateKey, keyId } = generateTestKeyPair();
+
+    const app = express();
+    app.use(createHttpSigMiddleware({ privateKey, keyId, bindRequest: false }));
+    app.get('/info', (_req, res) => {
+      // Simulate an upstream gateway's signature headers on a response that
+      // has no trust-trigger header. Our middleware must still strip them so
+      // they don't leak to the client as if signed by us.
+      res.header('Signature', 'sig1=:upstreamsig:');
+      res.header('Signature-Input', 'sig1=("@status");keyid="upstream"');
+      res.setHeader('Content-Type', 'application/json');
+      res.send('{"ok":true}');
+    });
+
+    const res = await request(app).get('/info');
+    assert.equal(res.headers['signature'], undefined);
+    assert.equal(res.headers['signature-input'], undefined);
+  });
+
   it('signs x-arweave-tag-* headers via prefix match', async () => {
     const { privateKey, keyId } = generateTestKeyPair();
 
@@ -211,9 +231,9 @@ describe('createHttpSigMiddleware', () => {
     );
 
     // Rebuild the signature base
-    const signatureBase = buildSignatureBase(
+    const { base } = buildSignatureBase(
       res.status,
-      (name) => res.headers[name.toLowerCase()] as string,
+      (name) => res.headers[name] as string,
       coveredHeaders,
       'GET',
       '/raw/testid',
@@ -225,7 +245,7 @@ describe('createHttpSigMiddleware', () => {
     // Verify the signature
     const valid = crypto.verify(
       null,
-      Buffer.from(signatureBase, 'ascii'),
+      Buffer.from(base, 'ascii'),
       publicKey,
       sigBytes,
     );

--- a/src/middleware/httpsig.test.ts
+++ b/src/middleware/httpsig.test.ts
@@ -1,0 +1,232 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import crypto from 'node:crypto';
+import express from 'express';
+import { default as request } from 'supertest';
+
+import { createHttpSigMiddleware } from './httpsig.js';
+import { buildSignatureBase, isSignableHeader } from '../lib/httpsig.js';
+
+/** Generate a fresh Ed25519 keypair for test isolation. */
+function generateTestKeyPair() {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519');
+  const spkiDer = publicKey.export({ type: 'spki', format: 'der' });
+  const raw = spkiDer.subarray(12);
+  const keyId = `ed25519:${raw.toString('base64url')}`;
+  return { privateKey, publicKey, keyId };
+}
+
+describe('createHttpSigMiddleware', () => {
+  it('signs response when signable headers are present', async () => {
+    const { privateKey, keyId } = generateTestKeyPair();
+
+    const app = express();
+    app.use(createHttpSigMiddleware({ privateKey, keyId, bindRequest: false }));
+    app.get('/test', (_req, res) => {
+      res.header('X-AR-IO-Data-Id', 'abc123');
+      res.header('X-AR-IO-Verified', 'true');
+      res.send('ok');
+    });
+
+    const res = await request(app).get('/test');
+    assert.ok(res.headers['signature'] !== undefined);
+    assert.ok(res.headers['signature-input'] !== undefined);
+  });
+
+  it('Signature-Input lists correct covered components', async () => {
+    const { privateKey, keyId } = generateTestKeyPair();
+
+    const app = express();
+    app.use(createHttpSigMiddleware({ privateKey, keyId, bindRequest: false }));
+    app.get('/test', (_req, res) => {
+      res.header('Content-Type', 'text/plain');
+      res.header('X-AR-IO-Data-Id', 'abc123');
+      res.send('ok');
+    });
+
+    const res = await request(app).get('/test');
+    const input = res.headers['signature-input'] as string;
+    assert.ok(input.includes('"@status"'));
+    assert.ok(input.includes('"content-type"'));
+    assert.ok(input.includes('"x-ar-io-data-id"'));
+    assert.ok(input.includes(`keyid="${keyId}"`));
+    assert.ok(input.includes('alg="ed25519"'));
+  });
+
+  it('skips signing when no signable headers are present', async () => {
+    const { privateKey, keyId } = generateTestKeyPair();
+
+    const app = express();
+    app.use(createHttpSigMiddleware({ privateKey, keyId, bindRequest: false }));
+    app.get('/test', (_req, res) => {
+      // Send raw bytes without setting any AR.IO/ArNS/chunk headers.
+      // Express sets content-type automatically via res.json/res.send, and
+      // content-type IS signable, so use writeHead + end directly.
+      res.writeHead(200);
+      res.end();
+    });
+
+    const res = await request(app).get('/test');
+    assert.equal(res.headers['signature'], undefined);
+    assert.equal(res.headers['signature-input'], undefined);
+  });
+
+  it('strips upstream Signature/Signature-Input before re-signing', async () => {
+    const { privateKey, keyId } = generateTestKeyPair();
+
+    const app = express();
+    app.use(createHttpSigMiddleware({ privateKey, keyId, bindRequest: false }));
+    app.get('/test', (_req, res) => {
+      // Simulate upstream gateway headers that should be stripped
+      res.header('Signature', 'sig1=:upstreamsig:');
+      res.header('Signature-Input', 'sig1=("@status");keyid="upstream"');
+      res.header('X-AR-IO-Data-Id', 'abc123');
+      res.send('ok');
+    });
+
+    const res = await request(app).get('/test');
+    const input = res.headers['signature-input'] as string;
+    // Should have our keyId, not the upstream one
+    assert.ok(input.includes(`keyid="${keyId}"`));
+    assert.ok(!input.includes('upstream'));
+  });
+
+  it('signs x-arweave-tag-* headers via prefix match', async () => {
+    const { privateKey, keyId } = generateTestKeyPair();
+
+    const app = express();
+    app.use(createHttpSigMiddleware({ privateKey, keyId, bindRequest: false }));
+    app.get('/test', (_req, res) => {
+      res.header('X-AR-IO-Data-Id', 'abc123');
+      res.header('X-Arweave-Tag-Content-Type', 'image/png');
+      res.header('X-Arweave-Tag-App-Name', 'ArDrive');
+      res.send('ok');
+    });
+
+    const res = await request(app).get('/test');
+    const input = res.headers['signature-input'] as string;
+    assert.ok(input.includes('"x-arweave-tag-content-type"'));
+    assert.ok(input.includes('"x-arweave-tag-app-name"'));
+  });
+
+  it('signs x-arweave-tags-truncated header', async () => {
+    const { privateKey, keyId } = generateTestKeyPair();
+
+    const app = express();
+    app.use(createHttpSigMiddleware({ privateKey, keyId, bindRequest: false }));
+    app.get('/test', (_req, res) => {
+      res.header('X-AR-IO-Data-Id', 'abc123');
+      res.header('X-Arweave-Tags-Truncated', 'true');
+      res.send('ok');
+    });
+
+    const res = await request(app).get('/test');
+    const input = res.headers['signature-input'] as string;
+    assert.ok(input.includes('"x-arweave-tags-truncated"'));
+  });
+
+  it('includes @method;req and @path;req when bindRequest is true', async () => {
+    const { privateKey, keyId } = generateTestKeyPair();
+
+    const app = express();
+    app.use(createHttpSigMiddleware({ privateKey, keyId, bindRequest: true }));
+    app.get('/raw/:id', (_req, res) => {
+      res.header('X-AR-IO-Data-Id', 'abc123');
+      res.send('ok');
+    });
+
+    const res = await request(app).get('/raw/abc123');
+    const input = res.headers['signature-input'] as string;
+    assert.ok(input.includes('"@method";req'));
+    assert.ok(input.includes('"@path";req'));
+  });
+
+  it('omits request-bound components when bindRequest is false', async () => {
+    const { privateKey, keyId } = generateTestKeyPair();
+
+    const app = express();
+    app.use(createHttpSigMiddleware({ privateKey, keyId, bindRequest: false }));
+    app.get('/test', (_req, res) => {
+      res.header('X-AR-IO-Data-Id', 'abc123');
+      res.send('ok');
+    });
+
+    const res = await request(app).get('/test');
+    const input = res.headers['signature-input'] as string;
+    assert.ok(!input.includes('@method'));
+    assert.ok(!input.includes('@path'));
+  });
+
+  it('produces a valid Ed25519 signature that can be verified', async () => {
+    const { privateKey, publicKey, keyId } = generateTestKeyPair();
+
+    const app = express();
+    app.use(createHttpSigMiddleware({ privateKey, keyId, bindRequest: true }));
+    app.get('/raw/:id', (_req, res) => {
+      res.header('X-AR-IO-Data-Id', 'testid');
+      res.header('X-AR-IO-Verified', 'true');
+      res.send('data');
+    });
+
+    const res = await request(app).get('/raw/testid');
+    const sigHeader = res.headers['signature'] as string;
+    const inputHeader = res.headers['signature-input'] as string;
+
+    // Extract signature bytes from "sig1=:base64:"
+    const sigMatch = sigHeader.match(/^sig1=:(.+):$/);
+    assert.ok(sigMatch !== null);
+    const sigBytes = Buffer.from(sigMatch[1], 'base64');
+
+    // Parse the created timestamp from input header
+    const createdMatch = inputHeader.match(/created=(\d+)/);
+    assert.ok(createdMatch !== null);
+    const created = parseInt(createdMatch[1], 10);
+
+    // Reconstruct covered headers from the response
+    const allHeaders = Object.keys(res.headers);
+    const coveredHeaders = allHeaders.filter(
+      (h) =>
+        isSignableHeader(h) && h !== 'signature' && h !== 'signature-input',
+    );
+
+    // Rebuild the signature base
+    const signatureBase = buildSignatureBase(
+      res.status,
+      (name) => res.headers[name.toLowerCase()] as string,
+      coveredHeaders,
+      'GET',
+      '/raw/testid',
+      true,
+      created,
+      keyId,
+    );
+
+    // Verify the signature
+    const valid = crypto.verify(
+      null,
+      Buffer.from(signatureBase, 'ascii'),
+      publicKey,
+      sigBytes,
+    );
+
+    assert.equal(valid, true);
+  });
+
+  it('does not sign when middleware is not registered', async () => {
+    const app = express();
+    app.get('/test', (_req, res) => {
+      res.header('X-AR-IO-Data-Id', 'abc123');
+      res.send('ok');
+    });
+
+    const res = await request(app).get('/test');
+    assert.equal(res.headers['signature'], undefined);
+    assert.equal(res.headers['signature-input'], undefined);
+  });
+});

--- a/src/middleware/httpsig.test.ts
+++ b/src/middleware/httpsig.test.ts
@@ -59,20 +59,35 @@ describe('createHttpSigMiddleware', () => {
     assert.ok(input.includes('alg="ed25519"'));
   });
 
-  it('skips signing when no signable headers are present', async () => {
+  it('skips signing when no trigger headers are present', async () => {
     const { privateKey, keyId } = generateTestKeyPair();
 
     const app = express();
     app.use(createHttpSigMiddleware({ privateKey, keyId, bindRequest: false }));
     app.get('/test', (_req, res) => {
-      // Send raw bytes without setting any AR.IO/ArNS/chunk headers.
-      // Express sets content-type automatically via res.json/res.send, and
-      // content-type IS signable, so use writeHead + end directly.
-      res.writeHead(200);
-      res.end();
+      // No AR.IO/ArNS/chunk headers set. Express auto-sets content-type,
+      // but content-type alone is not a trigger.
+      res.json({ status: 'ok' });
     });
 
     const res = await request(app).get('/test');
+    assert.equal(res.headers['signature'], undefined);
+    assert.equal(res.headers['signature-input'], undefined);
+  });
+
+  it('skips signing when only content-type is present (e.g., /ar-io/info)', async () => {
+    const { privateKey, keyId } = generateTestKeyPair();
+
+    const app = express();
+    app.use(createHttpSigMiddleware({ privateKey, keyId, bindRequest: false }));
+    app.get('/info', (_req, res) => {
+      // Simulates /ar-io/info: JSON response with Content-Type but no
+      // trust-relevant AR.IO headers.
+      res.setHeader('Content-Type', 'application/json');
+      res.send('{"release":"test"}');
+    });
+
+    const res = await request(app).get('/info');
     assert.equal(res.headers['signature'], undefined);
     assert.equal(res.headers['signature-input'], undefined);
   });

--- a/src/middleware/httpsig.ts
+++ b/src/middleware/httpsig.ts
@@ -90,7 +90,11 @@ export function createHttpSigMiddleware(opts: {
 
         // Ed25519 signing is synchronous and takes ~33us — faster than worker
         // thread IPC overhead.
-        const sig = crypto.sign(null, Buffer.from(base, 'ascii'), privateKey);
+        // latin1 matches Node's HTTP header byte representation — ASCII
+        // would strip the high bit on 0x80-0xFF header bytes (legal in
+        // latin1-range headers like Arweave tag values), producing a base
+        // that doesn't match what goes on the wire.
+        const sig = crypto.sign(null, Buffer.from(base, 'latin1'), privateKey);
 
         this.setHeader(headerNames.signatureInput, `sig1=${paramStr}`);
         this.setHeader(

--- a/src/middleware/httpsig.ts
+++ b/src/middleware/httpsig.ts
@@ -7,6 +7,8 @@
 import crypto from 'node:crypto';
 import { Handler, Request, Response } from 'express';
 
+import { headerNames } from '../constants.js';
+import log from '../log.js';
 import * as metrics from '../metrics.js';
 import { trace } from '../tracing.js';
 import {
@@ -45,8 +47,8 @@ export function createHttpSigMiddleware(opts: {
 
     res.writeHead = function (this: Response, ...args: any[]) {
       // Strip upstream signature headers (gateway-to-gateway forwarding)
-      this.removeHeader('Signature');
-      this.removeHeader('Signature-Input');
+      this.removeHeader(headerNames.signature);
+      this.removeHeader(headerNames.signatureInput);
 
       // Collect signable headers that are actually present on this response
       const presentHeaders = Object.keys(this.getHeaders());
@@ -106,9 +108,10 @@ export function createHttpSigMiddleware(opts: {
             'httpsig.components_count': coveredHeaders.length,
           });
         }
-      } catch {
+      } catch (error: any) {
         // Signing failure must not break the response — fall through unsigned.
         metrics.httpSigErrorsTotal.inc();
+        log.debug('HTTPSIG signing failed', { error: error?.message });
       }
 
       return (

--- a/src/middleware/httpsig.ts
+++ b/src/middleware/httpsig.ts
@@ -1,0 +1,121 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import crypto from 'node:crypto';
+import { Handler, Request, Response } from 'express';
+
+import * as metrics from '../metrics.js';
+import { trace } from '../tracing.js';
+import {
+  isSignableHeader,
+  buildSignatureBase,
+  formatSignatureInput,
+} from '../lib/httpsig.js';
+
+/**
+ * Creates Express middleware that signs HTTP responses per RFC 9421.
+ *
+ * Intercepts `res.writeHead()` to add `Signature` and `Signature-Input`
+ * headers after all other middleware has finalized response headers but before
+ * bytes are flushed to the wire. This pattern is the same as the cache-control
+ * middleware in this codebase.
+ *
+ * Only responses with trust-relevant headers (data, ArNS, chunk, tag headers)
+ * are signed. Endpoints that set no signable headers (admin, GraphQL, health)
+ * are automatically skipped.
+ *
+ * Upstream `Signature`/`Signature-Input` headers from gateway-to-gateway
+ * forwarding are stripped before the local gateway signs its own assessment.
+ */
+export function createHttpSigMiddleware(opts: {
+  privateKey: crypto.KeyObject;
+  keyId: string;
+  bindRequest: boolean;
+}): Handler {
+  const { privateKey, keyId, bindRequest } = opts;
+
+  return (req: Request, res: Response, next) => {
+    const originalWriteHead = res.writeHead;
+
+    // writeHead has multiple overload signatures; cast to a general callable
+    // so we can wrap it without fighting the overload types.
+
+    res.writeHead = function (this: Response, ...args: any[]) {
+      // Strip upstream signature headers (gateway-to-gateway forwarding)
+      this.removeHeader('Signature');
+      this.removeHeader('Signature-Input');
+
+      // Collect signable headers that are actually present on this response
+      const presentHeaders = Object.keys(this.getHeaders());
+      const coveredHeaders = presentHeaders.filter((h) => isSignableHeader(h));
+
+      // Skip signing if no trust-relevant headers are present (admin,
+      // GraphQL, health checks, error responses without data headers, etc.)
+      if (coveredHeaders.length === 0) {
+        return (
+          originalWriteHead as unknown as (...a: unknown[]) => Response
+        ).apply(this, args);
+      }
+
+      try {
+        const end = metrics.httpSigSigningDuration.startTimer();
+
+        const created = Math.floor(Date.now() / 1000);
+
+        const signatureBase = buildSignatureBase(
+          this.statusCode,
+          (name) => this.getHeader(name),
+          coveredHeaders,
+          req.method,
+          req.path,
+          bindRequest,
+          created,
+          keyId,
+        );
+
+        const inputValue = formatSignatureInput(
+          coveredHeaders,
+          created,
+          keyId,
+          bindRequest,
+        );
+
+        // Ed25519 signing is synchronous and takes ~33us — faster than worker
+        // thread IPC overhead.
+        const sig = crypto.sign(
+          null,
+          Buffer.from(signatureBase, 'ascii'),
+          privateKey,
+        );
+
+        this.setHeader('Signature-Input', `sig1=${inputValue}`);
+        this.setHeader('Signature', `sig1=:${sig.toString('base64')}:`);
+
+        end();
+        metrics.httpSigResponsesSignedTotal.inc();
+
+        // Add OTEL span attributes for tracing
+        const span = trace.getActiveSpan();
+        if (span !== undefined) {
+          span.setAttributes({
+            'httpsig.signed': true,
+            'httpsig.keyid': keyId,
+            'httpsig.components_count': coveredHeaders.length,
+          });
+        }
+      } catch {
+        // Signing failure must not break the response — fall through unsigned.
+        metrics.httpSigErrorsTotal.inc();
+      }
+
+      return (
+        originalWriteHead as unknown as (...a: unknown[]) => Response
+      ).apply(this, args);
+    } as typeof res.writeHead;
+
+    next();
+  };
+}

--- a/src/middleware/httpsig.ts
+++ b/src/middleware/httpsig.ts
@@ -26,9 +26,10 @@ import {
  * bytes are flushed to the wire. This pattern is the same as the cache-control
  * middleware in this codebase.
  *
- * Only responses with trust-relevant headers (data, ArNS, chunk, tag headers)
- * are signed. Endpoints that set no signable headers (admin, GraphQL, health)
- * are automatically skipped.
+ * Only responses carrying a trust-trigger header (e.g., `x-ar-io-data-id`,
+ * `x-arns-resolved-id`, `x-arweave-chunk-data-root`) are signed. Endpoints
+ * that emit only operational headers (admin, `/ar-io/info`, GraphQL, health
+ * checks, generic errors with just Content-Type) are automatically skipped.
  *
  * Upstream `Signature`/`Signature-Input` headers from gateway-to-gateway
  * forwarding are stripped before the local gateway signs its own assessment.

--- a/src/middleware/httpsig.ts
+++ b/src/middleware/httpsig.ts
@@ -15,7 +15,6 @@ import {
   isSignableHeader,
   isTriggerHeader,
   buildSignatureBase,
-  formatSignatureInput,
 } from '../lib/httpsig.js';
 
 /**
@@ -31,8 +30,9 @@ import {
  * that emit only operational headers (admin, `/ar-io/info`, GraphQL, health
  * checks, generic errors with just Content-Type) are automatically skipped.
  *
- * Upstream `Signature`/`Signature-Input` headers from gateway-to-gateway
- * forwarding are stripped before the local gateway signs its own assessment.
+ * Upstream `Signature`/`Signature-Input` headers are stripped unconditionally —
+ * including on responses the gateway does not sign — so upstream signatures
+ * never leak to clients.
  */
 export function createHttpSigMiddleware(opts: {
   privateKey: crypto.KeyObject;
@@ -52,27 +52,32 @@ export function createHttpSigMiddleware(opts: {
       this.removeHeader(headerNames.signature);
       this.removeHeader(headerNames.signatureInput);
 
-      // Skip signing unless at least one trust-trigger header is present.
-      // This excludes admin endpoints, /ar-io/info, GraphQL, health checks,
-      // and generic error responses — they carry Content-Type but no
-      // trust claims worth signing.
-      const presentHeaders = Object.keys(this.getHeaders());
-      const hasTrigger = presentHeaders.some((h) => isTriggerHeader(h));
+      // Single-pass over response headers: build coveredHeaders and track
+      // whether any trust-trigger is present. Skip signing if none — excludes
+      // admin endpoints, /ar-io/info, GraphQL, health checks, and generic
+      // error responses that carry only operational headers.
+      let hasTrigger = false;
+      const coveredHeaders: string[] = [];
+      for (const h of Object.keys(this.getHeaders())) {
+        if (isTriggerHeader(h)) {
+          hasTrigger = true;
+          coveredHeaders.push(h);
+        } else if (isSignableHeader(h)) {
+          coveredHeaders.push(h);
+        }
+      }
       if (!hasTrigger) {
         return (
           originalWriteHead as unknown as (...a: unknown[]) => Response
         ).apply(this, args);
       }
 
-      // Collect all signable headers (trigger + co-signable + tag prefix)
-      const coveredHeaders = presentHeaders.filter((h) => isSignableHeader(h));
-
       try {
         const end = metrics.httpSigSigningDuration.startTimer();
 
         const created = Math.floor(Date.now() / 1000);
 
-        const signatureBase = buildSignatureBase(
+        const { base, paramStr } = buildSignatureBase(
           this.statusCode,
           (name) => this.getHeader(name),
           coveredHeaders,
@@ -83,23 +88,15 @@ export function createHttpSigMiddleware(opts: {
           keyId,
         );
 
-        const inputValue = formatSignatureInput(
-          coveredHeaders,
-          created,
-          keyId,
-          bindRequest,
-        );
-
         // Ed25519 signing is synchronous and takes ~33us — faster than worker
         // thread IPC overhead.
-        const sig = crypto.sign(
-          null,
-          Buffer.from(signatureBase, 'ascii'),
-          privateKey,
-        );
+        const sig = crypto.sign(null, Buffer.from(base, 'ascii'), privateKey);
 
-        this.setHeader('Signature-Input', `sig1=${inputValue}`);
-        this.setHeader('Signature', `sig1=:${sig.toString('base64')}:`);
+        this.setHeader(headerNames.signatureInput, `sig1=${paramStr}`);
+        this.setHeader(
+          headerNames.signature,
+          `sig1=:${sig.toString('base64')}:`,
+        );
 
         end();
         metrics.httpSigResponsesSignedTotal.inc();

--- a/src/middleware/httpsig.ts
+++ b/src/middleware/httpsig.ts
@@ -13,6 +13,7 @@ import * as metrics from '../metrics.js';
 import { trace } from '../tracing.js';
 import {
   isSignableHeader,
+  isTriggerHeader,
   buildSignatureBase,
   formatSignatureInput,
 } from '../lib/httpsig.js';
@@ -50,17 +51,20 @@ export function createHttpSigMiddleware(opts: {
       this.removeHeader(headerNames.signature);
       this.removeHeader(headerNames.signatureInput);
 
-      // Collect signable headers that are actually present on this response
+      // Skip signing unless at least one trust-trigger header is present.
+      // This excludes admin endpoints, /ar-io/info, GraphQL, health checks,
+      // and generic error responses — they carry Content-Type but no
+      // trust claims worth signing.
       const presentHeaders = Object.keys(this.getHeaders());
-      const coveredHeaders = presentHeaders.filter((h) => isSignableHeader(h));
-
-      // Skip signing if no trust-relevant headers are present (admin,
-      // GraphQL, health checks, error responses without data headers, etc.)
-      if (coveredHeaders.length === 0) {
+      const hasTrigger = presentHeaders.some((h) => isTriggerHeader(h));
+      if (!hasTrigger) {
         return (
           originalWriteHead as unknown as (...a: unknown[]) => Response
         ).apply(this, args);
       }
+
+      // Collect all signable headers (trigger + co-signable + tag prefix)
+      const coveredHeaders = presentHeaders.filter((h) => isSignableHeader(h));
 
       try {
         const end = metrics.httpSigSigningDuration.startTimer();

--- a/src/routes/ar-io-info-builder.ts
+++ b/src/routes/ar-io-info-builder.ts
@@ -87,9 +87,6 @@ export interface X402Info {
 }
 
 /**
- * HTTPSIG response signing configuration exposed in the info endpoint.
- */
-/**
  * RSA-signed attestation linking an Ed25519 signing key to an Arweave
  * observer wallet identity. Enables verifiers to establish the trust chain
  * from HTTP signatures back to the on-chain gateway registration.
@@ -221,7 +218,6 @@ export function buildArIoInfo(config: ArIoInfoConfig): ArIoInfoResponse {
     },
   };
 
-  // Add rate limiter info if enabled
   if (config.rateLimiter?.enabled) {
     const { resourceCapacity, resourceRefillRate, ipCapacity, ipRefillRate } =
       config.rateLimiter;
@@ -247,7 +243,6 @@ export function buildArIoInfo(config: ArIoInfoConfig): ArIoInfoResponse {
     };
   }
 
-  // Add x402 payment info if enabled
   if (config.x402?.enabled) {
     const {
       network,
@@ -305,7 +300,6 @@ export function buildArIoInfo(config: ArIoInfoConfig): ArIoInfoResponse {
     };
   }
 
-  // Add HTTPSIG signing info if enabled
   if (config.httpsig?.enabled) {
     response.httpsig = {
       enabled: true,

--- a/src/routes/ar-io-info-builder.ts
+++ b/src/routes/ar-io-info-builder.ts
@@ -89,14 +89,28 @@ export interface X402Info {
 /**
  * HTTPSIG response signing configuration exposed in the info endpoint.
  */
+/**
+ * RSA-signed attestation linking an Ed25519 signing key to an Arweave
+ * observer wallet identity. Enables verifiers to establish the trust chain
+ * from HTTP signatures back to the on-chain gateway registration.
+ */
 export interface HttpsigAttestationInfo {
+  /** Arweave transaction ID where attestation is permanently stored. */
   txId?: string;
+  /** Base64url Arweave address of the observer wallet that signed the attestation. */
   observerAddress: string;
+  /** Canonical JSON attestation payload. */
   payload: string;
+  /** RSA-PSS-SHA256 signature over the payload (base64url). */
   signature: string;
+  /** RSA public key in SPKI DER format (base64url). */
   rsaPublicKey: string;
 }
 
+/**
+ * HTTPSIG response signing configuration exposed in the info endpoint.
+ * When enabled, qualifying responses include RFC 9421 Message Signatures.
+ */
 export interface HttpsigInfo {
   enabled: true;
   algorithm: string;

--- a/src/routes/ar-io-info-builder.ts
+++ b/src/routes/ar-io-info-builder.ts
@@ -87,6 +87,26 @@ export interface X402Info {
 }
 
 /**
+ * HTTPSIG response signing configuration exposed in the info endpoint.
+ */
+export interface HttpsigAttestationInfo {
+  txId?: string;
+  observerAddress: string;
+  payload: string;
+  signature: string;
+  rsaPublicKey: string;
+}
+
+export interface HttpsigInfo {
+  enabled: true;
+  algorithm: string;
+  publicKey: string;
+  keyId: string;
+  solanaAddress?: string;
+  attestation?: HttpsigAttestationInfo;
+}
+
+/**
  * Complete AR.IO info endpoint response structure.
  */
 export interface ArIoInfoResponse {
@@ -99,6 +119,7 @@ export interface ArIoInfoResponse {
   services: ServicesInfo;
   rateLimiter?: RateLimiterInfo;
   x402?: X402Info;
+  httpsig?: HttpsigInfo;
 }
 
 /**
@@ -127,6 +148,20 @@ export interface ArIoInfoConfig {
     minPrice: number;
     maxPrice: number;
     capacityMultiplier: number;
+  };
+  httpsig?: {
+    enabled: boolean;
+    algorithm: string;
+    publicKey: string;
+    keyId: string;
+    solanaAddress?: string;
+    attestation?: {
+      txId?: string;
+      observerAddress: string;
+      payload: string;
+      signature: string;
+      rsaPublicKey: string;
+    };
   };
 }
 
@@ -253,6 +288,18 @@ export function buildArIoInfo(config: ArIoInfoConfig): ArIoInfoResponse {
         },
         rateLimiterCapacityMultiplier: capacityMultiplier,
       },
+    };
+  }
+
+  // Add HTTPSIG signing info if enabled
+  if (config.httpsig?.enabled) {
+    response.httpsig = {
+      enabled: true,
+      algorithm: config.httpsig.algorithm,
+      publicKey: config.httpsig.publicKey,
+      keyId: config.httpsig.keyId,
+      solanaAddress: config.httpsig.solanaAddress,
+      attestation: config.httpsig.attestation,
     };
   }
 

--- a/src/routes/ar-io.test.ts
+++ b/src/routes/ar-io.test.ts
@@ -465,4 +465,83 @@ describe('buildArIoInfo', () => {
       assert.strictEqual(Object.keys(bundler)[0], 'url');
     });
   });
+
+  it('should include httpsig in info response when enabled', () => {
+    const result = buildArIoInfo({
+      wallet: 'test-wallet',
+      processId: 'test-process',
+      ans104UnbundleFilter: {},
+      ans104IndexFilter: {},
+      release: 'r123',
+      bundlerUrls: [],
+      httpsig: {
+        enabled: true,
+        algorithm: 'ed25519',
+        publicKey: 'test-public-key-base64url',
+        keyId: 'ed25519:test-public-key-base64url',
+      },
+    });
+
+    assert.strictEqual(result.httpsig?.enabled, true);
+    assert.strictEqual(result.httpsig?.algorithm, 'ed25519');
+    assert.strictEqual(result.httpsig?.publicKey, 'test-public-key-base64url');
+    assert.strictEqual(
+      result.httpsig?.keyId,
+      'ed25519:test-public-key-base64url',
+    );
+  });
+
+  it('should include httpsig with attestation and solana address', () => {
+    const result = buildArIoInfo({
+      wallet: 'test-wallet',
+      processId: 'test-process',
+      ans104UnbundleFilter: {},
+      ans104IndexFilter: {},
+      release: 'r123',
+      bundlerUrls: [],
+      httpsig: {
+        enabled: true,
+        algorithm: 'ed25519',
+        publicKey: 'test-pubkey',
+        keyId: 'ed25519:test-pubkey',
+        solanaAddress: 'SoLaNaAdDrEsS',
+        attestation: {
+          txId: 'arweave-tx-123',
+          observerAddress: 'observer-addr',
+          payload: '{"test":"payload"}',
+          signature: 'sig-base64url',
+          rsaPublicKey: 'rsa-pub-base64url',
+        },
+      },
+    });
+
+    assert.strictEqual(result.httpsig?.solanaAddress, 'SoLaNaAdDrEsS');
+    assert.strictEqual(result.httpsig?.attestation?.txId, 'arweave-tx-123');
+    assert.strictEqual(
+      result.httpsig?.attestation?.observerAddress,
+      'observer-addr',
+    );
+    assert.strictEqual(
+      result.httpsig?.attestation?.payload,
+      '{"test":"payload"}',
+    );
+    assert.strictEqual(result.httpsig?.attestation?.signature, 'sig-base64url');
+    assert.strictEqual(
+      result.httpsig?.attestation?.rsaPublicKey,
+      'rsa-pub-base64url',
+    );
+  });
+
+  it('should omit httpsig when not configured', () => {
+    const result = buildArIoInfo({
+      wallet: 'test-wallet',
+      processId: 'test-process',
+      ans104UnbundleFilter: {},
+      ans104IndexFilter: {},
+      release: 'r123',
+      bundlerUrls: [],
+    });
+
+    assert.strictEqual(result.httpsig, undefined);
+  });
 });

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -197,21 +197,22 @@ export const arIoInfoHandler = (_req: Request, res: Response) => {
         }
       : undefined,
     httpsig:
-      config.HTTPSIG_ENABLED && config.HTTPSIG_PUBLIC_KEY_B64URL !== undefined
+      config.HTTPSIG_ENABLED && config.HTTPSIG_SIGNER !== undefined
         ? {
             enabled: true,
             algorithm: 'ed25519',
-            publicKey: config.HTTPSIG_PUBLIC_KEY_B64URL,
-            keyId: config.HTTPSIG_KEY_ID!,
-            solanaAddress: config.HTTPSIG_SOLANA_ADDRESS,
+            publicKey: config.HTTPSIG_SIGNER.publicKeyB64Url,
+            keyId: config.HTTPSIG_SIGNER.keyId,
+            solanaAddress: config.HTTPSIG_SIGNER.solanaAddress,
             attestation:
-              config.HTTPSIG_ATTESTATION !== undefined
+              config.HTTPSIG_OBSERVER !== undefined
                 ? {
-                    txId: config.getHttpSigAttestationTxId(),
-                    observerAddress: config.HTTPSIG_OBSERVER_ADDRESS!,
-                    payload: config.HTTPSIG_ATTESTATION.payload,
-                    signature: config.HTTPSIG_ATTESTATION.signature,
-                    rsaPublicKey: config.HTTPSIG_ATTESTATION.rsaPublicKey,
+                    txId: config.HTTPSIG_OBSERVER.attestationTxId,
+                    observerAddress: config.HTTPSIG_OBSERVER.address,
+                    payload: config.HTTPSIG_OBSERVER.attestation.payload,
+                    signature: config.HTTPSIG_OBSERVER.attestation.signature,
+                    rsaPublicKey:
+                      config.HTTPSIG_OBSERVER.attestation.rsaPublicKey,
                   }
                 : undefined,
           }

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -196,6 +196,26 @@ export const arIoInfoHandler = (_req: Request, res: Response) => {
           capacityMultiplier: config.X_402_RATE_LIMIT_CAPACITY_MULTIPLIER,
         }
       : undefined,
+    httpsig:
+      config.HTTPSIG_ENABLED && config.HTTPSIG_PUBLIC_KEY_B64URL !== undefined
+        ? {
+            enabled: true,
+            algorithm: 'ed25519',
+            publicKey: config.HTTPSIG_PUBLIC_KEY_B64URL,
+            keyId: config.HTTPSIG_KEY_ID!,
+            solanaAddress: config.HTTPSIG_SOLANA_ADDRESS,
+            attestation:
+              config.HTTPSIG_ATTESTATION !== undefined
+                ? {
+                    txId: config.getHttpSigAttestationTxId(),
+                    observerAddress: config.HTTPSIG_OBSERVER_ADDRESS!,
+                    payload: config.HTTPSIG_ATTESTATION.payload,
+                    signature: config.HTTPSIG_ATTESTATION.signature,
+                    rsaPublicKey: config.HTTPSIG_ATTESTATION.rsaPublicKey,
+                  }
+                : undefined,
+          }
+        : undefined,
   });
 
   res.status(200).send(response);


### PR DESCRIPTION
## Summary

- Add opt-in RFC 9421 HTTP Message Signature support (`HTTPSIG_ENABLED=true`)
- Every qualifying response gets `Signature` + `Signature-Input` headers signed by an Ed25519 key (~33us per request)
- Observer wallet RSA attestation links Ed25519 key to on-chain gateway identity, uploaded permanently to Arweave
- Self-contained `keyId` embeds full public key — no lookup needed for verification
- Solana address derived from Ed25519 key for future multi-chain identity
- Signs trust headers, ArNS resolution, data item tags, Content-Digest, chunk provenance
- Auto-skips admin/GraphQL/health endpoints, strips upstream signatures on gateway-to-gateway forwarding
- Prometheus metrics, OTEL span attributes, docs/envs.md documented

## Test plan

- [ ] 69 unit + integration tests passing (signing, attestation, info builder, middleware)
- [ ] Full test suite: 1617/1622 pass (1 pre-existing failure in DataVerificationWorker, 4 skipped)
- [ ] TypeScript compiles clean, lint clean
- [ ] Live verified on gateway: response signatures valid, RSA attestation valid, attestation TX on Arweave
- [ ] End-to-end verification script confirms full trust chain
- [ ] Performance: ~40us/request, negligible at 3,000 req/s
- [ ] `HTTPSIG_ENABLED=false` (default) has zero impact on existing behavior