### PR TITLE
fix(graphql): return NOT_FOUND when data item signature fetch fails

### DIFF
--- a/src/routes/graphql/resolvers.ts
+++ b/src/routes/graphql/resolvers.ts
@@ -175,7 +175,7 @@ export async function resolveTxSignature(tx: GqlTransaction) {
         signatureOffset: parseInt(tx.signatureOffset),
       });
 
-      return signature;
+      return signature ?? NOT_FOUND;
     } else {
       return NOT_FOUND;
     }


### PR DESCRIPTION
## Summary

- The data item branch of `resolveTxSignature` (`src/routes/graphql/resolvers.ts:178`) returned the fetcher result directly. When `SignatureFetcher.getDataItemSignature` returned `undefined` (missing attributes, or an exception caught at `src/data/attribute-fetchers.ts:209-215` while streaming from the parent bundle), `undefined` propagated to the GraphQL executor.
- The schema declares `signature: String!`, so `undefined` triggers a "Cannot return null for non-nullable field" error and nulls the transaction in the response.
- Mirrored the transaction path (line 188) by falling back to the `NOT_FOUND` sentinel (`"<not-found>"`), matching the intended graceful-degradation behavior.

## Test plan

- [ ] Existing `resolveTxSignature` unit test still passes
- [ ] Manual: query a bundled data item whose parent bundle is unavailable and confirm the signature field returns `"<not-found>"` instead of a GraphQL error