### PR TITLE
feat: tag-based TTL rules for ClickHouse-exported data (PE-9058)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 /.env.bundler
 .env.bak*
 
+# Operator-specific ClickHouse TTL rules (copy from the .example file)
+/config/clickhouse-ttl-rules.yaml
+
 # Docker Compose overrides
 docker-compose.override.yaml
 docker-compose.override.yml

--- a/Dockerfile.clickhouse-auto-import
+++ b/Dockerfile.clickhouse-auto-import
@@ -21,10 +21,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         arm64) ARCH_SUFFIX=arm64 ;; \
         *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
     esac \
-    && curl -LO https://github.com/ClickHouse/ClickHouse/releases/download/v24.11.1.2557-stable/clickhouse-common-static-24.11.1.2557-${ARCH_SUFFIX}.tgz \
-    && tar -xzf clickhouse-common-static-24.11.1.2557-${ARCH_SUFFIX}.tgz \
-    && mv ./clickhouse-common-static-24.11.1.2557/usr/bin/clickhouse usr/local/bin/ \
-    && rm -r clickhouse-common-static-24.11.1.2557-${ARCH_SUFFIX}.tgz ./clickhouse-common-static-24.11.1.2557
+    && curl -LO https://github.com/ClickHouse/ClickHouse/releases/download/v26.3.9.8-lts/clickhouse-common-static-26.3.9.8-${ARCH_SUFFIX}.tgz \
+    && tar -xzf clickhouse-common-static-26.3.9.8-${ARCH_SUFFIX}.tgz \
+    && mv ./clickhouse-common-static-26.3.9.8/usr/bin/clickhouse usr/local/bin/ \
+    && rm -r clickhouse-common-static-26.3.9.8-${ARCH_SUFFIX}.tgz ./clickhouse-common-static-26.3.9.8
 
 # Install DuckDB
 RUN case ${TARGETARCH} in \

--- a/Dockerfile.clickhouse-auto-import
+++ b/Dockerfile.clickhouse-auto-import
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     python3-venv \
+    python3-yaml \
     && rm -rf /var/lib/apt/lists/* \
     && case ${TARGETARCH} in \
         amd64) ARCH_SUFFIX=amd64 ;; \
@@ -56,12 +57,13 @@ RUN mkdir -p data/parquet/imported
 COPY src/database/clickhouse/schema.sql /app/src/database/clickhouse/schema.sql
 COPY scripts/clickhouse-auto-import /app/scripts/
 COPY scripts/clickhouse-import /app/scripts/
+COPY scripts/clickhouse-load-ttl-rules.py /app/scripts/
 COPY scripts/parquet-export /app/scripts/
 COPY scripts/generate-iceberg-metadata /app/scripts/
 COPY scripts/lib /app/scripts/lib/
 
 # Make scripts executable
-RUN chmod +x /app/scripts/clickhouse-auto-import /app/scripts/clickhouse-import /app/scripts/parquet-export /app/scripts/generate-iceberg-metadata
+RUN chmod +x /app/scripts/clickhouse-auto-import /app/scripts/clickhouse-import /app/scripts/clickhouse-load-ttl-rules.py /app/scripts/parquet-export /app/scripts/generate-iceberg-metadata
 
 # Environment variables
 ENV ADMIN_API_KEY=""

--- a/Dockerfile.clickhouse-auto-import
+++ b/Dockerfile.clickhouse-auto-import
@@ -14,7 +14,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     python3-venv \
-    python3-yaml \
     && rm -rf /var/lib/apt/lists/* \
     && case ${TARGETARCH} in \
         amd64) ARCH_SUFFIX=amd64 ;; \
@@ -47,7 +46,8 @@ RUN python3 -m venv /app/venv && \
         psycopg2-binary \
         pandas \
         fsspec[http] \
-        fastavro
+        fastavro \
+        pyyaml
 
 # Create necessary directories
 WORKDIR /app

--- a/config/clickhouse-ttl-rules.example.yaml
+++ b/config/clickhouse-ttl-rules.example.yaml
@@ -13,8 +13,10 @@
 # Normalization:
 #   - tag_name is lower-cased + trimmed on both sides of the lookup.
 #   - tag_value is trimmed but case-preserving.
-#   - owner `value` is base64url (as operators see on Arweave); decoded to raw
-#     bytes at load time so it matches the stored owner_address BLOB.
+#   - owner `value` is base64url (as operators see on Arweave) and is stored
+#     verbatim; the migrate query compares base64URLEncode(owner_address)
+#     against it, so prefix rules match the base64url text directly
+#     (e.g. "abcDEF" catches every address whose base64url starts with that).
 #
 # Match modes:
 #   - exact (default): O(1) dictionary lookup.

--- a/config/clickhouse-ttl-rules.example.yaml
+++ b/config/clickhouse-ttl-rules.example.yaml
@@ -1,0 +1,50 @@
+# ClickHouse TTL rules (tag-based + owner-based) — EXAMPLE TEMPLATE.
+#
+# To activate retention rules, copy this file to
+#   config/clickhouse-ttl-rules.yaml
+# (the real filename is gitignored so operator rules aren't committed) and
+# uncomment/edit the entries below. clickhouse-auto-import mounts that file
+# into the container and loads it at the top of every import cycle.
+#
+# Rules apply only to rows imported after they are loaded (no retroactive
+# backfill in v1). If multiple rules match a row, the shortest TTL wins. If
+# no rules match, expires_at is NULL and the row is kept indefinitely.
+#
+# Normalization:
+#   - tag_name is lower-cased + trimmed on both sides of the lookup.
+#   - tag_value is trimmed but case-preserving.
+#   - owner `value` is base64url (as operators see on Arweave); decoded to raw
+#     bytes at load time so it matches the stored owner_address BLOB.
+#
+# Match modes:
+#   - exact (default): O(1) dictionary lookup.
+#   - prefix: linear scan of a small prefix table via startsWith().
+#
+# To catch Content-Type values with parameters (e.g. "image/gif; charset=..."),
+# use `match: prefix` with just the media type/subtype.
+#
+# See docs/parquet-and-clickhouse-usage.md for the full reference.
+
+rules: []
+#  - tag_name: App-Name
+#    tag_value: ephemeral-chat
+#    ttl_seconds: 86400        # 1 day
+#
+#  - tag_name: App-Name
+#    tag_value: test-
+#    match: prefix
+#    ttl_seconds: 3600         # 1 hour
+#
+#  - tag_name: Content-Type
+#    tag_value: image/gif
+#    match: prefix
+#    ttl_seconds: 2592000      # 30 days (catches "image/gif; charset=...")
+#
+#  - field: owner_address
+#    value: abcDEF0123...xyz   # base64url owner address
+#    ttl_seconds: 604800       # 7 days
+#
+#  - field: owner_address
+#    value: test-uploader-
+#    match: prefix
+#    ttl_seconds: 3600

--- a/config/clickhouse-ttl-rules.example.yaml
+++ b/config/clickhouse-ttl-rules.example.yaml
@@ -7,8 +7,14 @@
 # into the container and loads it at the top of every import cycle.
 #
 # Rules apply only to rows imported after they are loaded (no retroactive
-# backfill in v1). If multiple rules match a row, the shortest TTL wins. If
-# no rules match, expires_at is NULL and the row is kept indefinitely.
+# backfill in v1).
+#
+# Precedence for a row (first applicable branch wins):
+#   1. Any matching rule with `never_expire: true` → expires_at = NULL
+#      (row is kept indefinitely, overriding default_ttl_seconds).
+#   2. One or more matching TTL rules → shortest ttl_seconds wins.
+#   3. default_ttl_seconds set (top-level) → that value is applied.
+#   4. Otherwise → expires_at is NULL.
 #
 # Normalization:
 #   - tag_name is lower-cased + trimmed on both sides of the lookup.
@@ -27,6 +33,10 @@
 #
 # See docs/parquet-and-clickhouse-usage.md for the full reference.
 
+# Optional: applied to rows no rule matched. Omit (or leave commented) to
+# keep unmatched rows indefinitely.
+# default_ttl_seconds: 2592000   # 30 days
+
 rules: []
 #  - tag_name: App-Name
 #    tag_value: ephemeral-chat
@@ -41,6 +51,13 @@ rules: []
 #    tag_value: image/gif
 #    match: prefix
 #    ttl_seconds: 2592000      # 30 days (catches "image/gif; charset=...")
+#
+#  # Exempt rule: keep ArDrive rows forever even when default_ttl_seconds
+#  # is set. Use `never_expire: true` in place of `ttl_seconds`.
+#  - tag_name: App-Name
+#    tag_value: ArDrive
+#    match: prefix
+#    never_expire: true
 #
 #  - field: owner_address
 #    value: abcDEF0123...xyz   # base64url owner address

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -482,6 +482,7 @@ services:
       - ./data/sqlite:/app/data/sqlite:ro
       - ${LOCAL_DATASETS_PATH:-./data/datasets}:/app/data/datasets
       - ${ETL_STAGING_PATH:-./data/etl/staging}:/app/data/etl/staging
+      - ${CLICKHOUSE_TTL_RULES_PATH:-./config/clickhouse-ttl-rules.yaml}:/app/config/clickhouse-ttl-rules.yaml:ro
     environment:
       - DEBUG=${CLICKHOUSE_DEBUG:-}
       - AR_IO_HOST=core
@@ -497,6 +498,7 @@ services:
       - CLICKHOUSE_AUTO_IMPORT_SLEEP_INTERVAL=${CLICKHOUSE_AUTO_IMPORT_SLEEP_INTERVAL:-}
       - CLICKHOUSE_AUTO_IMPORT_HEIGHT_INTERVAL=${CLICKHOUSE_AUTO_IMPORT_HEIGHT_INTERVAL:-}
       - CLICKHOUSE_AUTO_IMPORT_MAX_ROWS_PER_FILE=${CLICKHOUSE_AUTO_IMPORT_MAX_ROWS_PER_FILE:-}
+      - CLICKHOUSE_TTL_RULES_PATH=/app/config/clickhouse-ttl-rules.yaml
     networks:
       - ar-io-network
     depends_on:

--- a/docs/envs.md
+++ b/docs/envs.md
@@ -331,3 +331,14 @@ When `OBSERVER_WALLET` is set, the gateway also creates an RSA attestation linki
 | HTTPSIG_UPLOAD_ATTESTATION  | Boolean | true                   | Upload the attestation to Arweave at startup (requires `OBSERVER_WALLET`). Set to false to skip upload               |
 | OBSERVER_WALLET             | String  | -                      | Arweave wallet address for attestation signing. Key file must exist at `<WALLETS_PATH>/<OBSERVER_WALLET>.json`       |
 | WALLETS_PATH                | String  | wallets                | Directory containing wallet JWK files                                                                                |
+
+## ClickHouse TTL Rules
+
+Operator-defined TTL rules for data in ClickHouse. Reloaded from disk by
+`clickhouse-auto-import` at the top of every import cycle. See
+[Parquet and ClickHouse usage](./parquet-and-clickhouse-usage.md#tag-based-ttl-rules)
+for the rules-file format and behavior.
+
+| ENV_NAME                    | TYPE    | DEFAULT_VALUE                        | DESCRIPTION                                                                                                  |
+| --------------------------- | ------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| CLICKHOUSE_TTL_RULES_PATH   | String  | ./config/clickhouse-ttl-rules.yaml   | Path to the YAML file of tag- and owner-based TTL rules loaded into ClickHouse before each import cycle       |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -166,6 +166,14 @@ verification status, and retry attempts.
 **Moderation Database** - SQLite database managing content blocking and
 filtering rules.
 
+<a id="ttl-rules"></a> **TTL Rules (ClickHouse)** - Operator-defined retention
+policies that expire rows in the ClickHouse `transactions` table. Matches on
+[tags](#tags) (`tag_name` + `tag_value`, exact or prefix) or owner address
+(base64url, exact or prefix) and assigns a `ttl_seconds`. Rules live in a
+YAML file loaded at the top of every import cycle; when multiple rules match
+a row the shortest TTL wins. Unmatched rows are retained indefinitely. See
+[Parquet and ClickHouse usage](./parquet-and-clickhouse-usage.md#tag-based-ttl-rules).
+
 ## CDB64 Indexing
 
 **CDB64** — Constant database format with 64-bit file offset support, used for

--- a/docs/parquet-and-clickhouse-usage.md
+++ b/docs/parquet-and-clickhouse-usage.md
@@ -141,6 +141,108 @@ includes:
 
 See `src/database/clickhouse/schema.sql` for the full definition.
 
+## Tag-based TTL Rules
+
+ClickHouse retains imported transactions indefinitely unless an operator
+defines a matching TTL rule. Rules let you expire rows by tag content or
+by uploader owner address — useful for short-lived app data (ephemeral
+chat, test uploads, specific content types) or for data from a
+short-retention uploader.
+
+Rules live in a YAML file at `config/clickhouse-ttl-rules.yaml`
+(override the host path with `CLICKHOUSE_TTL_RULES_PATH`). The repo ships a
+committed template at `config/clickhouse-ttl-rules.example.yaml` — copy it
+to activate rules:
+
+```sh
+cp config/clickhouse-ttl-rules.example.yaml config/clickhouse-ttl-rules.yaml
+# then edit config/clickhouse-ttl-rules.yaml
+```
+
+The real filename is gitignored so operator policies aren't committed.
+`clickhouse-auto-import` mounts the file into the container and loads it at
+the top of every import cycle via `scripts/clickhouse-load-ttl-rules.py`.
+Normalized rules are written to four source tables; two dictionaries
+(`ttl_tag_rules`, `ttl_owner_rules`) layered over the exact-match tables
+refresh on a 60–300 s `LIFETIME` and are used by
+`migrate_staging_to_final` to compute `transactions.expires_at` on every
+staging→final insert. If the file doesn't exist at import time the loader
+logs a warning and proceeds; rule tables stay empty and all rows get
+`expires_at = NULL`.
+
+### Rules file format
+
+```yaml
+rules:
+  # Tag rules (field defaults to "tag")
+  - tag_name: App-Name
+    tag_value: ephemeral-chat
+    ttl_seconds: 86400          # 1 day
+
+  - tag_name: App-Name
+    tag_value: test-
+    match: prefix
+    ttl_seconds: 3600           # 1 hour
+
+  - tag_name: Content-Type      # use match: prefix to catch parameterized
+    tag_value: image/gif        # forms like "image/gif; charset=utf-8"
+    match: prefix
+    ttl_seconds: 2592000
+
+  # Owner rules (value is base64url, as operators see on Arweave)
+  - field: owner_address
+    value: abcDEF0123...xyz
+    ttl_seconds: 604800
+
+  - field: owner_address
+    value: test-uploader-
+    match: prefix
+    ttl_seconds: 3600
+```
+
+Defaults: `field` is `tag`, `match` is `exact`.
+
+### Behavior
+
+- **Shortest TTL wins.** If multiple rules match a row (e.g. both a tag rule
+  and an owner rule), `expires_at` is computed from the smallest `ttl_seconds`.
+- **No match → `NULL` `expires_at` → kept indefinitely.**
+- **Normalization.** `tag_name` is lower-cased + trimmed on both sides;
+  `tag_value` is trimmed but case-preserving; the loader base64url-decodes
+  owner `value` into raw bytes so matching happens against the stored
+  `owner_address` BLOB directly.
+- **Content-Type parameters.** There is no special handling for Content-Type.
+  To match `image/gif; charset=utf-8` use `match: prefix` with
+  `tag_value: image/gif`.
+- **No backfill in v1.** Rules apply only to rows imported after the rules
+  are loaded; previously-imported rows keep their existing `expires_at`
+  (or `NULL`).
+- **Fail-open.** A missing or malformed rules file logs a warning and exits
+  cleanly; existing rules remain in place and the import proceeds.
+
+### Inspecting loaded rules
+
+```sh
+clickhouse client --password <your-password> -q 'SELECT * FROM ttl_tag_rules_src'
+clickhouse client --password <your-password> -q 'SELECT * FROM ttl_tag_prefix_rules'
+clickhouse client --password <your-password> -q 'SELECT * FROM ttl_owner_rules_src'
+clickhouse client --password <your-password> -q 'SELECT * FROM ttl_owner_prefix_rules'
+```
+
+### Backfilling existing rows (optional)
+
+Rules don't apply retroactively. To compute `expires_at` for previously
+imported rows, operators can run a mutation against `transactions` using
+the same lookup logic as `migrate_staging_to_final`:
+
+```sql
+ALTER TABLE transactions
+UPDATE expires_at = <same expression used at import time>
+WHERE 1;
+```
+
+This is a heavy mutation and should be scheduled off-peak.
+
 ## Rollback
 
 If a re-import using the consolidated schema causes problems, revert as

--- a/docs/parquet-and-clickhouse-usage.md
+++ b/docs/parquet-and-clickhouse-usage.md
@@ -143,11 +143,13 @@ See `src/database/clickhouse/schema.sql` for the full definition.
 
 ## Tag-based TTL Rules
 
-ClickHouse retains imported transactions indefinitely unless an operator
-defines a matching TTL rule. Rules let you expire rows by tag content or
-by uploader owner address — useful for short-lived app data (ephemeral
-chat, test uploads, specific content types) or for data from a
-short-retention uploader.
+By default ClickHouse retains imported transactions indefinitely. Operators
+can define TTL rules that expire rows by tag content or by uploader owner
+address — useful for short-lived app data (ephemeral chat, test uploads,
+specific content types) or for data from a short-retention uploader. A
+top-level `default_ttl_seconds` can apply a fallback TTL to every row that
+no rule matched, and individual rules can opt rows out of expiry entirely
+with `never_expire: true`.
 
 Rules live in a YAML file at `config/clickhouse-ttl-rules.yaml`
 (override the host path with `CLICKHOUSE_TTL_RULES_PATH`). The repo ships a
@@ -174,6 +176,10 @@ remain active, and if no rules have ever been loaded rows get
 ### Rules file format
 
 ```yaml
+# Optional: applied when no rule matches a row. Omit to keep unmatched rows
+# indefinitely (the prior default).
+default_ttl_seconds: 2592000    # 30 days
+
 rules:
   # Tag rules (field defaults to "tag")
   - tag_name: App-Name
@@ -190,6 +196,14 @@ rules:
     match: prefix
     ttl_seconds: 2592000
 
+  # Exempt rule: use `never_expire: true` in place of `ttl_seconds` to opt
+  # matching rows out of expiry entirely (overrides default_ttl_seconds
+  # and any other TTL rule that might also match).
+  - tag_name: App-Name
+    tag_value: ArDrive
+    match: prefix
+    never_expire: true
+
   # Owner rules (value is base64url, as operators see on Arweave)
   - field: owner_address
     value: abcDEF0123...xyz
@@ -201,13 +215,16 @@ rules:
     ttl_seconds: 3600
 ```
 
-Defaults: `field` is `tag`, `match` is `exact`.
+Defaults: `field` is `tag`, `match` is `exact`. A rule must set exactly one
+of `ttl_seconds` (positive integer) or `never_expire: true`.
 
 ### Behavior
 
-- **Shortest TTL wins.** If multiple rules match a row (e.g. both a tag rule
-  and an owner rule), `expires_at` is computed from the smallest `ttl_seconds`.
-- **No match → `NULL` `expires_at` → kept indefinitely.**
+- **Precedence** (first applicable branch wins):
+  1. Any matching rule with `never_expire: true` → `expires_at = NULL`.
+  2. One or more matching TTL rules → shortest `ttl_seconds` wins.
+  3. `default_ttl_seconds` set at the top level → that value is applied.
+  4. Otherwise → `expires_at` is `NULL` and the row is kept indefinitely.
 - **Normalization.** `tag_name` is lower-cased + trimmed on both sides;
   `tag_value` is trimmed but case-preserving. Owner `value` is stored as
   the operator-supplied base64url string and compared against
@@ -236,6 +253,7 @@ clickhouse client --password <your-password> -q 'SELECT * FROM ttl_tag_rules_src
 clickhouse client --password <your-password> -q 'SELECT * FROM ttl_tag_prefix_rules'
 clickhouse client --password <your-password> -q 'SELECT * FROM ttl_owner_rules_src'
 clickhouse client --password <your-password> -q 'SELECT * FROM ttl_owner_prefix_rules'
+clickhouse client --password <your-password> -q 'SELECT * FROM ttl_settings FINAL'
 ```
 
 ### Backfilling existing rows (optional)

--- a/docs/parquet-and-clickhouse-usage.md
+++ b/docs/parquet-and-clickhouse-usage.md
@@ -167,7 +167,8 @@ Normalized rules are written to four source tables; two dictionaries
 refresh on a 60–300 s `LIFETIME` and are used by
 `migrate_staging_to_final` to compute `transactions.expires_at` on every
 staging→final insert. If the file doesn't exist at import time the loader
-logs a warning and proceeds; rule tables stay empty and all rows get
+logs a warning and skips the reload step; any previously loaded rules
+remain active, and if no rules have ever been loaded rows get
 `expires_at = NULL`.
 
 ### Rules file format

--- a/docs/parquet-and-clickhouse-usage.md
+++ b/docs/parquet-and-clickhouse-usage.md
@@ -219,12 +219,15 @@ Defaults: `field` is `tag`, `match` is `exact`.
 - **No backfill in v1.** Rules apply only to rows imported after the rules
   are loaded; previously-imported rows keep their existing `expires_at`
   (or `NULL`).
-- **Fail-open.** A missing or malformed rules file logs a warning and exits
-  cleanly; existing rules remain in place and the import proceeds. If
-  ClickHouse rejects a write mid-load, the loader best-effort truncates all
-  four rule tables so the next import runs with no TTL rules rather than a
-  partial rule set, and returns a non-zero exit so the auto-import loop logs
-  the failure.
+- **Fail-open.** A missing, unreadable, or malformed rules file logs a
+  warning and exits 0; previously loaded rules remain active and imports
+  proceed normally. If ClickHouse rejects a write mid-load, the loader
+  best-effort truncates the four rule tables and retries the dictionary
+  reload with a short backoff. On the happy recovery path the cycle sees
+  no TTL rules; if the retries still can't reload the dictionaries, prefix
+  rules are cleared but exact-match dictionaries may briefly serve stale
+  entries until the next successful load. The loader's stderr identifies
+  which case fired.
 
 ### Inspecting loaded rules
 

--- a/docs/parquet-and-clickhouse-usage.md
+++ b/docs/parquet-and-clickhouse-usage.md
@@ -208,9 +208,10 @@ Defaults: `field` is `tag`, `match` is `exact`.
   and an owner rule), `expires_at` is computed from the smallest `ttl_seconds`.
 - **No match → `NULL` `expires_at` → kept indefinitely.**
 - **Normalization.** `tag_name` is lower-cased + trimmed on both sides;
-  `tag_value` is trimmed but case-preserving; the loader base64url-decodes
-  owner `value` into raw bytes so matching happens against the stored
-  `owner_address` BLOB directly.
+  `tag_value` is trimmed but case-preserving. Owner `value` is stored as
+  the operator-supplied base64url string and compared against
+  `base64URLEncode(owner_address)` at query time — so prefix rules match
+  textually (e.g. a 6-character base64url prefix works), not on raw bytes.
 - **Content-Type parameters.** There is no special handling for Content-Type.
   To match `image/gif; charset=utf-8` use `match: prefix` with
   `tag_value: image/gif`.
@@ -218,7 +219,11 @@ Defaults: `field` is `tag`, `match` is `exact`.
   are loaded; previously-imported rows keep their existing `expires_at`
   (or `NULL`).
 - **Fail-open.** A missing or malformed rules file logs a warning and exits
-  cleanly; existing rules remain in place and the import proceeds.
+  cleanly; existing rules remain in place and the import proceeds. If
+  ClickHouse rejects a write mid-load, the loader best-effort truncates all
+  four rule tables so the next import runs with no TTL rules rather than a
+  partial rule set, and returns a non-zero exit so the auto-import loop logs
+  the failure.
 
 ### Inspecting loaded rules
 

--- a/scripts/clickhouse-auto-import
+++ b/scripts/clickhouse-auto-import
@@ -55,6 +55,23 @@ while true; do
     loop_start_time=$(date +%s)
     echo "Starting new import cycle at $(date)"
 
+    # Refresh operator TTL rules before importing new partitions. The loader is
+    # idempotent; if the rules file is missing or malformed, it logs a warning
+    # and exits 0 so the import can proceed with whatever rules are already in
+    # ClickHouse (fails open).
+    if [ -n "${CLICKHOUSE_TTL_RULES_PATH:-}" ] && [ -f "$CLICKHOUSE_TTL_RULES_PATH" ]; then
+        echo "Loading TTL rules from $CLICKHOUSE_TTL_RULES_PATH..."
+        ttl_load_start=$(date +%s)
+        if python3 "$SCRIPT_DIR/clickhouse-load-ttl-rules.py" "$CLICKHOUSE_TTL_RULES_PATH"; then
+            log_timing "Load TTL rules" "$ttl_load_start" "$(date +%s)"
+        else
+            echo "Warning: TTL rules load failed; continuing with existing rules."
+            log_timing "Load TTL rules (failed)" "$ttl_load_start" "$(date +%s)"
+        fi
+    else
+        echo "No TTL rules file at ${CLICKHOUSE_TTL_RULES_PATH:-<unset>}; skipping TTL load."
+    fi
+
     echo "Attempting to fetch debug info from admin endpoint..."
     fetch_debug_start_time=$(date +%s)
     debug_info="$(curl -s --fail --show-error -H "Authorization: Bearer $ADMIN_API_KEY" "http://${ar_io_host}:${ar_io_port}/ar-io/admin/debug")"

--- a/scripts/clickhouse-auto-import
+++ b/scripts/clickhouse-auto-import
@@ -55,17 +55,18 @@ while true; do
     loop_start_time=$(date +%s)
     echo "Starting new import cycle at $(date)"
 
-    # Refresh operator TTL rules before importing new partitions. The loader is
-    # idempotent; if the rules file is missing or malformed, it logs a warning
-    # and exits 0 so the import can proceed with whatever rules are already in
-    # ClickHouse (fails open).
+    # Refresh operator TTL rules before importing new partitions. The loader
+    # exits 0 (no-op) if the rules file is missing/malformed — existing rules
+    # stay in place. A non-zero exit means ClickHouse rejected a write mid-load
+    # and the loader truncated all rule tables to avoid a partial set, so this
+    # cycle's imports will run with no enforced TTLs.
     if [ -n "${CLICKHOUSE_TTL_RULES_PATH:-}" ] && [ -f "$CLICKHOUSE_TTL_RULES_PATH" ]; then
         echo "Loading TTL rules from $CLICKHOUSE_TTL_RULES_PATH..."
         ttl_load_start=$(date +%s)
         if python3 "$SCRIPT_DIR/clickhouse-load-ttl-rules.py" "$CLICKHOUSE_TTL_RULES_PATH"; then
             log_timing "Load TTL rules" "$ttl_load_start" "$(date +%s)"
         else
-            echo "Warning: TTL rules load failed; continuing with existing rules."
+            echo "Warning: TTL rules load failed; rule tables cleared. Imports this cycle will not apply TTLs."
             log_timing "Load TTL rules (failed)" "$ttl_load_start" "$(date +%s)"
         fi
     else

--- a/scripts/clickhouse-auto-import
+++ b/scripts/clickhouse-auto-import
@@ -56,17 +56,19 @@ while true; do
     echo "Starting new import cycle at $(date)"
 
     # Refresh operator TTL rules before importing new partitions. The loader
-    # exits 0 (no-op) if the rules file is missing/malformed — existing rules
-    # stay in place. A non-zero exit means ClickHouse rejected a write mid-load
-    # and the loader truncated all rule tables to avoid a partial set, so this
-    # cycle's imports will run with no enforced TTLs.
+    # exits 0 for missing/malformed files and leaves any previously loaded
+    # rules in place. A non-zero exit means ClickHouse rejected a write
+    # mid-load; the loader best-effort clears rule tables and retries the
+    # dictionary reload, but the final state of the exact-match dictionaries
+    # isn't guaranteed — the loader's stderr distinguishes "cleaned" vs
+    # "stale-dictionaries" cases.
     if [ -n "${CLICKHOUSE_TTL_RULES_PATH:-}" ] && [ -f "$CLICKHOUSE_TTL_RULES_PATH" ]; then
         echo "Loading TTL rules from $CLICKHOUSE_TTL_RULES_PATH..."
         ttl_load_start=$(date +%s)
         if python3 "$SCRIPT_DIR/clickhouse-load-ttl-rules.py" "$CLICKHOUSE_TTL_RULES_PATH"; then
             log_timing "Load TTL rules" "$ttl_load_start" "$(date +%s)"
         else
-            echo "Warning: TTL rules load failed; rule tables cleared. Imports this cycle will not apply TTLs."
+            echo "Warning: TTL rules load failed; TTL state may be partially stale for this cycle (see loader output above)."
             log_timing "Load TTL rules (failed)" "$ttl_load_start" "$(date +%s)"
         fi
     else

--- a/scripts/clickhouse-import
+++ b/scripts/clickhouse-import
@@ -404,76 +404,154 @@ migrate_staging_to_final() {
     --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" \
     --query "INSERT INTO transactions
 SELECT
-  txs.height,
-  txs.block_transaction_index,
-  txs.is_data_item,
-  txs.id,
-  txs.anchor,
-  txs.owner_address,
-  txs.target,
-  txs.quantity,
-  txs.reward,
-  txs.data_size,
-  txs.content_type,
-  txs.format,
-  txs.data_root,
-  txs.parent AS parent_id,
-  blocks.indep_hash AS block_indep_hash,
-  blocks.block_timestamp,
-  blocks.previous_block AS block_previous_block,
-  txs.indexed_at,
-  now() AS inserted_at,
-  txs.offset,
-  txs.size,
-  txs.data_offset,
-  txs.owner_offset,
-  txs.owner_size,
-  txs.owner,
-  txs.signature_offset,
-  txs.signature_size,
-  txs.signature_type,
-  txs.root_transaction_id,
-  txs.root_parent_offset,
-  arrayMap(x -> (x.1, x.2),
-    arraySort(x -> x.3,
-      groupUniqArrayIf((tag_name, tag_value, tag_index), tag_name != '')
-    )
-  ) AS tags,
-  length(tags) AS tags_count
-FROM staging_transactions AS txs FINAL
-LEFT JOIN staging_tags AS tags FINAL ON txs.height = tags.height AND txs.id = tags.id
-JOIN staging_blocks AS blocks FINAL ON txs.height = blocks.height
-WHERE txs.height >= ${min_height} AND txs.height <= ${max_height}
-GROUP BY
-  txs.height,
-  txs.block_transaction_index,
-  txs.is_data_item,
-  txs.id,
-  txs.anchor,
-  txs.owner_address,
-  txs.target,
-  txs.quantity,
-  txs.reward,
-  txs.data_size,
-  txs.content_type,
-  txs.format,
-  txs.data_root,
-  txs.parent,
-  blocks.indep_hash,
-  blocks.block_timestamp,
-  blocks.previous_block,
-  txs.indexed_at,
-  txs.offset,
-  txs.size,
-  txs.data_offset,
-  txs.owner_offset,
-  txs.owner_size,
-  txs.owner,
-  txs.signature_offset,
-  txs.signature_size,
-  txs.signature_type,
-  txs.root_transaction_id,
-  txs.root_parent_offset;" || {
+  height,
+  block_transaction_index,
+  is_data_item,
+  id,
+  anchor,
+  owner_address,
+  target,
+  quantity,
+  reward,
+  data_size,
+  content_type,
+  format,
+  data_root,
+  parent_id,
+  block_indep_hash,
+  block_timestamp,
+  block_previous_block,
+  indexed_at,
+  inserted_at,
+  tx_offset,
+  tx_size,
+  data_offset,
+  owner_offset,
+  owner_size,
+  owner,
+  signature_offset,
+  signature_size,
+  signature_type,
+  root_transaction_id,
+  root_parent_offset,
+  tags,
+  tags_count,
+  -- TTL subcomponents are NULL when a branch had no match; the UInt32 max
+  -- sentinel in least() keeps unmatched branches from dominating the min.
+  if(
+    tag_exact_ttl IS NULL AND tag_prefix_ttl IS NULL
+      AND owner_exact_ttl IS NULL AND owner_prefix_ttl IS NULL,
+    NULL,
+    now() + toIntervalSecond(least(
+      coalesce(tag_exact_ttl,    toUInt32(4294967295)),
+      coalesce(tag_prefix_ttl,   toUInt32(4294967295)),
+      coalesce(owner_exact_ttl,  toUInt32(4294967295)),
+      coalesce(owner_prefix_ttl, toUInt32(4294967295))
+    ))
+  ) AS expires_at
+FROM
+(
+  SELECT
+    txs.height AS height,
+    txs.block_transaction_index AS block_transaction_index,
+    txs.is_data_item AS is_data_item,
+    txs.id AS id,
+    txs.anchor AS anchor,
+    txs.owner_address AS owner_address,
+    txs.target AS target,
+    txs.quantity AS quantity,
+    txs.reward AS reward,
+    txs.data_size AS data_size,
+    txs.content_type AS content_type,
+    txs.format AS format,
+    txs.data_root AS data_root,
+    txs.parent AS parent_id,
+    blocks.indep_hash AS block_indep_hash,
+    blocks.block_timestamp AS block_timestamp,
+    blocks.previous_block AS block_previous_block,
+    txs.indexed_at AS indexed_at,
+    now() AS inserted_at,
+    txs.offset AS tx_offset,
+    txs.size AS tx_size,
+    txs.data_offset AS data_offset,
+    txs.owner_offset AS owner_offset,
+    txs.owner_size AS owner_size,
+    txs.owner AS owner,
+    txs.signature_offset AS signature_offset,
+    txs.signature_size AS signature_size,
+    txs.signature_type AS signature_type,
+    txs.root_transaction_id AS root_transaction_id,
+    txs.root_parent_offset AS root_parent_offset,
+    arrayMap(x -> (x.1, x.2),
+      arraySort(x -> x.3,
+        groupUniqArrayIf((tag_name, tag_value, tag_index), tag_name != '')
+      )
+    ) AS tags,
+    length(tags) AS tags_count,
+    minOrNull(if(
+      tag_name != '',
+      dictGetOrNull('ttl_tag_rules', 'ttl_seconds',
+        (lower(trim(CAST(tag_name AS String))), CAST(tag_value AS String))
+      ),
+      NULL
+    )) AS tag_exact_ttl,
+    minOrNull(if(
+      tag_name != '',
+      arrayReduce('minOrNull',
+        arrayMap(
+          p -> if(p.1 = lower(trim(CAST(tag_name AS String)))
+                  AND startsWith(CAST(tag_value AS String), p.2),
+                  p.3,
+                  NULL),
+          (SELECT groupArray(tuple(tag_name, tag_value, ttl_seconds)) FROM ttl_tag_prefix_rules)
+        )
+      ),
+      NULL
+    )) AS tag_prefix_ttl,
+    any(dictGetOrNull('ttl_owner_rules', 'ttl_seconds',
+      tuple(CAST(txs.owner_address AS String))
+    )) AS owner_exact_ttl,
+    any(arrayReduce('minOrNull',
+      arrayMap(
+        p -> if(startsWith(CAST(txs.owner_address AS String), p.1), p.2, NULL),
+        (SELECT groupArray(tuple(owner_address, ttl_seconds)) FROM ttl_owner_prefix_rules)
+      )
+    )) AS owner_prefix_ttl
+  FROM staging_transactions AS txs FINAL
+  LEFT JOIN staging_tags AS tags FINAL ON txs.height = tags.height AND txs.id = tags.id
+  JOIN staging_blocks AS blocks FINAL ON txs.height = blocks.height
+  WHERE txs.height >= ${min_height} AND txs.height <= ${max_height}
+  GROUP BY
+    txs.height,
+    txs.block_transaction_index,
+    txs.is_data_item,
+    txs.id,
+    txs.anchor,
+    txs.owner_address,
+    txs.target,
+    txs.quantity,
+    txs.reward,
+    txs.data_size,
+    txs.content_type,
+    txs.format,
+    txs.data_root,
+    txs.parent,
+    blocks.indep_hash,
+    blocks.block_timestamp,
+    blocks.previous_block,
+    txs.indexed_at,
+    txs.offset,
+    txs.size,
+    txs.data_offset,
+    txs.owner_offset,
+    txs.owner_size,
+    txs.owner,
+    txs.signature_offset,
+    txs.signature_size,
+    txs.signature_type,
+    txs.root_transaction_id,
+    txs.root_parent_offset
+);" || {
     echo "    Warning: Failed to migrate data to transactions table" >&2
     return 1
   }

--- a/scripts/clickhouse-import
+++ b/scripts/clickhouse-import
@@ -509,11 +509,11 @@ FROM
       NULL
     )) AS tag_prefix_ttl,
     any(dictGetOrNull('ttl_owner_rules', 'ttl_seconds',
-      tuple(CAST(txs.owner_address AS String))
+      tuple(base64URLEncode(txs.owner_address))
     )) AS owner_exact_ttl,
     any(arrayReduce('minOrNull',
       arrayMap(
-        p -> if(startsWith(CAST(txs.owner_address AS String), p.1), p.2, NULL),
+        p -> if(startsWith(base64URLEncode(txs.owner_address), p.1), p.2, NULL),
         (SELECT groupArray(tuple(owner_address, ttl_seconds)) FROM ttl_owner_prefix_rules)
       )
     )) AS owner_prefix_ttl

--- a/scripts/clickhouse-import
+++ b/scripts/clickhouse-import
@@ -403,6 +403,7 @@ migrate_staging_to_final() {
   clickhouse client --host "$CLICKHOUSE_HOST" --port "$CLICKHOUSE_PORT" \
     --user "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" \
     --query "INSERT INTO transactions
+WITH (SELECT default_ttl_seconds FROM ttl_settings FINAL LIMIT 1) AS default_ttl
 SELECT
   height,
   block_transaction_index,
@@ -436,18 +437,28 @@ SELECT
   root_parent_offset,
   tags,
   tags_count,
-  -- TTL subcomponents are NULL when a branch had no match; the UInt32 max
-  -- sentinel in least() keeps unmatched branches from dominating the min.
-  if(
-    tag_exact_ttl IS NULL AND tag_prefix_ttl IS NULL
-      AND owner_exact_ttl IS NULL AND owner_prefix_ttl IS NULL,
+  -- Precedence: any matching exempt rule (never_expire=1) wins and forces
+  -- expires_at = NULL, beating TTL matches and the default. If no exempt
+  -- fires and at least one branch produced a TTL, the shortest wins via
+  -- least() with UInt32-max sentinels masking unmatched branches. If
+  -- nothing matched at all, fall back to default_ttl (NULL → keep forever).
+  multiIf(
+    coalesce(tag_exact_exempt, 0) = 1
+      OR coalesce(tag_prefix_exempt, 0) = 1
+      OR coalesce(owner_exact_exempt, 0) = 1
+      OR coalesce(owner_prefix_exempt, 0) = 1,
     NULL,
+    tag_exact_ttl IS NOT NULL OR tag_prefix_ttl IS NOT NULL
+      OR owner_exact_ttl IS NOT NULL OR owner_prefix_ttl IS NOT NULL,
     now() + toIntervalSecond(least(
       coalesce(tag_exact_ttl,    toUInt32(4294967295)),
       coalesce(tag_prefix_ttl,   toUInt32(4294967295)),
       coalesce(owner_exact_ttl,  toUInt32(4294967295)),
       coalesce(owner_prefix_ttl, toUInt32(4294967295))
-    ))
+    )),
+    default_ttl IS NOT NULL,
+    now() + toIntervalSecond(default_ttl),
+    NULL
   ) AS expires_at
 FROM
 (
@@ -488,35 +499,81 @@ FROM
       )
     ) AS tags,
     length(tags) AS tags_count,
+    -- Exact tag TTL: only contributes to the shortest-TTL race when the
+    -- matched rule is not exempt. never_expire=1 entries keep ttl_seconds=0
+    -- and are filtered out here; they surface via tag_exact_exempt instead.
     minOrNull(if(
-      tag_name != '',
+      tag_name != ''
+        AND dictGetOrNull('ttl_tag_rules', 'never_expire',
+          (lower(trim(CAST(tag_name AS String))), CAST(tag_value AS String))
+        ) = 0,
       dictGetOrNull('ttl_tag_rules', 'ttl_seconds',
         (lower(trim(CAST(tag_name AS String))), CAST(tag_value AS String))
       ),
       NULL
     )) AS tag_exact_ttl,
+    maxOrNull(if(
+      tag_name != '',
+      dictGetOrNull('ttl_tag_rules', 'never_expire',
+        (lower(trim(CAST(tag_name AS String))), CAST(tag_value AS String))
+      ),
+      NULL
+    )) AS tag_exact_exempt,
     minOrNull(if(
       tag_name != '',
       arrayReduce('minOrNull',
         arrayMap(
           p -> if(p.1 = lower(trim(CAST(tag_name AS String)))
-                  AND startsWith(CAST(tag_value AS String), p.2),
+                  AND startsWith(CAST(tag_value AS String), p.2)
+                  AND p.4 = 0,
                   p.3,
                   NULL),
-          (SELECT groupArray(tuple(tag_name, tag_value, ttl_seconds)) FROM ttl_tag_prefix_rules)
+          (SELECT groupArray(tuple(tag_name, tag_value, ttl_seconds, never_expire)) FROM ttl_tag_prefix_rules)
         )
       ),
       NULL
     )) AS tag_prefix_ttl,
-    any(dictGetOrNull('ttl_owner_rules', 'ttl_seconds',
-      tuple(base64URLEncode(txs.owner_address))
+    maxOrNull(if(
+      tag_name != '',
+      arrayReduce('maxOrNull',
+        arrayMap(
+          p -> if(p.1 = lower(trim(CAST(tag_name AS String)))
+                  AND startsWith(CAST(tag_value AS String), p.2),
+                  p.4,
+                  NULL),
+          (SELECT groupArray(tuple(tag_name, tag_value, ttl_seconds, never_expire)) FROM ttl_tag_prefix_rules)
+        )
+      ),
+      NULL
+    )) AS tag_prefix_exempt,
+    any(if(
+      dictGetOrNull('ttl_owner_rules', 'never_expire',
+        tuple(base64URLEncode(txs.owner_address))
+      ) = 0,
+      dictGetOrNull('ttl_owner_rules', 'ttl_seconds',
+        tuple(base64URLEncode(txs.owner_address))
+      ),
+      NULL
     )) AS owner_exact_ttl,
+    any(dictGetOrNull('ttl_owner_rules', 'never_expire',
+      tuple(base64URLEncode(txs.owner_address))
+    )) AS owner_exact_exempt,
     any(arrayReduce('minOrNull',
       arrayMap(
-        p -> if(startsWith(base64URLEncode(txs.owner_address), p.1), p.2, NULL),
-        (SELECT groupArray(tuple(owner_address, ttl_seconds)) FROM ttl_owner_prefix_rules)
+        p -> if(startsWith(base64URLEncode(txs.owner_address), p.1) AND p.3 = 0,
+                p.2,
+                NULL),
+        (SELECT groupArray(tuple(owner_address, ttl_seconds, never_expire)) FROM ttl_owner_prefix_rules)
       )
-    )) AS owner_prefix_ttl
+    )) AS owner_prefix_ttl,
+    any(arrayReduce('maxOrNull',
+      arrayMap(
+        p -> if(startsWith(base64URLEncode(txs.owner_address), p.1),
+                p.3,
+                NULL),
+        (SELECT groupArray(tuple(owner_address, ttl_seconds, never_expire)) FROM ttl_owner_prefix_rules)
+      )
+    )) AS owner_prefix_exempt
   FROM staging_transactions AS txs FINAL
   LEFT JOIN staging_tags AS tags FINAL ON txs.height = tags.height AND txs.id = tags.id
   JOIN staging_blocks AS blocks FINAL ON txs.height = blocks.height

--- a/scripts/clickhouse-import
+++ b/scripts/clickhouse-import
@@ -242,6 +242,27 @@ validate_transactions_schema() {
   fi
 }
 
+# Refresh operator TTL rules so migrate_staging_to_final computes expires_at
+# from the latest ttl_settings and dictionaries. The loader exits 0 for
+# missing/malformed files (leaving previously loaded rules untouched) and
+# non-zero on ClickHouse write failure; in either case, proceed with the
+# import since partial TTL state is better than aborting a manual run.
+refresh_ttl_rules() {
+  if [[ -z "${CLICKHOUSE_TTL_RULES_PATH:-}" ]]; then
+    echo "  No CLICKHOUSE_TTL_RULES_PATH set; skipping TTL rules refresh."
+    return 0
+  fi
+  if [[ ! -f "$CLICKHOUSE_TTL_RULES_PATH" ]]; then
+    echo "  No TTL rules file at $CLICKHOUSE_TTL_RULES_PATH; skipping TTL rules refresh."
+    return 0
+  fi
+
+  echo "Loading TTL rules from $CLICKHOUSE_TTL_RULES_PATH..."
+  if ! python3 "$SCRIPT_DIR/clickhouse-load-ttl-rules.py" "$CLICKHOUSE_TTL_RULES_PATH"; then
+    echo "Warning: TTL rules load failed; TTL state may be partially stale for this import (see loader output above)." >&2
+  fi
+}
+
 # Initialize ClickHouse schema if needed
 initialize_clickhouse_schema() {
   echo "Initializing ClickHouse schema..."
@@ -758,7 +779,14 @@ find_flat_partitions() {
 main() {
   test_clickhouse_connection
   initialize_clickhouse_schema
-  
+
+  # Refresh TTL rules before any migrate_staging_to_final runs (partition mode
+  # only — single-file imports write straight to staging and don't compute
+  # expires_at). Skipped in dry-run because no migrate executes.
+  if [[ -z "$PARQUET_FILE" ]] && ! $DRY_RUN; then
+    refresh_ttl_rules
+  fi
+
   if [[ -n "$PARQUET_FILE" ]]; then
     # Single file import mode
     echo "Importing single file: $PARQUET_FILE -> $TABLE"

--- a/scripts/clickhouse-load-ttl-rules.py
+++ b/scripts/clickhouse-load-ttl-rules.py
@@ -45,6 +45,8 @@ ALL_RULE_TABLES = (
     "ttl_owner_prefix_rules",
 )
 
+SETTINGS_TABLE = "ttl_settings"
+
 EXACT_DICTIONARIES = (
     "ttl_tag_rules",
     "ttl_owner_rules",
@@ -107,6 +109,7 @@ def bucket_rules(rules: Iterable[dict[str, Any]]) -> dict[str, list[tuple]]:
         field = raw.get("field", "tag")
         match = raw.get("match", "exact")
         ttl = raw.get("ttl_seconds")
+        never_expire = raw.get("never_expire", False)
 
         if field not in ("tag", "owner_address"):
             print(
@@ -120,12 +123,31 @@ def bucket_rules(rules: Iterable[dict[str, Any]]) -> dict[str, list[tuple]]:
                 file=sys.stderr,
             )
             continue
-        if not isinstance(ttl, int) or ttl <= 0:
+        if not isinstance(never_expire, bool):
             print(
-                f"warning: rule #{idx} has non-positive ttl_seconds {ttl!r}; skipping",
+                f"warning: rule #{idx} has non-boolean never_expire {never_expire!r}; skipping",
                 file=sys.stderr,
             )
             continue
+        if never_expire:
+            if ttl is not None:
+                print(
+                    f"warning: rule #{idx} sets both never_expire and ttl_seconds;"
+                    " skipping (use one or the other)",
+                    file=sys.stderr,
+                )
+                continue
+            ttl_value = 0
+        else:
+            if not isinstance(ttl, int) or isinstance(ttl, bool) or ttl <= 0:
+                print(
+                    f"warning: rule #{idx} has non-positive ttl_seconds {ttl!r}; skipping",
+                    file=sys.stderr,
+                )
+                continue
+            ttl_value = ttl
+
+        never_flag = 1 if never_expire else 0
 
         if field == "tag":
             tag_name = raw.get("tag_name")
@@ -145,7 +167,7 @@ def bucket_rules(rules: Iterable[dict[str, Any]]) -> dict[str, list[tuple]]:
             normalized_name = tag_name.strip().lower()
             normalized_value = tag_value.strip()
             key = "tag_exact" if match == "exact" else "tag_prefix"
-            buckets[key].append((normalized_name, normalized_value, ttl))
+            buckets[key].append((normalized_name, normalized_value, ttl_value, never_flag))
         else:
             raw_value = raw.get("value")
             if not isinstance(raw_value, str) or not raw_value.strip():
@@ -163,7 +185,7 @@ def bucket_rules(rules: Iterable[dict[str, Any]]) -> dict[str, list[tuple]]:
                 )
                 continue
             key = "owner_exact" if match == "exact" else "owner_prefix"
-            buckets[key].append((normalized_value, ttl))
+            buckets[key].append((normalized_value, ttl_value, never_flag))
 
     return buckets
 
@@ -173,10 +195,13 @@ def load_tag_bucket(table: str, rows: list[tuple]) -> None:
     if not rows:
         return
     values = ",".join(
-        f"({escape_str(name)}, {escape_str(value)}, {ttl})"
-        for (name, value, ttl) in rows
+        f"({escape_str(name)}, {escape_str(value)}, {ttl}, {never})"
+        for (name, value, ttl, never) in rows
     )
-    run_query(f"INSERT INTO {table} (tag_name, tag_value, ttl_seconds) VALUES {values}")
+    run_query(
+        f"INSERT INTO {table} (tag_name, tag_value, ttl_seconds, never_expire)"
+        f" VALUES {values}"
+    )
 
 
 def load_owner_bucket(table: str, rows: list[tuple]) -> None:
@@ -184,9 +209,21 @@ def load_owner_bucket(table: str, rows: list[tuple]) -> None:
     if not rows:
         return
     values = ",".join(
-        f"({escape_str(owner)}, {ttl})" for (owner, ttl) in rows
+        f"({escape_str(owner)}, {ttl}, {never})" for (owner, ttl, never) in rows
     )
-    run_query(f"INSERT INTO {table} (owner_address, ttl_seconds) VALUES {values}")
+    run_query(
+        f"INSERT INTO {table} (owner_address, ttl_seconds, never_expire)"
+        f" VALUES {values}"
+    )
+
+
+def load_settings(default_ttl_seconds: int | None) -> None:
+    run_query(f"TRUNCATE TABLE {SETTINGS_TABLE}")
+    value = "NULL" if default_ttl_seconds is None else str(default_ttl_seconds)
+    run_query(
+        f"INSERT INTO {SETTINGS_TABLE} (singleton, default_ttl_seconds)"
+        f" VALUES (1, {value})"
+    )
 
 
 def reload_dictionaries() -> None:
@@ -221,15 +258,18 @@ def reload_dictionaries_with_retry(attempts: int = 3, delay_seconds: float = 0.5
 def truncate_all_rule_tables() -> None:
     for table in ALL_RULE_TABLES:
         try_truncate(table)
+    try_truncate(SETTINGS_TABLE)
 
 
-def load_rules_file(path: str) -> list[Any] | None:
+def load_rules_file(path: str) -> tuple[list[Any], int | None] | None:
     """Read and parse the rules YAML.
 
-    Returns a list of rule mappings, an empty list if the file is missing /
-    empty / structurally doesn't contain rules, or None if the caller should
-    skip the load entirely (unreadable / malformed). All failure modes here
-    log a warning but never raise.
+    Returns a (rules, default_ttl_seconds) tuple on success — rules is an
+    empty list if the file is missing rules or is empty-but-well-formed;
+    default_ttl_seconds is the top-level `default_ttl_seconds` value or None
+    if unset/invalid. Returns None if the caller should skip the load
+    entirely (file missing/unreadable/malformed). All failure modes here log
+    a warning but never raise.
     """
     if not os.path.isfile(path):
         print(
@@ -255,27 +295,40 @@ def load_rules_file(path: str) -> list[Any] | None:
         return None
 
     if doc is None:
-        return []
+        return ([], None)
 
     if not isinstance(doc, dict):
         print(
             f"warning: {path} root is {type(doc).__name__}, expected mapping; treating as no rules",
             file=sys.stderr,
         )
-        return []
+        return ([], None)
+
+    default_ttl = doc.get("default_ttl_seconds")
+    if default_ttl is not None and (
+        not isinstance(default_ttl, int)
+        or isinstance(default_ttl, bool)
+        or default_ttl <= 0
+    ):
+        print(
+            f"warning: {path} default_ttl_seconds {default_ttl!r} is not a positive"
+            " integer; ignoring",
+            file=sys.stderr,
+        )
+        default_ttl = None
 
     rules = doc.get("rules")
     if rules is None:
-        return []
+        return ([], default_ttl)
 
     if not isinstance(rules, list):
         print(
             f"warning: {path} 'rules' key is {type(rules).__name__}, expected list; treating as empty",
             file=sys.stderr,
         )
-        return []
+        return ([], default_ttl)
 
-    return rules
+    return (rules, default_ttl)
 
 
 def main() -> int:
@@ -295,13 +348,14 @@ def main() -> int:
         )
         return 0
 
-    rules = load_rules_file(args.path)
-    if rules is None:
+    parsed = load_rules_file(args.path)
+    if parsed is None:
         # File missing / unreadable / malformed. Leave previously loaded rules
-        # in place; the auto-import loop continues with whatever is already
-        # in ClickHouse.
+        # and settings in place; the auto-import loop continues with whatever
+        # is already in ClickHouse.
         return 0
 
+    rules, default_ttl = parsed
     buckets = bucket_rules(rules)
 
     try:
@@ -309,6 +363,7 @@ def main() -> int:
         load_tag_bucket("ttl_tag_prefix_rules", buckets["tag_prefix"])
         load_owner_bucket("ttl_owner_rules_src", buckets["owner_exact"])
         load_owner_bucket("ttl_owner_prefix_rules", buckets["owner_prefix"])
+        load_settings(default_ttl)
         if not reload_dictionaries_with_retry():
             raise subprocess.CalledProcessError(1, "SYSTEM RELOAD DICTIONARY")
     except subprocess.CalledProcessError as exc:
@@ -335,12 +390,14 @@ def main() -> int:
 
     print(
         "TTL rules loaded from {path}: "
-        "tag_exact={te} tag_prefix={tp} owner_exact={oe} owner_prefix={op}".format(
+        "tag_exact={te} tag_prefix={tp} owner_exact={oe} owner_prefix={op}"
+        " default_ttl_seconds={dt}".format(
             path=args.path,
             te=len(buckets["tag_exact"]),
             tp=len(buckets["tag_prefix"]),
             oe=len(buckets["owner_exact"]),
             op=len(buckets["owner_prefix"]),
+            dt="none" if default_ttl is None else default_ttl,
         )
     )
     return 0

--- a/scripts/clickhouse-load-ttl-rules.py
+++ b/scripts/clickhouse-load-ttl-rules.py
@@ -3,32 +3,51 @@
 """Load operator-defined TTL rules from a YAML file into ClickHouse.
 
 Populates the four rule-source tables (ttl_tag_rules_src, ttl_tag_prefix_rules,
-ttl_owner_rules_src, ttl_owner_prefix_rules). The two dictionaries layered on
-top of the exact-match source tables (ttl_tag_rules, ttl_owner_rules) refresh
-independently on their LIFETIME clauses; this script does not reload them
-directly.
+ttl_owner_rules_src, ttl_owner_prefix_rules) and force-reloads the two
+dictionaries (ttl_tag_rules, ttl_owner_rules) so the new rules are visible to
+the next migrate_staging_to_final invocation without waiting for the
+dictionaries' LIFETIME to expire.
 
-Fails open: a missing or malformed rules file logs a warning and exits 0 so
-imports continue against whatever rules are already in the source tables. On
-success, each run is a TRUNCATE+INSERT per bucket so removed YAML entries
-disappear on the next load.
+Owner values stay in their base64url form (never decoded) on both sides: the
+migrate query compares base64URLEncode(owner_address) against the stored
+string. That lets operators write textual prefixes like "test-uploader-"
+rather than raw-byte prefixes which wouldn't correspond to any clean base64url
+cut.
+
+Fail-open semantics:
+  * Missing, unreadable, or malformed rules file → log a warning and exit 0.
+    The _src / prefix tables keep their previous contents.
+  * ClickHouse rejecting any of the TRUNCATE/INSERT/RELOAD statements → make
+    a best-effort pass to truncate every rule table to leave a consistent
+    empty state (no TTL rules applied rather than a partial mix), then exit 1.
+    The calling auto-import loop treats this as "imports proceed without
+    enforced TTLs until the next successful load".
 """
 
 from __future__ import annotations
 
 import argparse
-import base64
 import os
+import re
 import subprocess
 import sys
 from typing import Any, Iterable
 
 import yaml
 
+ALL_RULE_TABLES = (
+    "ttl_tag_rules_src",
+    "ttl_tag_prefix_rules",
+    "ttl_owner_rules_src",
+    "ttl_owner_prefix_rules",
+)
 
-def b64url_decode(value: str) -> bytes:
-    padded = value + "=" * (-len(value) % 4)
-    return base64.urlsafe_b64decode(padded)
+EXACT_DICTIONARIES = (
+    "ttl_tag_rules",
+    "ttl_owner_rules",
+)
+
+BASE64URL_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def clickhouse_args() -> list[str]:
@@ -53,6 +72,16 @@ def run_query(query: str) -> None:
         clickhouse_args() + ["--query", query],
         check=True,
     )
+
+
+def try_truncate(table: str) -> None:
+    try:
+        run_query(f"TRUNCATE TABLE {table}")
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"warning: best-effort truncate of {table} failed (exit {exc.returncode})",
+            file=sys.stderr,
+        )
 
 
 def escape_str(s: str) -> str:
@@ -122,16 +151,16 @@ def bucket_rules(rules: Iterable[dict[str, Any]]) -> dict[str, list[tuple]]:
                     file=sys.stderr,
                 )
                 continue
-            try:
-                decoded = b64url_decode(raw_value.strip())
-            except (ValueError, base64.binascii.Error) as exc:
+            normalized_value = raw_value.strip()
+            if not BASE64URL_RE.match(normalized_value):
                 print(
-                    f"warning: rule #{idx} value is not valid base64url ({exc}); skipping",
+                    f"warning: rule #{idx} value {normalized_value!r} is not base64url"
+                    " ([A-Za-z0-9_-]+); skipping",
                     file=sys.stderr,
                 )
                 continue
             key = "owner_exact" if match == "exact" else "owner_prefix"
-            buckets[key].append((decoded.hex(), ttl))
+            buckets[key].append((normalized_value, ttl))
 
     return buckets
 
@@ -152,9 +181,19 @@ def load_owner_bucket(table: str, rows: list[tuple]) -> None:
     if not rows:
         return
     values = ",".join(
-        f"(unhex('{hex_bytes}'), {ttl})" for (hex_bytes, ttl) in rows
+        f"({escape_str(owner)}, {ttl})" for (owner, ttl) in rows
     )
     run_query(f"INSERT INTO {table} (owner_address, ttl_seconds) VALUES {values}")
+
+
+def reload_dictionaries() -> None:
+    for dict_name in EXACT_DICTIONARIES:
+        run_query(f"SYSTEM RELOAD DICTIONARY {dict_name}")
+
+
+def truncate_all_rule_tables() -> None:
+    for table in ALL_RULE_TABLES:
+        try_truncate(table)
 
 
 def main() -> int:
@@ -206,11 +245,25 @@ def main() -> int:
         load_tag_bucket("ttl_tag_prefix_rules", buckets["tag_prefix"])
         load_owner_bucket("ttl_owner_rules_src", buckets["owner_exact"])
         load_owner_bucket("ttl_owner_prefix_rules", buckets["owner_prefix"])
+        reload_dictionaries()
     except subprocess.CalledProcessError as exc:
         print(
-            f"error: clickhouse client failed during TTL rules load (exit {exc.returncode})",
+            f"error: clickhouse client failed during TTL rules load (exit {exc.returncode});"
+            " truncating all rule tables to avoid a partial rule set",
             file=sys.stderr,
         )
+        truncate_all_rule_tables()
+        # Try once more to reload the dictionaries so they pick up the empty
+        # source tables; if this fails too, we've still made the migrate query
+        # fail open (dict lookups return NULL).
+        try:
+            reload_dictionaries()
+        except subprocess.CalledProcessError:
+            print(
+                "warning: dictionary reload after truncate also failed;"
+                " rules may remain stale until the next successful load",
+                file=sys.stderr,
+            )
         return 1
 
     print(

--- a/scripts/clickhouse-load-ttl-rules.py
+++ b/scripts/clickhouse-load-ttl-rules.py
@@ -54,6 +54,8 @@ EXACT_DICTIONARIES = (
 
 BASE64URL_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
+UINT32_MAX = 2**32 - 1
+
 
 def clickhouse_args() -> list[str]:
     args = ["clickhouse", "client"]
@@ -139,9 +141,15 @@ def bucket_rules(rules: Iterable[dict[str, Any]]) -> dict[str, list[tuple]]:
                 continue
             ttl_value = 0
         else:
-            if not isinstance(ttl, int) or isinstance(ttl, bool) or ttl <= 0:
+            if (
+                not isinstance(ttl, int)
+                or isinstance(ttl, bool)
+                or ttl <= 0
+                or ttl > UINT32_MAX
+            ):
                 print(
-                    f"warning: rule #{idx} has non-positive ttl_seconds {ttl!r}; skipping",
+                    f"warning: rule #{idx} has invalid ttl_seconds {ttl!r}"
+                    f" (must be a positive integer <= {UINT32_MAX}); skipping",
                     file=sys.stderr,
                 )
                 continue
@@ -268,8 +276,9 @@ def load_rules_file(path: str) -> tuple[list[Any], int | None] | None:
     empty list if the file is missing rules or is empty-but-well-formed;
     default_ttl_seconds is the top-level `default_ttl_seconds` value or None
     if unset/invalid. Returns None if the caller should skip the load
-    entirely (file missing/unreadable/malformed). All failure modes here log
-    a warning but never raise.
+    entirely (file missing/unreadable/malformed, or structurally invalid —
+    root not a mapping, `rules` not a list). All failure modes here log a
+    warning but never raise.
     """
     if not os.path.isfile(path):
         print(
@@ -299,20 +308,22 @@ def load_rules_file(path: str) -> tuple[list[Any], int | None] | None:
 
     if not isinstance(doc, dict):
         print(
-            f"warning: {path} root is {type(doc).__name__}, expected mapping; treating as no rules",
+            f"warning: {path} root is {type(doc).__name__}, expected mapping;"
+            " skipping load (previously loaded rules, if any, are retained)",
             file=sys.stderr,
         )
-        return ([], None)
+        return None
 
     default_ttl = doc.get("default_ttl_seconds")
     if default_ttl is not None and (
         not isinstance(default_ttl, int)
         or isinstance(default_ttl, bool)
         or default_ttl <= 0
+        or default_ttl > UINT32_MAX
     ):
         print(
             f"warning: {path} default_ttl_seconds {default_ttl!r} is not a positive"
-            " integer; ignoring",
+            f" integer <= {UINT32_MAX}; ignoring",
             file=sys.stderr,
         )
         default_ttl = None
@@ -323,10 +334,11 @@ def load_rules_file(path: str) -> tuple[list[Any], int | None] | None:
 
     if not isinstance(rules, list):
         print(
-            f"warning: {path} 'rules' key is {type(rules).__name__}, expected list; treating as empty",
+            f"warning: {path} 'rules' key is {type(rules).__name__}, expected list;"
+            " skipping load (previously loaded rules, if any, are retained)",
             file=sys.stderr,
         )
-        return ([], default_ttl)
+        return None
 
     return (rules, default_ttl)
 

--- a/scripts/clickhouse-load-ttl-rules.py
+++ b/scripts/clickhouse-load-ttl-rules.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+
+"""Load operator-defined TTL rules from a YAML file into ClickHouse.
+
+Populates the four rule-source tables (ttl_tag_rules_src, ttl_tag_prefix_rules,
+ttl_owner_rules_src, ttl_owner_prefix_rules). The two dictionaries layered on
+top of the exact-match source tables (ttl_tag_rules, ttl_owner_rules) refresh
+independently on their LIFETIME clauses; this script does not reload them
+directly.
+
+Fails open: a missing or malformed rules file logs a warning and exits 0 so
+imports continue against whatever rules are already in the source tables. On
+success, each run is a TRUNCATE+INSERT per bucket so removed YAML entries
+disappear on the next load.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+import subprocess
+import sys
+from typing import Any, Iterable
+
+import yaml
+
+
+def b64url_decode(value: str) -> bytes:
+    padded = value + "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(padded)
+
+
+def clickhouse_args() -> list[str]:
+    args = ["clickhouse", "client"]
+    host = os.environ.get("CLICKHOUSE_HOST")
+    port = os.environ.get("CLICKHOUSE_PORT")
+    user = os.environ.get("CLICKHOUSE_USER")
+    password = os.environ.get("CLICKHOUSE_PASSWORD")
+    if host:
+        args.append(f"--host={host}")
+    if port:
+        args.append(f"--port={port}")
+    if user:
+        args.append(f"--user={user}")
+    if password:
+        args.append(f"--password={password}")
+    return args
+
+
+def run_query(query: str) -> None:
+    subprocess.run(
+        clickhouse_args() + ["--query", query],
+        check=True,
+    )
+
+
+def escape_str(s: str) -> str:
+    return "'" + s.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def bucket_rules(rules: Iterable[dict[str, Any]]) -> dict[str, list[tuple]]:
+    buckets: dict[str, list[tuple]] = {
+        "tag_exact": [],
+        "tag_prefix": [],
+        "owner_exact": [],
+        "owner_prefix": [],
+    }
+
+    for idx, raw in enumerate(rules):
+        if not isinstance(raw, dict):
+            print(f"warning: rule #{idx} is not a mapping; skipping", file=sys.stderr)
+            continue
+
+        field = raw.get("field", "tag")
+        match = raw.get("match", "exact")
+        ttl = raw.get("ttl_seconds")
+
+        if field not in ("tag", "owner_address"):
+            print(
+                f"warning: rule #{idx} has invalid field {field!r}; skipping",
+                file=sys.stderr,
+            )
+            continue
+        if match not in ("exact", "prefix"):
+            print(
+                f"warning: rule #{idx} has invalid match {match!r}; skipping",
+                file=sys.stderr,
+            )
+            continue
+        if not isinstance(ttl, int) or ttl <= 0:
+            print(
+                f"warning: rule #{idx} has non-positive ttl_seconds {ttl!r}; skipping",
+                file=sys.stderr,
+            )
+            continue
+
+        if field == "tag":
+            tag_name = raw.get("tag_name")
+            tag_value = raw.get("tag_value")
+            if not isinstance(tag_name, str) or not tag_name.strip():
+                print(
+                    f"warning: rule #{idx} missing non-empty tag_name; skipping",
+                    file=sys.stderr,
+                )
+                continue
+            if not isinstance(tag_value, str) or not tag_value.strip():
+                print(
+                    f"warning: rule #{idx} missing non-empty tag_value; skipping",
+                    file=sys.stderr,
+                )
+                continue
+            normalized_name = tag_name.strip().lower()
+            normalized_value = tag_value.strip()
+            key = "tag_exact" if match == "exact" else "tag_prefix"
+            buckets[key].append((normalized_name, normalized_value, ttl))
+        else:
+            raw_value = raw.get("value")
+            if not isinstance(raw_value, str) or not raw_value.strip():
+                print(
+                    f"warning: rule #{idx} missing non-empty value; skipping",
+                    file=sys.stderr,
+                )
+                continue
+            try:
+                decoded = b64url_decode(raw_value.strip())
+            except (ValueError, base64.binascii.Error) as exc:
+                print(
+                    f"warning: rule #{idx} value is not valid base64url ({exc}); skipping",
+                    file=sys.stderr,
+                )
+                continue
+            key = "owner_exact" if match == "exact" else "owner_prefix"
+            buckets[key].append((decoded.hex(), ttl))
+
+    return buckets
+
+
+def load_tag_bucket(table: str, rows: list[tuple]) -> None:
+    run_query(f"TRUNCATE TABLE {table}")
+    if not rows:
+        return
+    values = ",".join(
+        f"({escape_str(name)}, {escape_str(value)}, {ttl})"
+        for (name, value, ttl) in rows
+    )
+    run_query(f"INSERT INTO {table} (tag_name, tag_value, ttl_seconds) VALUES {values}")
+
+
+def load_owner_bucket(table: str, rows: list[tuple]) -> None:
+    run_query(f"TRUNCATE TABLE {table}")
+    if not rows:
+        return
+    values = ",".join(
+        f"(unhex('{hex_bytes}'), {ttl})" for (hex_bytes, ttl) in rows
+    )
+    run_query(f"INSERT INTO {table} (owner_address, ttl_seconds) VALUES {values}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=os.environ.get("CLICKHOUSE_TTL_RULES_PATH"),
+        help="Path to rules YAML (falls back to CLICKHOUSE_TTL_RULES_PATH env)",
+    )
+    args = parser.parse_args()
+
+    if not args.path:
+        print(
+            "warning: no rules path supplied (set CLICKHOUSE_TTL_RULES_PATH or pass as argument); skipping load",
+            file=sys.stderr,
+        )
+        return 0
+
+    if not os.path.isfile(args.path):
+        print(
+            f"warning: rules file not found at {args.path}; skipping load",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        with open(args.path, "r", encoding="utf-8") as f:
+            doc = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        print(
+            f"warning: failed to parse {args.path} as YAML ({exc}); skipping load",
+            file=sys.stderr,
+        )
+        return 0
+
+    rules = (doc or {}).get("rules") or []
+    if not isinstance(rules, list):
+        print(
+            f"warning: {args.path} 'rules' key is not a list; treating as empty",
+            file=sys.stderr,
+        )
+        rules = []
+
+    buckets = bucket_rules(rules)
+
+    try:
+        load_tag_bucket("ttl_tag_rules_src", buckets["tag_exact"])
+        load_tag_bucket("ttl_tag_prefix_rules", buckets["tag_prefix"])
+        load_owner_bucket("ttl_owner_rules_src", buckets["owner_exact"])
+        load_owner_bucket("ttl_owner_prefix_rules", buckets["owner_prefix"])
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"error: clickhouse client failed during TTL rules load (exit {exc.returncode})",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "TTL rules loaded from {path}: "
+        "tag_exact={te} tag_prefix={tp} owner_exact={oe} owner_prefix={op}".format(
+            path=args.path,
+            te=len(buckets["tag_exact"]),
+            tp=len(buckets["tag_prefix"]),
+            oe=len(buckets["owner_exact"]),
+            op=len(buckets["owner_prefix"]),
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/clickhouse-load-ttl-rules.py
+++ b/scripts/clickhouse-load-ttl-rules.py
@@ -14,14 +14,16 @@ string. That lets operators write textual prefixes like "test-uploader-"
 rather than raw-byte prefixes which wouldn't correspond to any clean base64url
 cut.
 
-Fail-open semantics:
-  * Missing, unreadable, or malformed rules file → log a warning and exit 0.
-    The _src / prefix tables keep their previous contents.
-  * ClickHouse rejecting any of the TRUNCATE/INSERT/RELOAD statements → make
-    a best-effort pass to truncate every rule table to leave a consistent
-    empty state (no TTL rules applied rather than a partial mix), then exit 1.
-    The calling auto-import loop treats this as "imports proceed without
-    enforced TTLs until the next successful load".
+Exit codes:
+  * 0 — load succeeded, or the rules file was missing/unreadable/malformed
+    and existing rules were left untouched. Callers can proceed normally.
+  * 1 — ClickHouse rejected a write or a dictionary reload while loading a
+    parsed rules document. The loader makes a best-effort pass to leave the
+    rule state as empty as possible (TRUNCATE all four source tables, retry
+    the dictionary reload). When reload succeeds, the import cycle sees no
+    TTL rules; when it doesn't, prefix rules are cleared but exact-match
+    dictionaries may briefly serve stale entries until the next successful
+    load.
 """
 
 from __future__ import annotations
@@ -31,6 +33,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from typing import Any, Iterable
 
 import yaml
@@ -191,9 +194,88 @@ def reload_dictionaries() -> None:
         run_query(f"SYSTEM RELOAD DICTIONARY {dict_name}")
 
 
+def reload_dictionaries_with_retry(attempts: int = 3, delay_seconds: float = 0.5) -> bool:
+    """Reload exact-match dictionaries, retrying on transient failures.
+
+    Returns True on success, False if all attempts failed. Each retry waits
+    `delay_seconds * 2**attempt` before trying again (short backoff bounded
+    by attempts).
+    """
+    last_exit = 0
+    for attempt in range(attempts):
+        try:
+            reload_dictionaries()
+            return True
+        except subprocess.CalledProcessError as exc:
+            last_exit = exc.returncode
+            if attempt < attempts - 1:
+                time.sleep(delay_seconds * (2 ** attempt))
+    print(
+        f"warning: SYSTEM RELOAD DICTIONARY failed after {attempts} attempts"
+        f" (last exit {last_exit})",
+        file=sys.stderr,
+    )
+    return False
+
+
 def truncate_all_rule_tables() -> None:
     for table in ALL_RULE_TABLES:
         try_truncate(table)
+
+
+def load_rules_file(path: str) -> list[Any] | None:
+    """Read and parse the rules YAML.
+
+    Returns a list of rule mappings, an empty list if the file is missing /
+    empty / structurally doesn't contain rules, or None if the caller should
+    skip the load entirely (unreadable / malformed). All failure modes here
+    log a warning but never raise.
+    """
+    if not os.path.isfile(path):
+        print(
+            f"warning: rules file not found at {path}; skipping load",
+            file=sys.stderr,
+        )
+        return None
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            doc = yaml.safe_load(f)
+    except OSError as exc:
+        print(
+            f"warning: could not read {path} ({exc}); skipping load",
+            file=sys.stderr,
+        )
+        return None
+    except yaml.YAMLError as exc:
+        print(
+            f"warning: failed to parse {path} as YAML ({exc}); skipping load",
+            file=sys.stderr,
+        )
+        return None
+
+    if doc is None:
+        return []
+
+    if not isinstance(doc, dict):
+        print(
+            f"warning: {path} root is {type(doc).__name__}, expected mapping; treating as no rules",
+            file=sys.stderr,
+        )
+        return []
+
+    rules = doc.get("rules")
+    if rules is None:
+        return []
+
+    if not isinstance(rules, list):
+        print(
+            f"warning: {path} 'rules' key is {type(rules).__name__}, expected list; treating as empty",
+            file=sys.stderr,
+        )
+        return []
+
+    return rules
 
 
 def main() -> int:
@@ -213,30 +295,12 @@ def main() -> int:
         )
         return 0
 
-    if not os.path.isfile(args.path):
-        print(
-            f"warning: rules file not found at {args.path}; skipping load",
-            file=sys.stderr,
-        )
+    rules = load_rules_file(args.path)
+    if rules is None:
+        # File missing / unreadable / malformed. Leave previously loaded rules
+        # in place; the auto-import loop continues with whatever is already
+        # in ClickHouse.
         return 0
-
-    try:
-        with open(args.path, "r", encoding="utf-8") as f:
-            doc = yaml.safe_load(f)
-    except yaml.YAMLError as exc:
-        print(
-            f"warning: failed to parse {args.path} as YAML ({exc}); skipping load",
-            file=sys.stderr,
-        )
-        return 0
-
-    rules = (doc or {}).get("rules") or []
-    if not isinstance(rules, list):
-        print(
-            f"warning: {args.path} 'rules' key is not a list; treating as empty",
-            file=sys.stderr,
-        )
-        rules = []
 
     buckets = bucket_rules(rules)
 
@@ -245,7 +309,8 @@ def main() -> int:
         load_tag_bucket("ttl_tag_prefix_rules", buckets["tag_prefix"])
         load_owner_bucket("ttl_owner_rules_src", buckets["owner_exact"])
         load_owner_bucket("ttl_owner_prefix_rules", buckets["owner_prefix"])
-        reload_dictionaries()
+        if not reload_dictionaries_with_retry():
+            raise subprocess.CalledProcessError(1, "SYSTEM RELOAD DICTIONARY")
     except subprocess.CalledProcessError as exc:
         print(
             f"error: clickhouse client failed during TTL rules load (exit {exc.returncode});"
@@ -253,15 +318,17 @@ def main() -> int:
             file=sys.stderr,
         )
         truncate_all_rule_tables()
-        # Try once more to reload the dictionaries so they pick up the empty
-        # source tables; if this fails too, we've still made the migrate query
-        # fail open (dict lookups return NULL).
-        try:
-            reload_dictionaries()
-        except subprocess.CalledProcessError:
+        if reload_dictionaries_with_retry():
             print(
-                "warning: dictionary reload after truncate also failed;"
-                " rules may remain stale until the next successful load",
+                "info: after-failure cleanup cleared rule tables and reloaded"
+                " dictionaries; exact-match lookups will return NULL this cycle",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "warning: after-failure dictionary reload did not succeed; prefix"
+                " rules are cleared but exact-match dictionaries may serve stale"
+                " entries until the next successful load",
                 file=sys.stderr,
             )
         return 1

--- a/scripts/tests/parquet/test-clickhouse-ttl-rules
+++ b/scripts/tests/parquet/test-clickhouse-ttl-rules
@@ -6,8 +6,11 @@ set -euo pipefail
 #   1. Writes a known rules YAML to a temp path.
 #   2. Runs the loader.
 #   3. Verifies the four rule tables are populated correctly.
-#   4. Forces a dictionary refresh and checks dictGetOrNull answers.
-#   5. Reloads with an empty rules file and verifies tables are cleared.
+#   4. Confirms dictGetOrNull answers without a manual SYSTEM RELOAD (the
+#      loader is expected to force a reload).
+#   5. Checks the owner-prefix semantics: startsWith against
+#      base64URLEncode(owner_address), not against raw bytes.
+#   6. Reloads with an empty rules file and verifies tables are cleared.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
@@ -49,8 +52,9 @@ ch_query "SELECT 1 FROM ttl_tag_rules_src LIMIT 0" >/dev/null 2>&1 || {
     exit 1
 }
 
-# A known base64url owner address (43 chars, typical Arweave address form).
-OWNER_B64URL="abcDEF0123456789_-xyzABCDEF0123456789_-xyz"
+# A full 43-character base64url owner address and a textual prefix of it.
+OWNER_B64URL="abcDEF0123456789_-xyzABCDEF0123456789_-xyzAB"
+OWNER_PREFIX="abcDEF"
 
 cat >"$TMP_RULES" <<YAML
 rules:
@@ -72,7 +76,7 @@ rules:
     value: $OWNER_B64URL
     ttl_seconds: 90
   - field: owner_address
-    value: $OWNER_B64URL
+    value: $OWNER_PREFIX
     match: prefix
     ttl_seconds: 75
 YAML
@@ -108,29 +112,52 @@ else
 fi
 echo
 
-echo "Test 3: Force dictionary reload and query dictGetOrNull"
-ch_query "SYSTEM RELOAD DICTIONARY ttl_tag_rules"
-ch_query "SYSTEM RELOAD DICTIONARY ttl_owner_rules"
+echo "Test 3: Owner values are stored verbatim as base64url strings"
+OWNER_ROW_COUNT=$(ch_query "SELECT count() FROM ttl_owner_rules_src WHERE owner_address = '$OWNER_B64URL' AND ttl_seconds = 90" | tr -d '[:space:]')
+OWNER_PREFIX_COUNT=$(ch_query "SELECT count() FROM ttl_owner_prefix_rules WHERE owner_address = '$OWNER_PREFIX' AND ttl_seconds = 75" | tr -d '[:space:]')
+if [ "$OWNER_ROW_COUNT" = "1" ] && [ "$OWNER_PREFIX_COUNT" = "1" ]; then
+    echo "✓ Owner rules stored as base64url text on both tables"
+else
+    echo "✗ Expected owner rows not found (exact=$OWNER_ROW_COUNT, prefix=$OWNER_PREFIX_COUNT)"
+    exit 1
+fi
+echo
 
+echo "Test 4: Dictionaries are auto-reloaded (no manual SYSTEM RELOAD required)"
 TAG_DICT=$(ch_query "SELECT dictGetOrNull('ttl_tag_rules', 'ttl_seconds', ('app-name', 'ephemeral-chat'))" | tr -d '[:space:]')
 if [ "$TAG_DICT" = "60" ]; then
-    echo "✓ ttl_tag_rules dict returns 60 for ('app-name','ephemeral-chat')"
+    echo "✓ ttl_tag_rules returns 60 for ('app-name','ephemeral-chat')"
 else
     echo "✗ Expected 60, got '$TAG_DICT'"
     exit 1
 fi
 
-# Owner dictionary uses raw bytes; verify by decoding the same base64url in SQL.
-OWNER_DICT=$(ch_query "SELECT dictGetOrNull('ttl_owner_rules', 'ttl_seconds', tuple(base64URLDecode('$OWNER_B64URL')))" | tr -d '[:space:]')
+OWNER_DICT=$(ch_query "SELECT dictGetOrNull('ttl_owner_rules', 'ttl_seconds', tuple('$OWNER_B64URL'))" | tr -d '[:space:]')
 if [ "$OWNER_DICT" = "90" ]; then
-    echo "✓ ttl_owner_rules dict returns 90 for the decoded owner address"
+    echo "✓ ttl_owner_rules returns 90 for the base64url owner"
 else
     echo "✗ Expected 90, got '$OWNER_DICT'"
     exit 1
 fi
 echo
 
-echo "Test 4: Unknown key returns NULL"
+echo "Test 5: Owner prefix semantics — startsWith against base64URLEncode"
+# Decode the full owner to raw bytes, then re-encode and verify the prefix
+# rule's owner_address matches startsWith of that re-encoding. This mirrors
+# what the migrate query does against transactions.owner_address.
+PREFIX_MATCH=$(ch_query "
+  SELECT count() FROM ttl_owner_prefix_rules
+  WHERE startsWith(base64URLEncode(base64URLDecode('$OWNER_B64URL')), owner_address)
+" | tr -d '[:space:]')
+if [ "$PREFIX_MATCH" = "1" ]; then
+    echo "✓ Prefix rule matches base64URLEncode of the decoded owner"
+else
+    echo "✗ Expected 1 matching prefix rule, got $PREFIX_MATCH"
+    exit 1
+fi
+echo
+
+echo "Test 6: Unknown key returns NULL"
 UNKNOWN=$(ch_query "SELECT dictGetOrNull('ttl_tag_rules', 'ttl_seconds', ('app-name', 'does-not-exist'))")
 if [ -z "$(echo "$UNKNOWN" | tr -d '[:space:]')" ] || [ "$(echo "$UNKNOWN" | tr -d '[:space:]')" = "\\N" ]; then
     echo "✓ Unknown key returns NULL"
@@ -140,7 +167,7 @@ else
 fi
 echo
 
-echo "Test 5: Empty rules file clears the tables"
+echo "Test 7: Empty rules file clears the tables"
 cat >"$EMPTY_RULES" <<YAML
 rules: []
 YAML

--- a/scripts/tests/parquet/test-clickhouse-ttl-rules
+++ b/scripts/tests/parquet/test-clickhouse-ttl-rules
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Integration test for tag-based TTL rules (PE-9058).
+# Exercises scripts/clickhouse-load-ttl-rules.py end to end:
+#   1. Writes a known rules YAML to a temp path.
+#   2. Runs the loader.
+#   3. Verifies the four rule tables are populated correctly.
+#   4. Forces a dictionary refresh and checks dictGetOrNull answers.
+#   5. Reloads with an empty rules file and verifies tables are cleared.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
+
+echo "Testing ClickHouse TTL rules loader"
+echo "===================================="
+echo
+
+load_env
+load_clickhouse_config
+
+if ! command -v clickhouse >/dev/null 2>&1; then
+    echo "✗ clickhouse client not installed; cannot run this test"
+    exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "✗ python3 not installed; cannot run this test"
+    exit 1
+fi
+
+ch_query() {
+    clickhouse client \
+        --host "$CLICKHOUSE_HOST" \
+        --port "$CLICKHOUSE_PORT" \
+        --user "$CLICKHOUSE_USER" \
+        --password "$CLICKHOUSE_PASSWORD" \
+        --query "$1"
+}
+
+TMP_RULES=$(mktemp --suffix=.yaml)
+EMPTY_RULES=$(mktemp --suffix=.yaml)
+trap 'rm -f "$TMP_RULES" "$EMPTY_RULES"' EXIT
+
+# Ensure schema (including rule tables and dictionaries) exists. Safe to re-run.
+./scripts/clickhouse-import --input-dir /tmp --all-partitions --dry-run >/dev/null 2>&1 || true
+ch_query "SELECT 1 FROM ttl_tag_rules_src LIMIT 0" >/dev/null 2>&1 || {
+    echo "✗ Expected TTL rule tables not found. Apply src/database/clickhouse/schema.sql first." >&2
+    exit 1
+}
+
+# A known base64url owner address (43 chars, typical Arweave address form).
+OWNER_B64URL="abcDEF0123456789_-xyzABCDEF0123456789_-xyz"
+
+cat >"$TMP_RULES" <<YAML
+rules:
+  - tag_name: App-Name
+    tag_value: ephemeral-chat
+    ttl_seconds: 60
+  - tag_name: Content-Type
+    tag_value: image/gif
+    ttl_seconds: 30
+  - tag_name: App-Name
+    tag_value: test-
+    match: prefix
+    ttl_seconds: 45
+  - tag_name: Content-Type
+    tag_value: image/gif
+    match: prefix
+    ttl_seconds: 120
+  - field: owner_address
+    value: $OWNER_B64URL
+    ttl_seconds: 90
+  - field: owner_address
+    value: $OWNER_B64URL
+    match: prefix
+    ttl_seconds: 75
+YAML
+
+echo "Test 1: Load rules and verify row counts"
+python3 ./scripts/clickhouse-load-ttl-rules.py "$TMP_RULES"
+
+EXACT_TAGS=$(ch_query "SELECT count() FROM ttl_tag_rules_src" | tr -d '[:space:]')
+PREFIX_TAGS=$(ch_query "SELECT count() FROM ttl_tag_prefix_rules" | tr -d '[:space:]')
+EXACT_OWNERS=$(ch_query "SELECT count() FROM ttl_owner_rules_src" | tr -d '[:space:]')
+PREFIX_OWNERS=$(ch_query "SELECT count() FROM ttl_owner_prefix_rules" | tr -d '[:space:]')
+
+echo "  ttl_tag_rules_src:       $EXACT_TAGS (expected 2)"
+echo "  ttl_tag_prefix_rules:    $PREFIX_TAGS (expected 2)"
+echo "  ttl_owner_rules_src:     $EXACT_OWNERS (expected 1)"
+echo "  ttl_owner_prefix_rules:  $PREFIX_OWNERS (expected 1)"
+
+if [ "$EXACT_TAGS" = "2" ] && [ "$PREFIX_TAGS" = "2" ] && [ "$EXACT_OWNERS" = "1" ] && [ "$PREFIX_OWNERS" = "1" ]; then
+    echo "✓ Rule counts match"
+else
+    echo "✗ Rule counts mismatch"
+    exit 1
+fi
+echo
+
+echo "Test 2: tag_name is normalized to lowercase on load"
+LOWER_ROWS=$(ch_query "SELECT count() FROM ttl_tag_rules_src WHERE tag_name = 'app-name' AND tag_value = 'ephemeral-chat' AND ttl_seconds = 60" | tr -d '[:space:]')
+if [ "$LOWER_ROWS" = "1" ]; then
+    echo "✓ 'App-Name' stored as 'app-name'"
+else
+    echo "✗ Expected lowercase 'app-name' row not found"
+    exit 1
+fi
+echo
+
+echo "Test 3: Force dictionary reload and query dictGetOrNull"
+ch_query "SYSTEM RELOAD DICTIONARY ttl_tag_rules"
+ch_query "SYSTEM RELOAD DICTIONARY ttl_owner_rules"
+
+TAG_DICT=$(ch_query "SELECT dictGetOrNull('ttl_tag_rules', 'ttl_seconds', ('app-name', 'ephemeral-chat'))" | tr -d '[:space:]')
+if [ "$TAG_DICT" = "60" ]; then
+    echo "✓ ttl_tag_rules dict returns 60 for ('app-name','ephemeral-chat')"
+else
+    echo "✗ Expected 60, got '$TAG_DICT'"
+    exit 1
+fi
+
+# Owner dictionary uses raw bytes; verify by decoding the same base64url in SQL.
+OWNER_DICT=$(ch_query "SELECT dictGetOrNull('ttl_owner_rules', 'ttl_seconds', tuple(base64URLDecode('$OWNER_B64URL')))" | tr -d '[:space:]')
+if [ "$OWNER_DICT" = "90" ]; then
+    echo "✓ ttl_owner_rules dict returns 90 for the decoded owner address"
+else
+    echo "✗ Expected 90, got '$OWNER_DICT'"
+    exit 1
+fi
+echo
+
+echo "Test 4: Unknown key returns NULL"
+UNKNOWN=$(ch_query "SELECT dictGetOrNull('ttl_tag_rules', 'ttl_seconds', ('app-name', 'does-not-exist'))")
+if [ -z "$(echo "$UNKNOWN" | tr -d '[:space:]')" ] || [ "$(echo "$UNKNOWN" | tr -d '[:space:]')" = "\\N" ]; then
+    echo "✓ Unknown key returns NULL"
+else
+    echo "✗ Expected NULL, got '$UNKNOWN'"
+    exit 1
+fi
+echo
+
+echo "Test 5: Empty rules file clears the tables"
+cat >"$EMPTY_RULES" <<YAML
+rules: []
+YAML
+python3 ./scripts/clickhouse-load-ttl-rules.py "$EMPTY_RULES"
+
+TOTAL=$(ch_query "SELECT (SELECT count() FROM ttl_tag_rules_src)
+                       + (SELECT count() FROM ttl_tag_prefix_rules)
+                       + (SELECT count() FROM ttl_owner_rules_src)
+                       + (SELECT count() FROM ttl_owner_prefix_rules)" | tr -d '[:space:]')
+if [ "$TOTAL" = "0" ]; then
+    echo "✓ All rule tables are empty after loading an empty rules file"
+else
+    echo "✗ Expected 0 total rows, got $TOTAL"
+    exit 1
+fi
+echo
+
+echo "All TTL rule tests passed."

--- a/scripts/tests/parquet/test-clickhouse-ttl-rules
+++ b/scripts/tests/parquet/test-clickhouse-ttl-rules
@@ -57,6 +57,7 @@ OWNER_B64URL="abcDEF0123456789_-xyzABCDEF0123456789_-xyzAB"
 OWNER_PREFIX="abcDEF"
 
 cat >"$TMP_RULES" <<YAML
+default_ttl_seconds: 3600
 rules:
   - tag_name: App-Name
     tag_value: ephemeral-chat
@@ -72,6 +73,9 @@ rules:
     tag_value: image/gif
     match: prefix
     ttl_seconds: 120
+  - tag_name: App-Name
+    tag_value: persistent
+    never_expire: true
   - field: owner_address
     value: $OWNER_B64URL
     ttl_seconds: 90
@@ -89,12 +93,12 @@ PREFIX_TAGS=$(ch_query "SELECT count() FROM ttl_tag_prefix_rules" | tr -d '[:spa
 EXACT_OWNERS=$(ch_query "SELECT count() FROM ttl_owner_rules_src" | tr -d '[:space:]')
 PREFIX_OWNERS=$(ch_query "SELECT count() FROM ttl_owner_prefix_rules" | tr -d '[:space:]')
 
-echo "  ttl_tag_rules_src:       $EXACT_TAGS (expected 2)"
+echo "  ttl_tag_rules_src:       $EXACT_TAGS (expected 3)"
 echo "  ttl_tag_prefix_rules:    $PREFIX_TAGS (expected 2)"
 echo "  ttl_owner_rules_src:     $EXACT_OWNERS (expected 1)"
 echo "  ttl_owner_prefix_rules:  $PREFIX_OWNERS (expected 1)"
 
-if [ "$EXACT_TAGS" = "2" ] && [ "$PREFIX_TAGS" = "2" ] && [ "$EXACT_OWNERS" = "1" ] && [ "$PREFIX_OWNERS" = "1" ]; then
+if [ "$EXACT_TAGS" = "3" ] && [ "$PREFIX_TAGS" = "2" ] && [ "$EXACT_OWNERS" = "1" ] && [ "$PREFIX_OWNERS" = "1" ]; then
     echo "✓ Rule counts match"
 else
     echo "✗ Rule counts mismatch"
@@ -167,7 +171,34 @@ else
 fi
 echo
 
-echo "Test 7: Empty rules file clears the tables"
+echo "Test 7: default_ttl_seconds populates ttl_settings"
+DEFAULT_TTL=$(ch_query "SELECT default_ttl_seconds FROM ttl_settings FINAL LIMIT 1" | tr -d '[:space:]')
+if [ "$DEFAULT_TTL" = "3600" ]; then
+    echo "✓ ttl_settings.default_ttl_seconds = 3600"
+else
+    echo "✗ Expected default_ttl_seconds=3600, got '$DEFAULT_TTL'"
+    exit 1
+fi
+echo
+
+echo "Test 8: never_expire rule stores ttl_seconds=0 with never_expire=1"
+NEVER_ROW=$(ch_query "SELECT count() FROM ttl_tag_rules_src WHERE tag_name = 'app-name' AND tag_value = 'persistent' AND ttl_seconds = 0 AND never_expire = 1" | tr -d '[:space:]')
+if [ "$NEVER_ROW" = "1" ]; then
+    echo "✓ never_expire rule stored with ttl_seconds=0 and never_expire=1"
+else
+    echo "✗ Expected never_expire row for ('app-name','persistent') not found"
+    exit 1
+fi
+NEVER_DICT=$(ch_query "SELECT dictGetOrNull('ttl_tag_rules', 'never_expire', ('app-name', 'persistent'))" | tr -d '[:space:]')
+if [ "$NEVER_DICT" = "1" ]; then
+    echo "✓ ttl_tag_rules dictionary returns never_expire=1"
+else
+    echo "✗ Expected never_expire=1 from dictionary, got '$NEVER_DICT'"
+    exit 1
+fi
+echo
+
+echo "Test 9: Empty rules file clears the tables"
 cat >"$EMPTY_RULES" <<YAML
 rules: []
 YAML

--- a/src/database/clickhouse/schema.sql
+++ b/src/database/clickhouse/schema.sql
@@ -90,6 +90,9 @@ CREATE TABLE IF NOT EXISTS transactions (
   root_parent_offset UInt64,
   tags Array(Tuple(BLOB, BLOB)),
   tags_count UInt32,
+  -- Set by migrate_staging_to_final when an operator TTL rule matches this row.
+  -- NULL means "retain indefinitely".
+  expires_at Nullable(DateTime),
   -- Materialized columns for tag bloom filter indexing. Bloom filter skip
   -- indexes match reliably against column references but not against lambda
   -- expressions like arrayMap(x -> x.1, tags), so we project the names and
@@ -108,4 +111,71 @@ CREATE TABLE IF NOT EXISTS transactions (
 ) Engine = ReplacingMergeTree(inserted_at)
 PARTITION BY intDiv(height, 100000)
 ORDER BY (height, block_transaction_index, is_data_item, id)
+TTL expires_at DELETE WHERE expires_at IS NOT NULL
 SETTINGS deduplicate_merge_projection_mode = 'rebuild';
+
+-- Idempotent upgrade path for nodes that already have a transactions table
+-- from before tag-based TTL rules were introduced. Safe to re-run; a no-op
+-- once applied.
+ALTER TABLE transactions ADD COLUMN IF NOT EXISTS expires_at Nullable(DateTime);
+ALTER TABLE transactions MODIFY TTL expires_at DELETE WHERE expires_at IS NOT NULL;
+
+-- Tag-based TTL rules. Operators populate the `_src` / prefix tables via
+-- scripts/clickhouse-load-ttl-rules.py (run by clickhouse-auto-import once per
+-- import cycle). The dictionaries layered over the exact-match source tables
+-- refresh on their LIFETIME without external orchestration.
+--
+-- Schema contract:
+--   - tag_name is stored lower-cased (normalization happens in the loader);
+--     the migrate query lower-casts the row's tag_name BLOB to String before
+--     dictionary / prefix lookup.
+--   - tag_value is stored trimmed but case-preserving.
+--   - owner_address is stored as the raw bytes decoded from the base64url
+--     form used in the rules file; matches the transactions.owner_address
+--     BLOB byte-for-byte once CAST(... AS String).
+--   - Prefix rules are scanned by startsWith() in correlated subqueries;
+--     exact rules go through dictGetOrNull() for O(1) lookup.
+CREATE TABLE IF NOT EXISTS ttl_tag_rules_src (
+  tag_name String,
+  tag_value String,
+  ttl_seconds UInt32
+) Engine = ReplacingMergeTree()
+ORDER BY (tag_name, tag_value);
+
+CREATE TABLE IF NOT EXISTS ttl_tag_prefix_rules (
+  tag_name String,
+  tag_value String,
+  ttl_seconds UInt32
+) Engine = ReplacingMergeTree()
+ORDER BY (tag_name, tag_value);
+
+CREATE TABLE IF NOT EXISTS ttl_owner_rules_src (
+  owner_address String,
+  ttl_seconds UInt32
+) Engine = ReplacingMergeTree()
+ORDER BY owner_address;
+
+CREATE TABLE IF NOT EXISTS ttl_owner_prefix_rules (
+  owner_address String,
+  ttl_seconds UInt32
+) Engine = ReplacingMergeTree()
+ORDER BY owner_address;
+
+CREATE DICTIONARY IF NOT EXISTS ttl_tag_rules (
+  tag_name String,
+  tag_value String,
+  ttl_seconds UInt32
+)
+PRIMARY KEY tag_name, tag_value
+SOURCE(CLICKHOUSE(TABLE 'ttl_tag_rules_src'))
+LAYOUT(COMPLEX_KEY_HASHED())
+LIFETIME(MIN 60 MAX 300);
+
+CREATE DICTIONARY IF NOT EXISTS ttl_owner_rules (
+  owner_address String,
+  ttl_seconds UInt32
+)
+PRIMARY KEY owner_address
+SOURCE(CLICKHOUSE(TABLE 'ttl_owner_rules_src'))
+LAYOUT(COMPLEX_KEY_HASHED())
+LIFETIME(MIN 60 MAX 300);

--- a/src/database/clickhouse/schema.sql
+++ b/src/database/clickhouse/schema.sql
@@ -139,36 +139,45 @@ ALTER TABLE transactions MODIFY TTL expires_at DELETE WHERE expires_at IS NOT NU
 --   - Prefix rules are scanned by startsWith() over small arrays materialised
 --     from these tables; exact rules go through dictGetOrNull() for O(1)
 --     lookup.
+--   - never_expire = 1 marks an exempt rule; the migrate query treats any
+--     matching exempt rule as an overriding signal to leave expires_at NULL,
+--     beating both TTL matches and the default TTL. ttl_seconds is ignored
+--     (stored as 0) when never_expire = 1.
 CREATE TABLE IF NOT EXISTS ttl_tag_rules_src (
   tag_name String,
   tag_value String,
-  ttl_seconds UInt32
+  ttl_seconds UInt32,
+  never_expire UInt8 DEFAULT 0
 ) Engine = ReplacingMergeTree()
 ORDER BY (tag_name, tag_value);
 
 CREATE TABLE IF NOT EXISTS ttl_tag_prefix_rules (
   tag_name String,
   tag_value String,
-  ttl_seconds UInt32
+  ttl_seconds UInt32,
+  never_expire UInt8 DEFAULT 0
 ) Engine = ReplacingMergeTree()
 ORDER BY (tag_name, tag_value);
 
 CREATE TABLE IF NOT EXISTS ttl_owner_rules_src (
   owner_address String,
-  ttl_seconds UInt32
+  ttl_seconds UInt32,
+  never_expire UInt8 DEFAULT 0
 ) Engine = ReplacingMergeTree()
 ORDER BY owner_address;
 
 CREATE TABLE IF NOT EXISTS ttl_owner_prefix_rules (
   owner_address String,
-  ttl_seconds UInt32
+  ttl_seconds UInt32,
+  never_expire UInt8 DEFAULT 0
 ) Engine = ReplacingMergeTree()
 ORDER BY owner_address;
 
 CREATE DICTIONARY IF NOT EXISTS ttl_tag_rules (
   tag_name String,
   tag_value String,
-  ttl_seconds UInt32
+  ttl_seconds UInt32,
+  never_expire UInt8 DEFAULT 0
 )
 PRIMARY KEY tag_name, tag_value
 SOURCE(CLICKHOUSE(TABLE 'ttl_tag_rules_src'))
@@ -177,9 +186,22 @@ LIFETIME(MIN 60 MAX 300);
 
 CREATE DICTIONARY IF NOT EXISTS ttl_owner_rules (
   owner_address String,
-  ttl_seconds UInt32
+  ttl_seconds UInt32,
+  never_expire UInt8 DEFAULT 0
 )
 PRIMARY KEY owner_address
 SOURCE(CLICKHOUSE(TABLE 'ttl_owner_rules_src'))
 LAYOUT(COMPLEX_KEY_HASHED())
 LIFETIME(MIN 60 MAX 300);
+
+-- Single-row settings table for cross-rule knobs. Populated by the loader
+-- from the YAML (TRUNCATE + INSERT) so there is always at most one row;
+-- `updated_at` + ReplacingMergeTree(updated_at) ensures FINAL yields the
+-- latest write. default_ttl_seconds applies when no rule matches a row and
+-- no exempt rule fires.
+CREATE TABLE IF NOT EXISTS ttl_settings (
+  singleton UInt8 DEFAULT 1,
+  default_ttl_seconds Nullable(UInt32),
+  updated_at DateTime DEFAULT now()
+) Engine = ReplacingMergeTree(updated_at)
+ORDER BY singleton;

--- a/src/database/clickhouse/schema.sql
+++ b/src/database/clickhouse/schema.sql
@@ -122,19 +122,23 @@ ALTER TABLE transactions MODIFY TTL expires_at DELETE WHERE expires_at IS NOT NU
 
 -- Tag-based TTL rules. Operators populate the `_src` / prefix tables via
 -- scripts/clickhouse-load-ttl-rules.py (run by clickhouse-auto-import once per
--- import cycle). The dictionaries layered over the exact-match source tables
--- refresh on their LIFETIME without external orchestration.
+-- import cycle). The loader force-reloads the exact-match dictionaries after
+-- every load so new rules are visible to the next migrate query without
+-- waiting for LIFETIME to expire.
 --
 -- Schema contract:
 --   - tag_name is stored lower-cased (normalization happens in the loader);
 --     the migrate query lower-casts the row's tag_name BLOB to String before
 --     dictionary / prefix lookup.
 --   - tag_value is stored trimmed but case-preserving.
---   - owner_address is stored as the raw bytes decoded from the base64url
---     form used in the rules file; matches the transactions.owner_address
---     BLOB byte-for-byte once CAST(... AS String).
---   - Prefix rules are scanned by startsWith() in correlated subqueries;
---     exact rules go through dictGetOrNull() for O(1) lookup.
+--   - owner_address is stored as the operator-supplied base64url string
+--     verbatim (no decode). The migrate query compares
+--     base64URLEncode(transactions.owner_address) against it so a prefix
+--     like "test-uploader-" matches textually — raw-byte prefixes wouldn't
+--     correspond to any clean base64url cut.
+--   - Prefix rules are scanned by startsWith() over small arrays materialised
+--     from these tables; exact rules go through dictGetOrNull() for O(1)
+--     lookup.
 CREATE TABLE IF NOT EXISTS ttl_tag_rules_src (
   tag_name String,
   tag_value String,


### PR DESCRIPTION
Resolves [PE-9058](https://ardrive.atlassian.net/browse/PE-9058) / closes #673.

## Summary
- Operators can now declare TTL rules (by tag or owner address, exact or prefix) in `config/clickhouse-ttl-rules.yaml` to expire rows in the ClickHouse `transactions` table.
- A new Python loader (`scripts/clickhouse-load-ttl-rules.py`) is invoked at the top of every `clickhouse-auto-import` cycle; it normalizes rules and populates four source tables, and two `COMPLEX_KEY_HASHED` dictionaries refresh on a 60–300 s `LIFETIME`.
- `migrate_staging_to_final` now computes `expires_at = now() + min(ttl_seconds across matching branches)`; unmatched rows get `NULL` and are kept indefinitely. Enforcement is native: `TTL expires_at DELETE WHERE expires_at IS NOT NULL` on `transactions`.
- v1 is forward-only (no retroactive backfill). The loader fails open on a missing/malformed rules file so imports aren't blocked by config errors.

## Key design decisions (resolved during planning)
- **Dictionary w/ CH source** for exact-match lookups (vs. plain table JOIN) — O(1) `dictGetOrNull` + operator-inspectable `_src` tables.
- **Python loader** (vs. bash+yq or Node) — `python3` is already in `Dockerfile.clickhouse-auto-import`; added `python3-yaml` apt package.
- **Per-cycle reload** — the loader runs once per outer auto-import cycle so YAML edits are picked up on the next iteration without a restart.
- **Lowercase `tag_name` on both sides** — tolerates casing variance from uploaders; `tag_value` remains case-sensitive.
- **No Content-Type special case** — operators use `match: prefix` with `image/gif` to catch parameterized forms.
- **Example/real filename split** — committed template is `config/clickhouse-ttl-rules.example.yaml`; operators copy to `clickhouse-ttl-rules.yaml` (gitignored) to activate rules.

## Test plan
- [ ] Build the auto-import image: `docker compose build clickhouse-auto-import`
- [ ] Apply schema DDL on a fresh ClickHouse instance; verify `transactions.expires_at` column and TTL clause exist (`SHOW CREATE TABLE transactions`).
- [ ] Apply schema DDL on an upgraded node with an existing `transactions` table; verify the idempotent `ALTER TABLE` statements add `expires_at` without re-creating.
- [ ] Copy the example rules file and add a few tag + owner rules; run `python3 scripts/clickhouse-load-ttl-rules.py config/clickhouse-ttl-rules.yaml` manually and confirm the four `_src`/prefix tables are populated.
- [ ] `SYSTEM RELOAD DICTIONARY ttl_tag_rules; SELECT dictGetOrNull(...)` — verify lookups return expected TTLs.
- [ ] Run a small partition through `./scripts/clickhouse-import` and confirm `expires_at` is set on rows matching rules and NULL otherwise.
- [ ] Force a merge (`OPTIMIZE TABLE transactions FINAL`) and confirm rows past `expires_at` are deleted.
- [ ] Run `scripts/tests/parquet/test-clickhouse-ttl-rules` end-to-end.
- [ ] Run the existing `scripts/tests/parquet/test-clickhouse-integration` to confirm no regression.
- [ ] `yarn lint:check` (passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PE-9058]: https://ardrive.atlassian.net/browse/PE-9058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ