### PR TITLE
feat(tools): add ClickHouse GraphQL testing tool

### DIFF
--- a/tools/CLICKHOUSE_TESTING.md
+++ b/tools/CLICKHOUSE_TESTING.md
@@ -1,278 +1,188 @@
 # ClickHouse GraphQL Testing Tool
 
-This tool systematically tests the ClickHouse GraphQL implementation by comparing results against arweave.net, with a focus on Drive-Id tags and owner addresses.
+`./tools/test-clickhouse-graphql` systematically compares the local AR.IO node
+GraphQL endpoint against `arweave.net`, with a focus on Drive-Id tags and owner
+addresses. It also runs database-level integrity checks against the local
+ClickHouse instance.
 
-## Features
+## What it does
 
-- **Transaction Count Discovery**: Queries ClickHouse directly to find high-volume drives and owners
-- **Comprehensive Comparison**: Compares transaction data between local ClickHouse and arweave.net
-- **Duplicate Detection**: Identifies duplicate transactions within and across result sets
-- **Missing Item Detection**: Finds transactions present in one source but not the other
-- **Pagination Testing**: Tests pagination consistency in both HEIGHT_ASC and HEIGHT_DESC directions
-- **Detailed Reporting**: Generates HTML, JSON, and CSV reports with comprehensive metrics
+- **Transaction count discovery**: queries ClickHouse directly to find high-volume
+  drives (by `Drive-Id` tag) and owners by transaction count.
+- **Cross-endpoint comparison**: issues the same GraphQL query against the local
+  endpoint and `arweave.net`, then diffs the result sets.
+- **Duplicate / missing / discrepancy detection**: identifies transactions that
+  appear more than once, transactions present in only one source, and field-level
+  mismatches.
+- **Pagination consistency**: walks pages in both `HEIGHT_ASC` and `HEIGHT_DESC`
+  and checks ordering and cross-page duplicates.
+- **Database integrity**: samples ClickHouse rows and verifies they round-trip
+  through both GraphQL endpoints (and vice versa).
+- **Reporting**: writes HTML, JSON, and CSV reports under
+  `test-results/runs/<timestamp>/` with a `latest` symlink.
 
 ## Prerequisites
 
-- Node.js with TypeScript support
-- ClickHouse instance running and accessible
-- Local AR.IO node with GraphQL endpoint
-- Internet access to query arweave.net
-
-## Installation
-
-The tool is included with the AR.IO node codebase. Ensure dependencies are installed:
-
-```bash
-yarn install
-```
-
-## Quick Start
-
-### Auto-Discovery Mode
-
-Discover and test the top entities by transaction count:
-
-```bash
-# Test top 10 drives and owners
-./tools/test-clickhouse-graphql --auto-discover --top 10
-
-# Test only drives
-./tools/test-clickhouse-graphql --discover-drives --top 5
-
-# Test only owners
-./tools/test-clickhouse-graphql --discover-owners --top 5
-```
-
-### Manual Testing
-
-Test specific entities:
-
-```bash
-# Test specific drive
-./tools/test-clickhouse-graphql --drive-id "your-drive-id-here"
-
-# Test specific owner
-./tools/test-clickhouse-graphql --owner "owner-address-here"
-
-# Test multiple entities
-./tools/test-clickhouse-graphql --drive-id "drive1" --drive-id "drive2" --owner "owner1"
-```
-
-### Custom Configuration
-
-Use a configuration file for repeated testing:
-
-```bash
-# Copy and modify the example config
-cp tools/example-test-config.json my-test-config.json
-
-# Run with custom config
-./tools/test-clickhouse-graphql --config my-test-config.json --auto-discover
-```
+- Local ar-io-node service running (GraphQL on `http://localhost:${CORE_PORT}/graphql`).
+- ClickHouse reachable (defaults read from `.env`).
+- Internet access for `arweave.net`.
 
 ## Configuration
 
-Configuration can be provided via command line arguments or a JSON file:
+The bash wrapper loads `.env` via `node --env-file`, so variables defined there
+are picked up automatically. Canonical names (matching `docker-compose.yaml` and
+the rest of the project):
 
-### JSON Configuration File
+| Variable | Default | Purpose |
+|---|---|---|
+| `CORE_PORT` | `4000` | Local ar-io-node port. Used to build `http://localhost:${CORE_PORT}/graphql`. |
+| `CLICKHOUSE_HOST` | `localhost` | ClickHouse host. |
+| `CLICKHOUSE_PORT_2` | `8123` | ClickHouse HTTP port. |
+| `CLICKHOUSE_USER` | `default` | ClickHouse user. |
+| `CLICKHOUSE_PASSWORD` | _(empty)_ | ClickHouse password. |
+
+CLI flags override env values. See `--help` for the full list.
+
+### Config file
+
+You can instead pass a JSON config with `--config`. See
+`tools/example-test-config.json` for the shape. All top-level keys are optional —
+anything you omit falls back to the env/CLI defaults:
 
 ```json
 {
-  "clickhouse": {
-    "url": "http://localhost:8123",
-    "user": "default",
-    "password": ""
-  },
+  "clickhouse": { "url": "http://localhost:8123", "user": "default", "password": "" },
   "endpoints": {
     "local": "http://localhost:4000/graphql",
     "remote": "https://arweave.net/graphql"
   },
-  "discovery": {
-    "topDrives": 20,
-    "topOwners": 20,
-    "minTransactionCount": 100
-  },
+  "discovery": { "topDrives": 10, "topOwners": 10, "minTransactionCount": 100 },
   "testing": {
     "pageSize": 100,
-    "maxPagesPerTest": 10,
-    "testBothDirections": true
+    "maxPagesPerTest": 100,
+    "testBothDirections": true,
+    "maxTransactionsPerEntity": 10000,
+    "allowPartialComparisons": false
+  },
+  "databaseIntegrity": {
+    "enabled": true,
+    "enableDuplicateCheck": true,
+    "enableMissingCheck": true,
+    "sampleSize": 1000,
+    "checkRemoteGraphql": true
   }
 }
 ```
 
-### Command Line Options
+## Usage
 
 ```bash
---config <file>              Use configuration file
---drive-id <id>              Test specific drive ID
---owner <address>            Test specific owner address
---auto-discover              Auto-discover entities by transaction count
---discover-drives            Discover and test drives
---discover-owners            Discover and test owners
---top <n>                    Number of top entities to test
---sample-size <n>            Alias for --top
---clickhouse-url <url>       ClickHouse URL (default: http://localhost:8123)
---clickhouse-user <user>     ClickHouse user (default: default)
---clickhouse-password <pwd>  ClickHouse password
---local-endpoint <url>       Local GraphQL endpoint (default: http://localhost:4000/graphql)
---remote-endpoint <url>      Remote GraphQL endpoint (default: https://arweave.net/graphql)
---export-csv <file>          Export results to CSV file
---help                       Show help message
+# Auto-discover and test top 10 drives + owners
+./tools/test-clickhouse-graphql --auto-discover --top 10
+
+# Target a specific drive
+./tools/test-clickhouse-graphql --drive-id <drive-id>
+
+# Target a specific owner
+./tools/test-clickhouse-graphql --owner <owner-address>
+
+# Multiple entities in one run
+./tools/test-clickhouse-graphql --drive-id drive1 --drive-id drive2 --owner owner1
+
+# Config-driven
+./tools/test-clickhouse-graphql --config tools/example-test-config.json --auto-discover
+
+# Allow partial comparisons for entities with many transactions
+./tools/test-clickhouse-graphql --auto-discover --allow-partial
+
+# Tighter maxTransactionsPerEntity for faster iteration
+./tools/test-clickhouse-graphql --auto-discover --max-transactions 5000
+
+# Verbose — logs every GraphQL query
+./tools/test-clickhouse-graphql --drive-id <drive-id> --verbose
 ```
 
-## Output Structure
+Run `./tools/test-clickhouse-graphql --help` for the full flag list.
 
-Results are saved in `test-results/runs/` with a timestamp-based directory structure:
+## Output
 
 ```
 test-results/
 ├── runs/
-│   └── 2025-01-22-10-30-45/          # Timestamp-based run directory
-│       ├── config.json                # Test configuration snapshot
+│   └── 2026-04-23-10-30-45/
+│       ├── config.json            # Snapshot of the config used
 │       ├── discovery/
-│       │   ├── drive-counts.json      # Drive-ID transaction counts
-│       │   ├── owner-counts.json      # Owner transaction counts
-│       │   └── summary.json           # Discovery phase summary
+│       │   ├── drive-counts.json
+│       │   ├── owner-counts.json
+│       │   └── summary.json
 │       ├── tests/
-│       │   ├── drives/
-│       │   │   ├── drive_<id>_test.json
-│       │   │   └── drive_<id>_details.jsonl
-│       │   └── owners/
-│       │       ├── owner_<addr>_test.json
-│       │       └── owner_<addr>_details.jsonl
+│       │   ├── drives/drive_<id>_test.json
+│       │   └── owners/owner_<addr>_test.json
 │       ├── comparisons/
-│       │   ├── duplicates.json        # All duplicates found
-│       │   ├── missing.json           # Missing transactions
-│       │   └── discrepancies.json     # Data mismatches
-│       ├── report.html                # Human-readable HTML report
-│       ├── report.json                # Machine-readable summary
-│       └── metrics.json               # Performance metrics
-└── latest -> runs/2025-01-22-10-30-45 # Symlink to latest run
+│       │   ├── duplicates.json
+│       │   ├── missing.json
+│       │   └── discrepancies.json
+│       ├── report.html            # Interactive summary
+│       ├── report.json            # Machine-readable summary
+│       └── metrics.json
+└── latest -> runs/2026-04-23-10-30-45
 ```
 
-## Report Analysis
+Open `test-results/latest/report.html` in a browser for the interactive view.
 
-### HTML Report
+## Interpreting results
 
-Open `test-results/latest/report.html` in a browser for an interactive view of:
-- Test summary and statistics
-- Performance metrics comparison
-- Detailed issue breakdown
-- Entity-by-entity results
+- **Duplicates**: same transaction ID appears more than once in a result set.
+- **Missing**: transaction exists in one source but not the other.
+- **Discrepancies**: same transaction has different field values between sources.
 
-### JSON Report
+Severity:
 
-Machine-readable summary in `test-results/latest/report.json` containing:
-- Complete test results
-- Issue categorization
-- Performance metrics
-- Entity metadata
+- **Critical**: core transaction data differs (id, owner, amount, etc.).
+- **Minor**: non-essential differences.
+- **Informational**: expected differences (e.g. owner keys, which the gateway
+  may omit for data items).
 
-### CSV Export
+Pagination issues:
 
-Export results to CSV for spreadsheet analysis:
-
-```bash
-./tools/test-clickhouse-graphql --export-csv results.csv
-```
-
-## Understanding Results
-
-### Issue Types
-
-- **Duplicates**: Same transaction ID appears multiple times
-- **Missing**: Transaction exists in one source but not the other
-- **Discrepancies**: Same transaction has different field values
-
-### Severity Levels
-
-- **Critical**: Core transaction data differs (ID, owner, amount, etc.)
-- **Minor**: Non-essential differences (timestamps, formatting)
-- **Informational**: Expected differences (owner keys, metadata)
-
-### Pagination Issues
-
-- **Inconsistent Ordering**: Results not properly sorted by height
-- **Missing Transactions**: Gaps in pagination sequences
-- **Duplicate Across Pages**: Same transaction appears on multiple pages
+- **Order violations**: results not sorted consistently by height.
+- **Cross-page duplicates**: same transaction on multiple pages.
 
 ## Troubleshooting
 
-### Connection Issues
-
-1. **ClickHouse Connection Failed**
-   - Verify ClickHouse is running: `curl http://localhost:8123/ping`
-   - Check credentials and URL in configuration
-
-2. **Local GraphQL Endpoint Failed**
-   - Verify AR.IO node is running with GraphQL enabled
-   - Check endpoint URL (typically `http://localhost:4000/graphql`)
-
-3. **Remote GraphQL Endpoint Failed**
-   - Check internet connectivity
-   - Verify arweave.net is accessible
-
-### Performance Issues
-
-1. **Slow Queries**
-   - Reduce `pageSize` in configuration
-   - Lower `maxPagesPerTest` to limit scope
-   - Test fewer entities at once
-
-2. **Timeout Errors**
-   - Increase query timeout in GraphQL client
-   - Check network latency to remote endpoint
-
-### Data Issues
-
-1. **No Drive-Ids Found**
-   - Verify ClickHouse has ArDrive data
-   - Check if Drive-Id tags are properly indexed
-   - Try lowering `minTransactionCount`
-
-2. **No Owners Found**
-   - Verify owner_transactions table is populated
-   - Check ClickHouse indexing status
-
-## Advanced Usage
-
-### Testing Specific Height Ranges
+### Can't reach ClickHouse
 
 ```bash
-# Test entities with transactions in specific height range
-./tools/test-clickhouse-graphql --auto-discover --min-height 1000000 --max-height 1100000
+curl http://localhost:8123/ping   # should return "Ok."
 ```
 
-### Custom Comparison Settings
+Check `CLICKHOUSE_HOST` / `CLICKHOUSE_PORT_2` in `.env`. The ClickHouse container
+binds `${CLICKHOUSE_PORT_2:-8123}` on the host.
 
-Create a configuration file with custom comparison rules:
-
-```json
-{
-  "comparison": {
-    "strictComparison": true,
-    "checkOwnerKeys": true,
-    "tolerateTimestampDifference": 0,
-    "ignoreFields": []
-  }
-}
-```
-
-### Continuous Monitoring
-
-Set up scheduled testing to monitor data consistency:
+### Can't reach local GraphQL
 
 ```bash
-# Run hourly with cron
-0 * * * * /path/to/ar-io-node/tools/test-clickhouse-graphql --auto-discover --top 5
+curl -X POST http://localhost:4000/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ transactions(first:1){ edges { node { id } } } }"}'
 ```
 
-## Contributing
+Check `CORE_PORT`, and that the service is running.
 
-When modifying the testing tool:
+### No Drive-Ids discovered
 
-1. Update type definitions in the main script
-2. Add comprehensive error handling
-3. Include progress logging for long operations
-4. Update documentation for new features
-5. Test with various ClickHouse and GraphQL configurations
+- The ClickHouse `transactions` table may not be populated yet (data items are
+  unbundled asynchronously).
+- Lower `minTransactionCount` in `discovery` if you want to see smaller drives.
+
+### Slow queries or timeouts
+
+- Lower `pageSize` and/or `maxPagesPerTest` in config.
+- Reduce `--top` or test fewer entities at once.
+- Set `--max-transactions` to cap per-entity transaction fetching.
+
+## Schema note
+
+The tool reads directly from the ClickHouse `transactions` table. There is no
+separate `owner_transactions` table in the current schema — owner aggregation
+is done with `GROUP BY owner_address FROM transactions`.

--- a/tools/CLICKHOUSE_TESTING.md
+++ b/tools/CLICKHOUSE_TESTING.md
@@ -18,7 +18,7 @@ ClickHouse instance.
   and checks ordering and cross-page duplicates.
 - **Database integrity**: samples ClickHouse rows and verifies they round-trip
   through both GraphQL endpoints (and vice versa).
-- **Reporting**: writes HTML, JSON, and CSV reports under
+- **Reporting**: writes HTML and JSON reports under
   `test-results/runs/<timestamp>/` with a `latest` symlink.
 
 ## Prerequisites
@@ -185,4 +185,4 @@ Check `CORE_PORT`, and that the service is running.
 
 The tool reads directly from the ClickHouse `transactions` table. There is no
 separate `owner_transactions` table in the current schema — owner aggregation
-is done with `GROUP BY owner_address FROM transactions`.
+is done with `FROM transactions GROUP BY owner_address`.

--- a/tools/README.md
+++ b/tools/README.md
@@ -223,7 +223,7 @@ Run `./tools/queue-missing-bundles --help` for the full flag list.
 Compares the local AR.IO node GraphQL endpoint against `arweave.net` for
 Drive-Id and owner-address queries, runs pagination consistency checks in both
 directions, and performs database-level integrity checks against the local
-ClickHouse instance. Generates HTML, JSON, and CSV reports under
+ClickHouse instance. Generates HTML and JSON reports under
 `test-results/runs/<timestamp>/`. Defaults for the core port and ClickHouse
 credentials are read from `.env`. See
 [CLICKHOUSE_TESTING.md](./CLICKHOUSE_TESTING.md) for the full guide.

--- a/tools/README.md
+++ b/tools/README.md
@@ -219,6 +219,31 @@ cat data-items.csv | ./tools/queue-missing-bundles --input - \
 
 Run `./tools/queue-missing-bundles --help` for the full flag list.
 
+### `test-clickhouse-graphql`
+Compares the local AR.IO node GraphQL endpoint against `arweave.net` for
+Drive-Id and owner-address queries, runs pagination consistency checks in both
+directions, and performs database-level integrity checks against the local
+ClickHouse instance. Generates HTML, JSON, and CSV reports under
+`test-results/runs/<timestamp>/`. Defaults for the core port and ClickHouse
+credentials are read from `.env`. See
+[CLICKHOUSE_TESTING.md](./CLICKHOUSE_TESTING.md) for the full guide.
+
+**Usage:**
+```bash
+# Auto-discover top 10 drives and owners by transaction count and diff them
+./tools/test-clickhouse-graphql --auto-discover --top 10
+
+# Target a specific drive or owner
+./tools/test-clickhouse-graphql --drive-id <drive-id>
+./tools/test-clickhouse-graphql --owner <owner-address>
+
+# Config-driven run
+./tools/test-clickhouse-graphql --config tools/example-test-config.json --auto-discover
+```
+
+Run `./tools/test-clickhouse-graphql --help` for the full flag list. Open
+`test-results/latest/report.html` after a run for the interactive summary.
+
 ## Release tools
 
 Small, composable primitives used by the release workflow. Each tool does one

--- a/tools/example-test-config.json
+++ b/tools/example-test-config.json
@@ -1,0 +1,30 @@
+{
+  "clickhouse": {
+    "url": "http://localhost:8123",
+    "user": "default",
+    "password": ""
+  },
+  "endpoints": {
+    "local": "http://localhost:4000/graphql",
+    "remote": "https://arweave.net/graphql"
+  },
+  "discovery": {
+    "topDrives": 10,
+    "topOwners": 10,
+    "minTransactionCount": 100
+  },
+  "testing": {
+    "pageSize": 100,
+    "maxPagesPerTest": 100,
+    "testBothDirections": true,
+    "maxTransactionsPerEntity": 10000,
+    "allowPartialComparisons": false
+  },
+  "databaseIntegrity": {
+    "enabled": true,
+    "enableDuplicateCheck": true,
+    "enableMissingCheck": true,
+    "sampleSize": 1000,
+    "checkRemoteGraphql": true
+  }
+}

--- a/tools/lib/clickhouse-client.ts
+++ b/tools/lib/clickhouse-client.ts
@@ -6,6 +6,15 @@
  */
 import { ClickHouseClient, createClient } from '@clickhouse/client';
 
+import { hexToB64Url } from '../../src/lib/encoding.js';
+
+// Owner addresses are stored in ClickHouse as BLOBs (raw 32-byte SHA-256
+// hashes) and surfaced via `hex(owner_address)` as 64-char uppercase hex.
+// GraphQL represents the same address as 43-char base64url. Convert at method
+// boundaries so callers always see base64url.
+const b64UrlOwnerToUpperHex = (ownerAddress: string): string =>
+  Buffer.from(ownerAddress, 'base64url').toString('hex').toUpperCase();
+
 // Shape of the JSON response from ClickHouse for SELECT queries. Row fields are
 // query-dependent; call sites read them loosely rather than typing each query.
 interface ClickHouseJsonResult<TRow = any> {
@@ -106,7 +115,7 @@ export class ClickHouseAnalysisClient {
       const data = (await result.json()) as ClickHouseJsonResult;
 
       return data.data.map((row: any) => ({
-        ownerAddress: row.owner_address_hex,
+        ownerAddress: hexToB64Url(row.owner_address_hex),
         transactionCount: parseInt(row.transaction_count, 10),
       }));
     } catch (error) {
@@ -142,13 +151,14 @@ export class ClickHouseAnalysisClient {
   }
 
   /**
-   * Get transaction count for a specific owner address
+   * Get transaction count for a specific owner address (base64url).
    */
   async getOwnerTransactionCount(ownerAddress: string): Promise<number> {
+    const ownerHex = b64UrlOwnerToUpperHex(ownerAddress);
     const query = `
       SELECT COUNT(*) as transaction_count
       FROM transactions
-      WHERE hex(owner_address) = '${ownerAddress.replace(/^0x/, '').toUpperCase()}'
+      WHERE hex(owner_address) = '${ownerHex}'
     `;
 
     try {
@@ -158,51 +168,6 @@ export class ClickHouseAnalysisClient {
     } catch (error) {
       console.error(`Error getting transaction count for owner ${ownerAddress}:`, error);
       return 0;
-    }
-  }
-
-  /**
-   * Get all unique Drive-Ids in the database
-   */
-  async getAllDriveIds(): Promise<string[]> {
-    const driveIdTagHex = Buffer.from('Drive-Id').toString('hex');
-
-    const query = `
-      SELECT DISTINCT hex(arrayFirst(x -> x.1 = unhex('${driveIdTagHex}'), tags).2) as drive_id_hex
-      FROM transactions
-      WHERE has(tags, tuple(unhex('${driveIdTagHex}'), anyHeavy(arrayMap(x -> x.2, arrayFilter(y -> y.1 = unhex('${driveIdTagHex}'), tags)))))
-        AND drive_id_hex != ''
-      ORDER BY drive_id_hex
-    `;
-
-    try {
-      const result = await this.client.query({ query });
-      const data = (await result.json()) as ClickHouseJsonResult;
-      return data.data.map((row: any) => this.hexToString(row.drive_id_hex));
-    } catch (error) {
-      console.error('Error getting all Drive-Ids:', error);
-      return [];
-    }
-  }
-
-  /**
-   * Get all unique owner addresses in the database
-   */
-  async getAllOwners(): Promise<string[]> {
-    const query = `
-      SELECT DISTINCT hex(owner_address) as owner_address_hex
-      FROM transactions
-      WHERE length(owner_address) > 0
-      ORDER BY owner_address_hex
-    `;
-
-    try {
-      const result = await this.client.query({ query });
-      const data = (await result.json()) as ClickHouseJsonResult;
-      return data.data.map((row: any) => row.owner_address_hex);
-    } catch (error) {
-      console.error('Error getting all owners:', error);
-      return [];
     }
   }
 
@@ -255,8 +220,6 @@ export class ClickHouseAnalysisClient {
     totalTransactions: number;
     totalDrives: number;
     totalOwners: number;
-    avgTransactionsPerDrive: number;
-    avgTransactionsPerOwner: number;
     heightRange: { minHeight: number; maxHeight: number };
   }> {
     try {
@@ -301,8 +264,6 @@ export class ClickHouseAnalysisClient {
         totalTransactions,
         totalDrives,
         totalOwners,
-        avgTransactionsPerDrive: totalDrives > 0 ? totalTransactions / totalDrives : 0,
-        avgTransactionsPerOwner: totalOwners > 0 ? totalTransactions / totalOwners : 0,
         heightRange,
       };
     } catch (error) {
@@ -311,8 +272,6 @@ export class ClickHouseAnalysisClient {
         totalTransactions: 0,
         totalDrives: 0,
         totalOwners: 0,
-        avgTransactionsPerDrive: 0,
-        avgTransactionsPerOwner: 0,
         heightRange: { minHeight: 0, maxHeight: 0 },
       };
     }
@@ -362,13 +321,14 @@ export class ClickHouseAnalysisClient {
   }
 
   /**
-   * Get transaction IDs for a specific owner address
+   * Get transaction IDs for a specific owner address (base64url).
    */
   async getOwnerTransactionIds(ownerAddress: string): Promise<string[]> {
+    const ownerHex = b64UrlOwnerToUpperHex(ownerAddress);
     const query = `
       SELECT DISTINCT hex(id) as transaction_id
       FROM transactions
-      WHERE hex(owner_address) = '${ownerAddress.replace(/^0x/, '').toUpperCase()}'
+      WHERE hex(owner_address) = '${ownerHex}'
       ORDER BY transaction_id
     `;
 

--- a/tools/lib/clickhouse-client.ts
+++ b/tools/lib/clickhouse-client.ts
@@ -78,40 +78,7 @@ export class ClickHouseAnalysisClient {
       }));
     } catch (error) {
       console.error('Error querying Drive-Id counts:', error);
-      // Fallback: try a simpler query approach
-      return this.getDriveTransactionCountsFallback(minTransactionCount);
-    }
-  }
-
-  /**
-   * Fallback method for Drive-Id counts using a different approach
-   */
-  private async getDriveTransactionCountsFallback(minTransactionCount: number): Promise<DriveCount[]> {
-    // Simple fallback: just search for any transactions with Drive-Id in tag names
-    const driveIdTagHex = Buffer.from('Drive-Id').toString('hex');
-
-    const query = `
-      SELECT
-        'unknown' as drive_id_hex,
-        COUNT(*) as transaction_count
-      FROM transactions
-      WHERE arrayExists(x -> hex(x.1) = '${driveIdTagHex.toUpperCase()}', tags)
-      HAVING transaction_count >= ${minTransactionCount}
-    `;
-
-    console.log('🔄 Using fallback query for Drive-Id counts...');
-
-    try {
-      const result = await this.client.query({ query });
-      const data = (await result.json()) as ClickHouseJsonResult;
-
-      return data.data.map((row: any) => ({
-        driveId: 'unknown-drive-id',
-        transactionCount: parseInt(row.transaction_count, 10),
-      }));
-    } catch (error) {
-      console.warn('Fallback query also failed, returning empty Drive-Id results:', error);
-      return [];
+      throw error;
     }
   }
 
@@ -246,7 +213,9 @@ export class ClickHouseAnalysisClient {
     try {
       const result = await this.client.query({ query: 'SELECT 1 as test' });
       const data = (await result.json()) as ClickHouseJsonResult;
-      return data.data[0]?.test === 1;
+      // ClickHouse's JSON format stringifies numeric columns by default, so
+      // compare after coercion rather than with a strict `=== 1`.
+      return Number(data.data[0]?.test) === 1;
     } catch (error) {
       console.error('ClickHouse connection test failed:', error);
       return false;
@@ -455,59 +424,6 @@ export class ClickHouseAnalysisClient {
     }
   }
 
-  /**
-   * Verify if specific transaction IDs exist in ClickHouse
-   */
-  async verifyTransactionsExist(transactionIds: string[]): Promise<{
-    existing: string[];
-    missing: string[];
-  }> {
-    if (transactionIds.length === 0) {
-      return { existing: [], missing: [] };
-    }
-
-    try {
-      const hexIds = transactionIds.map(id => `'${id.replace(/^0x/, '').toUpperCase()}'`).join(', ');
-
-      const query = `
-        SELECT DISTINCT hex(id) as transaction_id
-        FROM transactions
-        WHERE hex(id) IN (${hexIds})
-      `;
-
-      const result = await this.client.query({ query });
-      const data = (await result.json()) as ClickHouseJsonResult;
-      const existing = data.data.map((row: any) => row.transaction_id);
-      const existingSet = new Set(existing);
-      const missing = transactionIds.filter(id => !existingSet.has(id.replace(/^0x/, '').toUpperCase()));
-
-      return { existing, missing };
-    } catch (error) {
-      console.error('Error verifying transaction existence:', error);
-      return { existing: [], missing: transactionIds };
-    }
-  }
-
-  /**
-   * Get sample transaction IDs for testing (random sample from database)
-   */
-  async getSampleTransactionIds(limit: number = 100): Promise<string[]> {
-    const query = `
-      SELECT hex(id) as transaction_id
-      FROM transactions
-      ORDER BY rand()
-      LIMIT ${limit}
-    `;
-
-    try {
-      const result = await this.client.query({ query });
-      const data = (await result.json()) as ClickHouseJsonResult;
-      return data.data.map((row: any) => row.transaction_id);
-    } catch (error) {
-      console.error('Error getting sample transaction IDs:', error);
-      return [];
-    }
-  }
 
   /**
    * Close the ClickHouse client connection

--- a/tools/lib/clickhouse-client.ts
+++ b/tools/lib/clickhouse-client.ts
@@ -1,0 +1,520 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { ClickHouseClient, createClient } from '@clickhouse/client';
+
+// Shape of the JSON response from ClickHouse for SELECT queries. Row fields are
+// query-dependent; call sites read them loosely rather than typing each query.
+interface ClickHouseJsonResult<TRow = any> {
+  data: TRow[];
+}
+
+interface DriveCount {
+  driveId: string;
+  transactionCount: number;
+}
+
+interface OwnerCount {
+  ownerAddress: string;
+  transactionCount: number;
+}
+
+interface ClickHouseConfig {
+  url: string;
+  user?: string;
+  password?: string;
+}
+
+export class ClickHouseAnalysisClient {
+  private client: ClickHouseClient;
+
+  constructor(config: ClickHouseConfig) {
+    this.client = createClient({
+      url: config.url,
+      username: config.user || 'default',
+      password: config.password || '',
+    });
+  }
+
+  /**
+   * Get transaction counts by Drive-Id tag
+   */
+  async getDriveTransactionCounts(minTransactionCount: number = 1): Promise<DriveCount[]> {
+    // Drive-Id tag is typically hex-encoded in ClickHouse
+    const driveIdTagHex = Buffer.from('Drive-Id').toString('hex');
+
+    // Use a more robust query that handles the array types correctly
+    const query = `
+      SELECT
+        hex(tag_value) as drive_id_hex,
+        COUNT(*) as transaction_count
+      FROM (
+        SELECT
+          arrayJoin(tags) as tag_pair,
+          tag_pair.1 as tag_name,
+          tag_pair.2 as tag_value
+        FROM transactions
+        WHERE length(tags) > 0
+      )
+      WHERE hex(tag_name) = '${driveIdTagHex.toUpperCase()}'
+        AND tag_value != ''
+      GROUP BY tag_value
+      HAVING transaction_count >= ${minTransactionCount}
+      ORDER BY transaction_count DESC
+    `;
+
+    console.log('🔍 Querying ClickHouse for Drive-Id transaction counts...');
+
+    try {
+      const result = await this.client.query({ query });
+      const data = (await result.json()) as ClickHouseJsonResult;
+
+      return data.data.map((row: any) => ({
+        driveId: this.hexToString(row.drive_id_hex),
+        transactionCount: parseInt(row.transaction_count, 10),
+      }));
+    } catch (error) {
+      console.error('Error querying Drive-Id counts:', error);
+      // Fallback: try a simpler query approach
+      return this.getDriveTransactionCountsFallback(minTransactionCount);
+    }
+  }
+
+  /**
+   * Fallback method for Drive-Id counts using a different approach
+   */
+  private async getDriveTransactionCountsFallback(minTransactionCount: number): Promise<DriveCount[]> {
+    // Simple fallback: just search for any transactions with Drive-Id in tag names
+    const driveIdTagHex = Buffer.from('Drive-Id').toString('hex');
+
+    const query = `
+      SELECT
+        'unknown' as drive_id_hex,
+        COUNT(*) as transaction_count
+      FROM transactions
+      WHERE arrayExists(x -> hex(x.1) = '${driveIdTagHex.toUpperCase()}', tags)
+      HAVING transaction_count >= ${minTransactionCount}
+    `;
+
+    console.log('🔄 Using fallback query for Drive-Id counts...');
+
+    try {
+      const result = await this.client.query({ query });
+      const data = (await result.json()) as ClickHouseJsonResult;
+
+      return data.data.map((row: any) => ({
+        driveId: 'unknown-drive-id',
+        transactionCount: parseInt(row.transaction_count, 10),
+      }));
+    } catch (error) {
+      console.warn('Fallback query also failed, returning empty Drive-Id results:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Get transaction counts by owner address
+   */
+  async getOwnerTransactionCounts(minTransactionCount: number = 1): Promise<OwnerCount[]> {
+    // There is no dedicated owner_transactions table in the current
+    // ClickHouse schema — aggregate directly from `transactions`.
+    const query = `
+      SELECT
+        hex(owner_address) as owner_address_hex,
+        COUNT(*) as transaction_count
+      FROM transactions
+      WHERE length(owner_address) > 0
+      GROUP BY owner_address
+      HAVING transaction_count >= ${minTransactionCount}
+      ORDER BY transaction_count DESC
+    `;
+
+    console.log('🔍 Querying ClickHouse for owner transaction counts...');
+
+    try {
+      const result = await this.client.query({ query });
+      const data = (await result.json()) as ClickHouseJsonResult;
+
+      return data.data.map((row: any) => ({
+        ownerAddress: row.owner_address_hex,
+        transactionCount: parseInt(row.transaction_count, 10),
+      }));
+    } catch (error) {
+      console.error('Error querying owner counts:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get transaction count for a specific Drive-Id
+   */
+  async getDriveTransactionCount(driveId: string): Promise<number> {
+    const driveIdHex = Buffer.from(driveId).toString('hex');
+    const driveIdTagHex = Buffer.from('Drive-Id').toString('hex');
+
+    const query = `
+      SELECT COUNT(*) as transaction_count
+      FROM (
+        SELECT *
+        FROM transactions
+        WHERE arrayExists(tag_pair -> (hex(tag_pair.1) = '${driveIdTagHex.toUpperCase()}' AND hex(tag_pair.2) = '${driveIdHex.toUpperCase()}'), tags)
+      )
+    `;
+
+    try {
+      const result = await this.client.query({ query });
+      const data = (await result.json()) as ClickHouseJsonResult;
+      return parseInt(data.data[0]?.transaction_count || '0', 10);
+    } catch (error) {
+      console.error(`Error getting transaction count for drive ${driveId}:`, error);
+      return 0;
+    }
+  }
+
+  /**
+   * Get transaction count for a specific owner address
+   */
+  async getOwnerTransactionCount(ownerAddress: string): Promise<number> {
+    const query = `
+      SELECT COUNT(*) as transaction_count
+      FROM transactions
+      WHERE hex(owner_address) = '${ownerAddress.replace(/^0x/, '').toUpperCase()}'
+    `;
+
+    try {
+      const result = await this.client.query({ query });
+      const data = (await result.json()) as ClickHouseJsonResult;
+      return parseInt(data.data[0]?.transaction_count || '0', 10);
+    } catch (error) {
+      console.error(`Error getting transaction count for owner ${ownerAddress}:`, error);
+      return 0;
+    }
+  }
+
+  /**
+   * Get all unique Drive-Ids in the database
+   */
+  async getAllDriveIds(): Promise<string[]> {
+    const driveIdTagHex = Buffer.from('Drive-Id').toString('hex');
+
+    const query = `
+      SELECT DISTINCT hex(arrayFirst(x -> x.1 = unhex('${driveIdTagHex}'), tags).2) as drive_id_hex
+      FROM transactions
+      WHERE has(tags, tuple(unhex('${driveIdTagHex}'), anyHeavy(arrayMap(x -> x.2, arrayFilter(y -> y.1 = unhex('${driveIdTagHex}'), tags)))))
+        AND drive_id_hex != ''
+      ORDER BY drive_id_hex
+    `;
+
+    try {
+      const result = await this.client.query({ query });
+      const data = (await result.json()) as ClickHouseJsonResult;
+      return data.data.map((row: any) => this.hexToString(row.drive_id_hex));
+    } catch (error) {
+      console.error('Error getting all Drive-Ids:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Get all unique owner addresses in the database
+   */
+  async getAllOwners(): Promise<string[]> {
+    const query = `
+      SELECT DISTINCT hex(owner_address) as owner_address_hex
+      FROM transactions
+      WHERE length(owner_address) > 0
+      ORDER BY owner_address_hex
+    `;
+
+    try {
+      const result = await this.client.query({ query });
+      const data = (await result.json()) as ClickHouseJsonResult;
+      return data.data.map((row: any) => row.owner_address_hex);
+    } catch (error) {
+      console.error('Error getting all owners:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Test ClickHouse connection
+   */
+  async testConnection(): Promise<boolean> {
+    try {
+      const result = await this.client.query({ query: 'SELECT 1 as test' });
+      const data = (await result.json()) as ClickHouseJsonResult;
+      return data.data[0]?.test === 1;
+    } catch (error) {
+      console.error('ClickHouse connection test failed:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Get the height range available in ClickHouse
+   */
+  async getHeightRange(): Promise<{ minHeight: number; maxHeight: number }> {
+    try {
+      const query = `
+        SELECT
+          MIN(height) as min_height,
+          MAX(height) as max_height
+        FROM transactions
+        WHERE height IS NOT NULL AND height > 0
+      `;
+
+      const result = await this.client.query({ query });
+      const data = (await result.json()) as ClickHouseJsonResult;
+
+      const minHeight = parseInt(data.data[0]?.min_height || '0', 10);
+      const maxHeight = parseInt(data.data[0]?.max_height || '0', 10);
+
+      return { minHeight, maxHeight };
+    } catch (error) {
+      console.error('Error getting height range:', error);
+      return { minHeight: 0, maxHeight: 0 };
+    }
+  }
+
+  /**
+   * Get database statistics
+   */
+  async getStats(): Promise<{
+    totalTransactions: number;
+    totalDrives: number;
+    totalOwners: number;
+    avgTransactionsPerDrive: number;
+    avgTransactionsPerOwner: number;
+    heightRange: { minHeight: number; maxHeight: number };
+  }> {
+    try {
+      // Get total transactions
+      const totalResult = await this.client.query({
+        query: 'SELECT COUNT(*) as total FROM transactions'
+      });
+      const totalData = (await totalResult.json()) as ClickHouseJsonResult;
+      const totalTransactions = parseInt(totalData.data[0]?.total || '0', 10);
+
+      // Get drive count (this is an approximation)
+      const driveIdTagHex = Buffer.from('Drive-Id').toString('hex');
+      const driveResult = await this.client.query({
+        query: `
+          SELECT COUNT(DISTINCT tag_value) as drive_count
+          FROM (
+            SELECT
+              arrayJoin(tags) as tag_pair,
+              tag_pair.1 as tag_name,
+              tag_pair.2 as tag_value
+            FROM transactions
+            WHERE length(tags) > 0
+          )
+          WHERE hex(tag_name) = '${driveIdTagHex.toUpperCase()}'
+            AND tag_value != ''
+        `
+      });
+      const driveData = (await driveResult.json()) as ClickHouseJsonResult;
+      const totalDrives = parseInt(driveData.data[0]?.drive_count || '0', 10);
+
+      // Get owner count
+      const ownerResult = await this.client.query({
+        query: 'SELECT COUNT(DISTINCT owner_address) as owner_count FROM transactions WHERE length(owner_address) > 0'
+      });
+      const ownerData = (await ownerResult.json()) as ClickHouseJsonResult;
+      const totalOwners = parseInt(ownerData.data[0]?.owner_count || '0', 10);
+
+      // Get height range
+      const heightRange = await this.getHeightRange();
+
+      return {
+        totalTransactions,
+        totalDrives,
+        totalOwners,
+        avgTransactionsPerDrive: totalDrives > 0 ? totalTransactions / totalDrives : 0,
+        avgTransactionsPerOwner: totalOwners > 0 ? totalTransactions / totalOwners : 0,
+        heightRange,
+      };
+    } catch (error) {
+      console.error('Error getting database stats:', error);
+      return {
+        totalTransactions: 0,
+        totalDrives: 0,
+        totalOwners: 0,
+        avgTransactionsPerDrive: 0,
+        avgTransactionsPerOwner: 0,
+        heightRange: { minHeight: 0, maxHeight: 0 },
+      };
+    }
+  }
+
+  /**
+   * Convert hex string to UTF-8 string, handling potential encoding issues
+   */
+  private hexToString(hex: string): string {
+    try {
+      // Remove any '0x' prefix and ensure even length
+      const cleanHex = hex.replace(/^0x/, '');
+      if (cleanHex.length % 2 !== 0) {
+        return cleanHex; // Return as-is if odd length
+      }
+
+      const bytes = Buffer.from(cleanHex, 'hex');
+      return bytes.toString('utf-8');
+    } catch (error) {
+      // If conversion fails, return the hex string as-is
+      return hex;
+    }
+  }
+
+  /**
+   * Get transaction IDs for a specific Drive-Id
+   */
+  async getDriveTransactionIds(driveId: string): Promise<string[]> {
+    const driveIdHex = Buffer.from(driveId).toString('hex');
+    const driveIdTagHex = Buffer.from('Drive-Id').toString('hex');
+
+    const query = `
+      SELECT DISTINCT hex(id) as transaction_id
+      FROM transactions
+      WHERE arrayExists(tag_pair -> (hex(tag_pair.1) = '${driveIdTagHex.toUpperCase()}' AND hex(tag_pair.2) = '${driveIdHex.toUpperCase()}'), tags)
+      ORDER BY transaction_id
+    `;
+
+    try {
+      const result = await this.client.query({ query });
+      const data = (await result.json()) as ClickHouseJsonResult;
+      return data.data.map((row: any) => row.transaction_id);
+    } catch (error) {
+      console.error(`Error getting transaction IDs for drive ${driveId}:`, error);
+      return [];
+    }
+  }
+
+  /**
+   * Get transaction IDs for a specific owner address
+   */
+  async getOwnerTransactionIds(ownerAddress: string): Promise<string[]> {
+    const query = `
+      SELECT DISTINCT hex(id) as transaction_id
+      FROM transactions
+      WHERE hex(owner_address) = '${ownerAddress.replace(/^0x/, '').toUpperCase()}'
+      ORDER BY transaction_id
+    `;
+
+    try {
+      const result = await this.client.query({ query });
+      const data = (await result.json()) as ClickHouseJsonResult;
+      return data.data.map((row: any) => row.transaction_id);
+    } catch (error) {
+      console.error(`Error getting transaction IDs for owner ${ownerAddress}:`, error);
+      return [];
+    }
+  }
+
+  /**
+   * Check for duplicate transaction IDs in ClickHouse
+   */
+  async checkDuplicateTransactions(transactionIds?: string[]): Promise<Array<{
+    transactionId: string;
+    count: number;
+    tables: string[];
+  }>> {
+    try {
+      let whereClause = '';
+      if (transactionIds && transactionIds.length > 0) {
+        const hexIds = transactionIds.map(id => `'${id.replace(/^0x/, '').toUpperCase()}'`).join(', ');
+        whereClause = `WHERE hex(id) IN (${hexIds})`;
+      }
+
+      // Only the `transactions` table is canonical in the current schema, so
+      // duplicate detection reduces to "is id duplicated within transactions".
+      const transactionsQuery = `
+        SELECT
+          hex(id) as transaction_id,
+          COUNT(*) as count
+        FROM transactions
+        ${whereClause}
+        GROUP BY id
+        HAVING count > 1
+        ORDER BY count DESC
+      `;
+
+      const transactionsResult = await this.client.query({ query: transactionsQuery });
+      const transactionsData = (await transactionsResult.json()) as ClickHouseJsonResult;
+
+      return transactionsData.data.map((row: any) => ({
+        transactionId: row.transaction_id,
+        count: parseInt(row.count, 10),
+        tables: ['transactions'],
+      }));
+    } catch (error) {
+      console.error('Error checking for duplicate transactions:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Verify if specific transaction IDs exist in ClickHouse
+   */
+  async verifyTransactionsExist(transactionIds: string[]): Promise<{
+    existing: string[];
+    missing: string[];
+  }> {
+    if (transactionIds.length === 0) {
+      return { existing: [], missing: [] };
+    }
+
+    try {
+      const hexIds = transactionIds.map(id => `'${id.replace(/^0x/, '').toUpperCase()}'`).join(', ');
+
+      const query = `
+        SELECT DISTINCT hex(id) as transaction_id
+        FROM transactions
+        WHERE hex(id) IN (${hexIds})
+      `;
+
+      const result = await this.client.query({ query });
+      const data = (await result.json()) as ClickHouseJsonResult;
+      const existing = data.data.map((row: any) => row.transaction_id);
+      const existingSet = new Set(existing);
+      const missing = transactionIds.filter(id => !existingSet.has(id.replace(/^0x/, '').toUpperCase()));
+
+      return { existing, missing };
+    } catch (error) {
+      console.error('Error verifying transaction existence:', error);
+      return { existing: [], missing: transactionIds };
+    }
+  }
+
+  /**
+   * Get sample transaction IDs for testing (random sample from database)
+   */
+  async getSampleTransactionIds(limit: number = 100): Promise<string[]> {
+    const query = `
+      SELECT hex(id) as transaction_id
+      FROM transactions
+      ORDER BY rand()
+      LIMIT ${limit}
+    `;
+
+    try {
+      const result = await this.client.query({ query });
+      const data = (await result.json()) as ClickHouseJsonResult;
+      return data.data.map((row: any) => row.transaction_id);
+    } catch (error) {
+      console.error('Error getting sample transaction IDs:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Close the ClickHouse client connection
+   */
+  async close(): Promise<void> {
+    await this.client.close();
+  }
+}
+
+export type { DriveCount, OwnerCount, ClickHouseConfig };

--- a/tools/lib/clickhouse-integrity.ts
+++ b/tools/lib/clickhouse-integrity.ts
@@ -7,6 +7,13 @@
 import type { GraphQLTransaction } from './graphql-client.js';
 import type { ClickHouseAnalysisClient } from './clickhouse-client.js';
 
+// ClickHouse stores transaction ids as raw BLOB and exposes them via `hex(id)`
+// (uppercase, 64 chars). GraphQL uses base64url (43 chars). Normalize to base64url
+// so set comparisons line up — base64url is case-sensitive, so we preserve case.
+function hexToBase64Url(hex: string): string {
+  return Buffer.from(hex, 'hex').toString('base64url');
+}
+
 interface DatabaseIntegrityResult {
   clickhouseDuplicates: Array<{
     transactionId: string;
@@ -168,9 +175,12 @@ export class ClickHouseIntegrityCheck {
   }> {
     console.log(`   🔍 Checking for missing transactions between GraphQL and ClickHouse...`);
 
-    const clickhouseSet = new Set(clickhouseTransactionIds.map(id => id.toLowerCase()));
-    const localSet = new Set(localTransactions.map(tx => tx.id.toLowerCase()));
-    const remoteSet = new Set(remoteTransactions.map(tx => tx.id.toLowerCase()));
+    // Normalize the ClickHouse hex ids to base64url so they compare cleanly
+    // against the GraphQL-side tx.id. Do NOT lowercase — base64url is
+    // case-sensitive and lowercasing would collapse distinct ids.
+    const clickhouseSet = new Set(clickhouseTransactionIds.map(hexToBase64Url));
+    const localSet = new Set(localTransactions.map(tx => tx.id));
+    const remoteSet = new Set(remoteTransactions.map(tx => tx.id));
 
     const graphqlToClickhouseMissing: Array<{
       transactionId: string;
@@ -187,8 +197,8 @@ export class ClickHouseIntegrityCheck {
 
     // Find transactions in GraphQL but missing from ClickHouse
     for (const tx of localTransactions) {
-      if (!clickhouseSet.has(tx.id.toLowerCase())) {
-        const inRemote = remoteSet.has(tx.id.toLowerCase());
+      if (!clickhouseSet.has(tx.id)) {
+        const inRemote = remoteSet.has(tx.id);
         graphqlToClickhouseMissing.push({
           transactionId: tx.id,
           source: inRemote ? 'both' : 'local',
@@ -200,7 +210,7 @@ export class ClickHouseIntegrityCheck {
 
     // Add remote-only transactions missing from ClickHouse
     for (const tx of remoteTransactions) {
-      if (!clickhouseSet.has(tx.id.toLowerCase()) && !localSet.has(tx.id.toLowerCase())) {
+      if (!clickhouseSet.has(tx.id) && !localSet.has(tx.id)) {
         graphqlToClickhouseMissing.push({
           transactionId: tx.id,
           source: 'remote',
@@ -210,27 +220,29 @@ export class ClickHouseIntegrityCheck {
       }
     }
 
-    // Find transactions in ClickHouse but missing from GraphQL (sample to avoid performance issues)
+    // Find transactions in ClickHouse but missing from GraphQL (sample to avoid performance issues).
+    // Compare in base64url space — the ClickHouse ids are hex.
     const sampledClickhouseIds = this.sampleTransactionIds(clickhouseTransactionIds);
-    for (const txId of sampledClickhouseIds) {
-      const inLocal = localSet.has(txId.toLowerCase());
-      const inRemote = remoteSet.has(txId.toLowerCase());
+    for (const hexId of sampledClickhouseIds) {
+      const b64Id = hexToBase64Url(hexId);
+      const inLocal = localSet.has(b64Id);
+      const inRemote = remoteSet.has(b64Id);
 
       if (!inLocal && !inRemote) {
         clickhouseToGraphqlMissing.push({
-          transactionId: txId,
+          transactionId: b64Id,
           target: 'both',
           severity: 'critical',
         });
       } else if (!inLocal) {
         clickhouseToGraphqlMissing.push({
-          transactionId: txId,
+          transactionId: b64Id,
           target: 'local',
           severity: 'warning',
         });
       } else if (!inRemote && this.options.checkRemoteGraphql) {
         clickhouseToGraphqlMissing.push({
-          transactionId: txId,
+          transactionId: b64Id,
           target: 'remote',
           severity: 'warning',
         });

--- a/tools/lib/clickhouse-integrity.ts
+++ b/tools/lib/clickhouse-integrity.ts
@@ -1,0 +1,338 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import type { GraphQLTransaction } from './graphql-client.js';
+import type { ClickHouseAnalysisClient } from './clickhouse-client.js';
+
+interface DatabaseIntegrityResult {
+  clickhouseDuplicates: Array<{
+    transactionId: string;
+    count: number;
+    tables: string[];
+    severity: 'critical' | 'warning';
+  }>;
+  graphqlToClickhouseMissing: Array<{
+    transactionId: string;
+    source: 'local' | 'remote' | 'both';
+    height?: number;
+    severity: 'critical' | 'warning';
+  }>;
+  clickhouseToGraphqlMissing: Array<{
+    transactionId: string;
+    target: 'local' | 'remote' | 'both';
+    severity: 'critical' | 'warning';
+  }>;
+  summary: {
+    totalClickhouseDuplicates: number;
+    totalGraphqlToClickhouseMissing: number;
+    totalClickhouseToGraphqlMissing: number;
+    criticalIssues: number;
+    warningIssues: number;
+  };
+}
+
+interface IntegrityCheckOptions {
+  enableDuplicateCheck?: boolean;
+  enableMissingCheck?: boolean;
+  sampleSize?: number;
+  checkRemoteGraphql?: boolean;
+}
+
+export class ClickHouseIntegrityCheck {
+  private clickhouseClient: ClickHouseAnalysisClient;
+  private options: IntegrityCheckOptions;
+
+  constructor(clickhouseClient: ClickHouseAnalysisClient, options: IntegrityCheckOptions = {}) {
+    this.clickhouseClient = clickhouseClient;
+    this.options = {
+      enableDuplicateCheck: true,
+      enableMissingCheck: true,
+      sampleSize: 1000,
+      checkRemoteGraphql: true,
+      ...options,
+    };
+  }
+
+  /**
+   * Perform comprehensive database integrity check
+   */
+  async checkIntegrity(
+    entity: { type: 'drive' | 'owner'; id: string },
+    localTransactions: GraphQLTransaction[],
+    remoteTransactions: GraphQLTransaction[]
+  ): Promise<DatabaseIntegrityResult> {
+    console.log(`   🔍 Checking ClickHouse database integrity for ${entity.type} ${entity.id}...`);
+
+    const result: DatabaseIntegrityResult = {
+      clickhouseDuplicates: [],
+      graphqlToClickhouseMissing: [],
+      clickhouseToGraphqlMissing: [],
+      summary: {
+        totalClickhouseDuplicates: 0,
+        totalGraphqlToClickhouseMissing: 0,
+        totalClickhouseToGraphqlMissing: 0,
+        criticalIssues: 0,
+        warningIssues: 0,
+      },
+    };
+
+    try {
+      // Get ClickHouse transaction IDs for this entity
+      const clickhouseTransactionIds = await this.getClickhouseTransactionIds(entity);
+      console.log(`   📊 Found ${clickhouseTransactionIds.length} transactions in ClickHouse for ${entity.type} ${entity.id}`);
+
+      // Check for duplicates in ClickHouse
+      if (this.options.enableDuplicateCheck) {
+        result.clickhouseDuplicates = await this.checkClickhouseDuplicates(clickhouseTransactionIds);
+      }
+
+      // Check for missing transactions between GraphQL and ClickHouse
+      if (this.options.enableMissingCheck) {
+        const { graphqlToClickhouseMissing, clickhouseToGraphqlMissing } = await this.checkMissingTransactions(
+          clickhouseTransactionIds,
+          localTransactions,
+          remoteTransactions
+        );
+        result.graphqlToClickhouseMissing = graphqlToClickhouseMissing;
+        result.clickhouseToGraphqlMissing = clickhouseToGraphqlMissing;
+      }
+
+      // Calculate summary
+      this.calculateSummary(result);
+
+      console.log(`   ✅ Database integrity check complete: ${result.summary.criticalIssues} critical, ${result.summary.warningIssues} warnings`);
+
+    } catch (error) {
+      console.error(`   ❌ Database integrity check failed: ${error}`);
+      // Add error to result
+      result.summary.criticalIssues = 1;
+    }
+
+    return result;
+  }
+
+  /**
+   * Get transaction IDs from ClickHouse for the specified entity
+   */
+  private async getClickhouseTransactionIds(entity: { type: 'drive' | 'owner'; id: string }): Promise<string[]> {
+    if (entity.type === 'drive') {
+      return this.clickhouseClient.getDriveTransactionIds(entity.id);
+    } else {
+      return this.clickhouseClient.getOwnerTransactionIds(entity.id);
+    }
+  }
+
+  /**
+   * Check for duplicate transactions in ClickHouse
+   */
+  private async checkClickhouseDuplicates(transactionIds: string[]): Promise<Array<{
+    transactionId: string;
+    count: number;
+    tables: string[];
+    severity: 'critical' | 'warning';
+  }>> {
+    console.log(`   🔍 Checking for duplicates in ClickHouse...`);
+
+    // Sample transaction IDs if too many
+    const sampled = this.sampleTransactionIds(transactionIds);
+    const duplicates = await this.clickhouseClient.checkDuplicateTransactions(sampled);
+
+    return duplicates.map(dup => ({
+      ...dup,
+      severity: (dup.count > 2 || dup.tables.length > 1) ? 'critical' as const : 'warning' as const,
+    }));
+  }
+
+  /**
+   * Check for missing transactions between GraphQL and ClickHouse
+   */
+  private async checkMissingTransactions(
+    clickhouseTransactionIds: string[],
+    localTransactions: GraphQLTransaction[],
+    remoteTransactions: GraphQLTransaction[]
+  ): Promise<{
+    graphqlToClickhouseMissing: Array<{
+      transactionId: string;
+      source: 'local' | 'remote' | 'both';
+      height?: number;
+      severity: 'critical' | 'warning';
+    }>;
+    clickhouseToGraphqlMissing: Array<{
+      transactionId: string;
+      target: 'local' | 'remote' | 'both';
+      severity: 'critical' | 'warning';
+    }>;
+  }> {
+    console.log(`   🔍 Checking for missing transactions between GraphQL and ClickHouse...`);
+
+    const clickhouseSet = new Set(clickhouseTransactionIds.map(id => id.toLowerCase()));
+    const localSet = new Set(localTransactions.map(tx => tx.id.toLowerCase()));
+    const remoteSet = new Set(remoteTransactions.map(tx => tx.id.toLowerCase()));
+
+    const graphqlToClickhouseMissing: Array<{
+      transactionId: string;
+      source: 'local' | 'remote' | 'both';
+      height?: number;
+      severity: 'critical' | 'warning';
+    }> = [];
+
+    const clickhouseToGraphqlMissing: Array<{
+      transactionId: string;
+      target: 'local' | 'remote' | 'both';
+      severity: 'critical' | 'warning';
+    }> = [];
+
+    // Find transactions in GraphQL but missing from ClickHouse
+    for (const tx of localTransactions) {
+      if (!clickhouseSet.has(tx.id.toLowerCase())) {
+        const inRemote = remoteSet.has(tx.id.toLowerCase());
+        graphqlToClickhouseMissing.push({
+          transactionId: tx.id,
+          source: inRemote ? 'both' : 'local',
+          height: tx.block?.height,
+          severity: inRemote ? 'critical' : 'warning', // Critical if both GraphQL endpoints have it
+        });
+      }
+    }
+
+    // Add remote-only transactions missing from ClickHouse
+    for (const tx of remoteTransactions) {
+      if (!clickhouseSet.has(tx.id.toLowerCase()) && !localSet.has(tx.id.toLowerCase())) {
+        graphqlToClickhouseMissing.push({
+          transactionId: tx.id,
+          source: 'remote',
+          height: tx.block?.height,
+          severity: 'warning',
+        });
+      }
+    }
+
+    // Find transactions in ClickHouse but missing from GraphQL (sample to avoid performance issues)
+    const sampledClickhouseIds = this.sampleTransactionIds(clickhouseTransactionIds);
+    for (const txId of sampledClickhouseIds) {
+      const inLocal = localSet.has(txId.toLowerCase());
+      const inRemote = remoteSet.has(txId.toLowerCase());
+
+      if (!inLocal && !inRemote) {
+        clickhouseToGraphqlMissing.push({
+          transactionId: txId,
+          target: 'both',
+          severity: 'critical',
+        });
+      } else if (!inLocal) {
+        clickhouseToGraphqlMissing.push({
+          transactionId: txId,
+          target: 'local',
+          severity: 'warning',
+        });
+      } else if (!inRemote && this.options.checkRemoteGraphql) {
+        clickhouseToGraphqlMissing.push({
+          transactionId: txId,
+          target: 'remote',
+          severity: 'warning',
+        });
+      }
+    }
+
+    return { graphqlToClickhouseMissing, clickhouseToGraphqlMissing };
+  }
+
+  /**
+   * Sample transaction IDs to limit the scope of checks for performance
+   */
+  private sampleTransactionIds(transactionIds: string[]): string[] {
+    if (!this.options.sampleSize || transactionIds.length <= this.options.sampleSize) {
+      return transactionIds;
+    }
+
+    // Simple random sampling
+    const sampled: string[] = [];
+    const step = Math.floor(transactionIds.length / this.options.sampleSize);
+
+    for (let i = 0; i < transactionIds.length; i += step) {
+      sampled.push(transactionIds[i]);
+      if (sampled.length >= this.options.sampleSize) break;
+    }
+
+    return sampled;
+  }
+
+  /**
+   * Calculate summary statistics
+   */
+  private calculateSummary(result: DatabaseIntegrityResult): void {
+    result.summary.totalClickhouseDuplicates = result.clickhouseDuplicates.length;
+    result.summary.totalGraphqlToClickhouseMissing = result.graphqlToClickhouseMissing.length;
+    result.summary.totalClickhouseToGraphqlMissing = result.clickhouseToGraphqlMissing.length;
+
+    result.summary.criticalIssues = [
+      ...result.clickhouseDuplicates,
+      ...result.graphqlToClickhouseMissing,
+      ...result.clickhouseToGraphqlMissing,
+    ].filter(issue => issue.severity === 'critical').length;
+
+    result.summary.warningIssues = [
+      ...result.clickhouseDuplicates,
+      ...result.graphqlToClickhouseMissing,
+      ...result.clickhouseToGraphqlMissing,
+    ].filter(issue => issue.severity === 'warning').length;
+  }
+
+  /**
+   * Generate human-readable report of database integrity issues
+   */
+  generateReport(result: DatabaseIntegrityResult): string {
+    const lines: string[] = [];
+
+    lines.push('=== ClickHouse Database Integrity Report ===');
+    lines.push('');
+
+    // Summary
+    lines.push('Summary:');
+    lines.push(`  ClickHouse Duplicates: ${result.summary.totalClickhouseDuplicates}`);
+    lines.push(`  GraphQL→ClickHouse Missing: ${result.summary.totalGraphqlToClickhouseMissing}`);
+    lines.push(`  ClickHouse→GraphQL Missing: ${result.summary.totalClickhouseToGraphqlMissing}`);
+    lines.push(`  Critical Issues: ${result.summary.criticalIssues}`);
+    lines.push(`  Warning Issues: ${result.summary.warningIssues}`);
+    lines.push('');
+
+    // ClickHouse Duplicates
+    if (result.clickhouseDuplicates.length > 0) {
+      lines.push('ClickHouse Duplicates:');
+      for (const dup of result.clickhouseDuplicates) {
+        lines.push(`  [${dup.severity.toUpperCase()}] ${dup.transactionId}: ${dup.count} copies in [${dup.tables.join(', ')}]`);
+      }
+      lines.push('');
+    }
+
+    // GraphQL→ClickHouse Missing
+    if (result.graphqlToClickhouseMissing.length > 0) {
+      lines.push('Transactions in GraphQL but missing from ClickHouse:');
+      for (const missing of result.graphqlToClickhouseMissing) {
+        const heightStr = missing.height ? ` (height ${missing.height})` : '';
+        lines.push(`  [${missing.severity.toUpperCase()}] ${missing.transactionId}: in ${missing.source} GraphQL${heightStr}`);
+      }
+      lines.push('');
+    }
+
+    // ClickHouse→GraphQL Missing
+    if (result.clickhouseToGraphqlMissing.length > 0) {
+      lines.push('Transactions in ClickHouse but missing from GraphQL:');
+      for (const missing of result.clickhouseToGraphqlMissing) {
+        lines.push(`  [${missing.severity.toUpperCase()}] ${missing.transactionId}: missing from ${missing.target} GraphQL`);
+      }
+      lines.push('');
+    }
+
+    if (result.summary.criticalIssues === 0 && result.summary.warningIssues === 0) {
+      lines.push('✅ No database integrity issues found!');
+    }
+
+    return lines.join('\n');
+  }
+}
+
+export type { DatabaseIntegrityResult, IntegrityCheckOptions };

--- a/tools/lib/comparison-engine.ts
+++ b/tools/lib/comparison-engine.ts
@@ -410,39 +410,62 @@ export class ComparisonEngine {
       severity: 'critical' | 'minor' | 'informational';
     }> = [];
 
-    // Create maps for efficient comparison
-    const localTagMap = new Map(localTags.map(tag => [tag.name, tag.value]));
-    const remoteTagMap = new Map(remoteTags.map(tag => [tag.name, tag.value]));
+    // ANS-104 allows repeated tag names, so we group all values per name and
+    // compare the sorted-values array. A plain Map<name, value> would silently
+    // drop duplicates and make two transactions compare equal when one side
+    // has a repeated tag and the other doesn't.
+    const toTagMap = (tags: Array<{ name: string; value: string }>): Map<string, string[]> => {
+      const tagMap = new Map<string, string[]>();
+      for (const tag of tags) {
+        const values = tagMap.get(tag.name) ?? [];
+        values.push(tag.value);
+        tagMap.set(tag.name, values);
+      }
+      for (const values of tagMap.values()) {
+        values.sort();
+      }
+      return tagMap;
+    };
 
-    // Check for missing tags
-    for (const [name, value] of localTagMap) {
-      if (!remoteTagMap.has(name)) {
+    const sameValues = (a: string[], b: string[]): boolean => {
+      if (a.length !== b.length) return false;
+      for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+      return true;
+    };
+
+    const localTagMap = toTagMap(localTags);
+    const remoteTagMap = toTagMap(remoteTags);
+
+    // Check for missing/differing tags by name
+    for (const [name, values] of localTagMap) {
+      const remoteValues = remoteTagMap.get(name);
+      if (remoteValues === undefined) {
         discrepancies.push({
           transactionId: id,
           field: `tags.${name}`,
-          localValue: value,
+          localValue: values,
           remoteValue: null,
           severity: 'minor',
         });
-      } else if (remoteTagMap.get(name) !== value) {
+      } else if (!sameValues(values, remoteValues)) {
         discrepancies.push({
           transactionId: id,
           field: `tags.${name}`,
-          localValue: value,
-          remoteValue: remoteTagMap.get(name),
+          localValue: values,
+          remoteValue: remoteValues,
           severity: 'minor',
         });
       }
     }
 
-    // Check for extra tags in remote
-    for (const [name, value] of remoteTagMap) {
+    // Extra tag names in remote
+    for (const [name, values] of remoteTagMap) {
       if (!localTagMap.has(name)) {
         discrepancies.push({
           transactionId: id,
           field: `tags.${name}`,
           localValue: null,
-          remoteValue: value,
+          remoteValue: values,
           severity: 'minor',
         });
       }

--- a/tools/lib/comparison-engine.ts
+++ b/tools/lib/comparison-engine.ts
@@ -96,9 +96,11 @@ export class ComparisonEngine {
     // Find duplicates across both sets
     result.duplicates.push(...this.findCrossSourcDuplicates(localMap, remoteMap));
 
-    // Find missing transactions
-    result.missing.push(...this.findMissingTransactions(localMap, remoteMap, 'remote'));
-    result.missing.push(...this.findMissingTransactions(remoteMap, localMap, 'local'));
+    // Find missing transactions. The third argument is where the id IS present
+    // (the source side), not where it's missing — findMissingTransactions
+    // iterates the source map and reports ids absent from target.
+    result.missing.push(...this.findMissingTransactions(localMap, remoteMap, 'local'));
+    result.missing.push(...this.findMissingTransactions(remoteMap, localMap, 'remote'));
 
     // Find discrepancies in matching transactions
     result.discrepancies.push(...this.findDiscrepancies(localMap, remoteMap));

--- a/tools/lib/comparison-engine.ts
+++ b/tools/lib/comparison-engine.ts
@@ -1,0 +1,535 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import type { GraphQLTransaction } from './graphql-client.js';
+
+interface ComparisonResult {
+  duplicates: Array<{
+    transactionId: string;
+    occurrences: number;
+    source: 'local' | 'remote' | 'both';
+    indices?: number[];
+  }>;
+  missing: Array<{
+    transactionId: string;
+    presentIn: 'local' | 'remote';
+    height: number;
+    tags: Array<{ name: string; value: string }>;
+    metadata: {
+      owner: string;
+      recipient: string;
+      dataSize: string;
+      timestamp?: number;
+    };
+  }>;
+  discrepancies: Array<{
+    transactionId: string;
+    field: string;
+    localValue: any;
+    remoteValue: any;
+    severity: 'critical' | 'minor' | 'informational';
+  }>;
+  summary: {
+    totalLocal: number;
+    totalRemote: number;
+    totalMatched: number;
+    duplicateCount: number;
+    missingCount: number;
+    discrepancyCount: number;
+  };
+}
+
+interface ComparisonOptions {
+  strictComparison?: boolean;
+  ignoreFields?: string[];
+  tolerateTimestampDifference?: number; // milliseconds
+  checkOwnerKeys?: boolean;
+}
+
+export class ComparisonEngine {
+  private options: ComparisonOptions;
+
+  constructor(options: ComparisonOptions = {}) {
+    this.options = {
+      strictComparison: false,
+      ignoreFields: ['owner.key'], // Owner keys might not always be available
+      tolerateTimestampDifference: 1000, // 1 second tolerance for timestamps
+      checkOwnerKeys: false,
+      ...options,
+    };
+  }
+
+  /**
+   * Compare two sets of transactions and identify duplicates, missing items, and discrepancies
+   */
+  compareTransactionSets(
+    localTransactions: GraphQLTransaction[],
+    remoteTransactions: GraphQLTransaction[]
+  ): ComparisonResult {
+    console.log(`   🔍 Comparing ${localTransactions.length} local vs ${remoteTransactions.length} remote transactions...`);
+
+    const result: ComparisonResult = {
+      duplicates: [],
+      missing: [],
+      discrepancies: [],
+      summary: {
+        totalLocal: localTransactions.length,
+        totalRemote: remoteTransactions.length,
+        totalMatched: 0,
+        duplicateCount: 0,
+        missingCount: 0,
+        discrepancyCount: 0,
+      },
+    };
+
+    // Create maps for efficient lookups
+    const localMap = this.createTransactionMap(localTransactions);
+    const remoteMap = this.createTransactionMap(remoteTransactions);
+
+    // Find duplicates within each set
+    result.duplicates.push(...this.findDuplicatesInSet(localTransactions, 'local'));
+    result.duplicates.push(...this.findDuplicatesInSet(remoteTransactions, 'remote'));
+
+    // Find duplicates across both sets
+    result.duplicates.push(...this.findCrossSourcDuplicates(localMap, remoteMap));
+
+    // Find missing transactions
+    result.missing.push(...this.findMissingTransactions(localMap, remoteMap, 'remote'));
+    result.missing.push(...this.findMissingTransactions(remoteMap, localMap, 'local'));
+
+    // Find discrepancies in matching transactions
+    result.discrepancies.push(...this.findDiscrepancies(localMap, remoteMap));
+
+    // Calculate summary
+    const localIds = new Set(localTransactions.map(tx => tx.id));
+    const remoteIds = new Set(remoteTransactions.map(tx => tx.id));
+    const intersection = new Set([...localIds].filter(id => remoteIds.has(id)));
+
+    result.summary.totalMatched = intersection.size;
+    result.summary.duplicateCount = result.duplicates.length;
+    result.summary.missingCount = result.missing.length;
+    result.summary.discrepancyCount = result.discrepancies.length;
+
+    console.log(`   ✓ Comparison complete: ${result.summary.totalMatched} matched, ${result.summary.missingCount} missing, ${result.summary.duplicateCount} duplicates, ${result.summary.discrepancyCount} discrepancies`);
+
+    return result;
+  }
+
+  private createTransactionMap(transactions: GraphQLTransaction[]): Map<string, GraphQLTransaction[]> {
+    const map = new Map<string, GraphQLTransaction[]>();
+
+    for (const tx of transactions) {
+      const existing = map.get(tx.id) || [];
+      existing.push(tx);
+      map.set(tx.id, existing);
+    }
+
+    return map;
+  }
+
+  private findDuplicatesInSet(
+    transactions: GraphQLTransaction[],
+    source: 'local' | 'remote'
+  ): Array<{
+    transactionId: string;
+    occurrences: number;
+    source: 'local' | 'remote' | 'both';
+    indices?: number[];
+  }> {
+    const duplicates: Array<{
+      transactionId: string;
+      occurrences: number;
+      source: 'local' | 'remote' | 'both';
+      indices?: number[];
+    }> = [];
+
+    const idCounts = new Map<string, number[]>();
+
+    transactions.forEach((tx, index) => {
+      const indices = idCounts.get(tx.id) || [];
+      indices.push(index);
+      idCounts.set(tx.id, indices);
+    });
+
+    for (const [id, indices] of idCounts) {
+      if (indices.length > 1) {
+        duplicates.push({
+          transactionId: id,
+          occurrences: indices.length,
+          source,
+          indices,
+        });
+      }
+    }
+
+    return duplicates;
+  }
+
+  private findCrossSourcDuplicates(
+    localMap: Map<string, GraphQLTransaction[]>,
+    remoteMap: Map<string, GraphQLTransaction[]>
+  ): Array<{
+    transactionId: string;
+    occurrences: number;
+    source: 'local' | 'remote' | 'both';
+  }> {
+    const duplicates: Array<{
+      transactionId: string;
+      occurrences: number;
+      source: 'local' | 'remote' | 'both';
+    }> = [];
+
+    for (const [id, localTxs] of localMap) {
+      const remoteTxs = remoteMap.get(id);
+      if (remoteTxs && (localTxs.length > 1 || remoteTxs.length > 1)) {
+        duplicates.push({
+          transactionId: id,
+          occurrences: localTxs.length + remoteTxs.length,
+          source: 'both',
+        });
+      }
+    }
+
+    return duplicates;
+  }
+
+  private findMissingTransactions(
+    sourceMap: Map<string, GraphQLTransaction[]>,
+    targetMap: Map<string, GraphQLTransaction[]>,
+    presentIn: 'local' | 'remote'
+  ): Array<{
+    transactionId: string;
+    presentIn: 'local' | 'remote';
+    height: number;
+    tags: Array<{ name: string; value: string }>;
+    metadata: {
+      owner: string;
+      recipient: string;
+      dataSize: string;
+      timestamp?: number;
+    };
+  }> {
+    const missing: Array<{
+      transactionId: string;
+      presentIn: 'local' | 'remote';
+      height: number;
+      tags: Array<{ name: string; value: string }>;
+      metadata: {
+        owner: string;
+        recipient: string;
+        dataSize: string;
+        timestamp?: number;
+      };
+    }> = [];
+
+    for (const [id, txs] of sourceMap) {
+      if (!targetMap.has(id)) {
+        // Take the first transaction if there are multiple (shouldn't happen, but defensive)
+        const tx = txs[0];
+        missing.push({
+          transactionId: id,
+          presentIn,
+          height: tx.block?.height || 0,
+          tags: tx.tags,
+          metadata: {
+            owner: tx.owner.address,
+            recipient: tx.recipient,
+            dataSize: tx.data.size,
+            timestamp: tx.block?.timestamp,
+          },
+        });
+      }
+    }
+
+    return missing;
+  }
+
+  private findDiscrepancies(
+    localMap: Map<string, GraphQLTransaction[]>,
+    remoteMap: Map<string, GraphQLTransaction[]>
+  ): Array<{
+    transactionId: string;
+    field: string;
+    localValue: any;
+    remoteValue: any;
+    severity: 'critical' | 'minor' | 'informational';
+  }> {
+    const discrepancies: Array<{
+      transactionId: string;
+      field: string;
+      localValue: any;
+      remoteValue: any;
+      severity: 'critical' | 'minor' | 'informational';
+    }> = [];
+
+    for (const [id, localTxs] of localMap) {
+      const remoteTxs = remoteMap.get(id);
+      if (remoteTxs) {
+        // Compare the first transaction from each set
+        const localTx = localTxs[0];
+        const remoteTx = remoteTxs[0];
+
+        discrepancies.push(...this.compareTransactions(id, localTx, remoteTx));
+      }
+    }
+
+    return discrepancies;
+  }
+
+  private compareTransactions(
+    id: string,
+    localTx: GraphQLTransaction,
+    remoteTx: GraphQLTransaction
+  ): Array<{
+    transactionId: string;
+    field: string;
+    localValue: any;
+    remoteValue: any;
+    severity: 'critical' | 'minor' | 'informational';
+  }> {
+    const discrepancies: Array<{
+      transactionId: string;
+      field: string;
+      localValue: any;
+      remoteValue: any;
+      severity: 'critical' | 'minor' | 'informational';
+    }> = [];
+
+    // Define field comparison rules
+    const fieldRules = [
+      {
+        field: 'owner.address',
+        getValue: (tx: GraphQLTransaction) => tx.owner.address,
+        severity: 'critical' as const,
+      },
+      {
+        field: 'owner.key',
+        getValue: (tx: GraphQLTransaction) => tx.owner.key,
+        severity: 'informational' as const,
+        skip: !this.options.checkOwnerKeys || this.options.ignoreFields?.includes('owner.key'),
+      },
+      {
+        field: 'recipient',
+        getValue: (tx: GraphQLTransaction) => tx.recipient,
+        severity: 'critical' as const,
+      },
+      {
+        field: 'fee.winston',
+        getValue: (tx: GraphQLTransaction) => tx.fee.winston,
+        severity: 'minor' as const,
+      },
+      {
+        field: 'quantity.winston',
+        getValue: (tx: GraphQLTransaction) => tx.quantity.winston,
+        severity: 'critical' as const,
+      },
+      {
+        field: 'data.size',
+        getValue: (tx: GraphQLTransaction) => tx.data.size,
+        severity: 'critical' as const,
+      },
+      {
+        field: 'data.type',
+        getValue: (tx: GraphQLTransaction) => tx.data.type,
+        severity: 'minor' as const,
+      },
+      {
+        field: 'block.height',
+        getValue: (tx: GraphQLTransaction) => tx.block?.height,
+        severity: 'critical' as const,
+      },
+      {
+        field: 'block.timestamp',
+        getValue: (tx: GraphQLTransaction) => tx.block?.timestamp,
+        severity: 'minor' as const,
+        customCompare: (local: number, remote: number) => {
+          if (this.options.tolerateTimestampDifference) {
+            return Math.abs(local - remote) <= this.options.tolerateTimestampDifference;
+          }
+          return local === remote;
+        },
+      },
+      {
+        field: 'bundledIn.id',
+        getValue: (tx: GraphQLTransaction) => tx.bundledIn?.id,
+        severity: 'minor' as const,
+      },
+    ];
+
+    // Compare tags separately
+    const tagDiscrepancies = this.compareTags(id, localTx.tags, remoteTx.tags);
+    discrepancies.push(...tagDiscrepancies);
+
+    // Compare other fields
+    for (const rule of fieldRules) {
+      if (rule.skip) continue;
+
+      const localValue = rule.getValue(localTx);
+      const remoteValue = rule.getValue(remoteTx);
+
+      let isEqual = false;
+      if (rule.customCompare && typeof localValue === 'number' && typeof remoteValue === 'number') {
+        isEqual = rule.customCompare(localValue, remoteValue);
+      } else {
+        isEqual = this.deepEqual(localValue, remoteValue);
+      }
+
+      if (!isEqual) {
+        discrepancies.push({
+          transactionId: id,
+          field: rule.field,
+          localValue,
+          remoteValue,
+          severity: rule.severity,
+        });
+      }
+    }
+
+    return discrepancies;
+  }
+
+  private compareTags(
+    id: string,
+    localTags: Array<{ name: string; value: string }>,
+    remoteTags: Array<{ name: string; value: string }>
+  ): Array<{
+    transactionId: string;
+    field: string;
+    localValue: any;
+    remoteValue: any;
+    severity: 'critical' | 'minor' | 'informational';
+  }> {
+    const discrepancies: Array<{
+      transactionId: string;
+      field: string;
+      localValue: any;
+      remoteValue: any;
+      severity: 'critical' | 'minor' | 'informational';
+    }> = [];
+
+    // Create maps for efficient comparison
+    const localTagMap = new Map(localTags.map(tag => [tag.name, tag.value]));
+    const remoteTagMap = new Map(remoteTags.map(tag => [tag.name, tag.value]));
+
+    // Check for missing tags
+    for (const [name, value] of localTagMap) {
+      if (!remoteTagMap.has(name)) {
+        discrepancies.push({
+          transactionId: id,
+          field: `tags.${name}`,
+          localValue: value,
+          remoteValue: null,
+          severity: 'minor',
+        });
+      } else if (remoteTagMap.get(name) !== value) {
+        discrepancies.push({
+          transactionId: id,
+          field: `tags.${name}`,
+          localValue: value,
+          remoteValue: remoteTagMap.get(name),
+          severity: 'minor',
+        });
+      }
+    }
+
+    // Check for extra tags in remote
+    for (const [name, value] of remoteTagMap) {
+      if (!localTagMap.has(name)) {
+        discrepancies.push({
+          transactionId: id,
+          field: `tags.${name}`,
+          localValue: null,
+          remoteValue: value,
+          severity: 'minor',
+        });
+      }
+    }
+
+    return discrepancies;
+  }
+
+  private deepEqual(a: any, b: any): boolean {
+    if (a === b) return true;
+    if (a == null || b == null) return a === b;
+    if (typeof a !== typeof b) return false;
+
+    if (typeof a === 'object') {
+      const keysA = Object.keys(a);
+      const keysB = Object.keys(b);
+
+      if (keysA.length !== keysB.length) return false;
+
+      for (const key of keysA) {
+        if (!keysB.includes(key)) return false;
+        if (!this.deepEqual(a[key], b[key])) return false;
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Generate a summary report of comparison results
+   */
+  generateSummaryReport(result: ComparisonResult): string {
+    const { summary, duplicates, missing, discrepancies } = result;
+
+    let report = `
+=== Comparison Summary ===
+Total Local Transactions: ${summary.totalLocal}
+Total Remote Transactions: ${summary.totalRemote}
+Matched Transactions: ${summary.totalMatched}
+Missing Transactions: ${summary.missingCount}
+Duplicate Transactions: ${summary.duplicateCount}
+Field Discrepancies: ${summary.discrepancyCount}
+
+`;
+
+    if (duplicates.length > 0) {
+      report += `=== Duplicates ===\n`;
+      for (const dup of duplicates.slice(0, 10)) { // Show first 10
+        report += `- ${dup.transactionId} (${dup.occurrences}x in ${dup.source})\n`;
+      }
+      if (duplicates.length > 10) {
+        report += `... and ${duplicates.length - 10} more\n`;
+      }
+      report += '\n';
+    }
+
+    if (missing.length > 0) {
+      report += `=== Missing Transactions ===\n`;
+      for (const miss of missing.slice(0, 10)) { // Show first 10
+        report += `- ${miss.transactionId} (present in ${miss.presentIn}, height: ${miss.height})\n`;
+      }
+      if (missing.length > 10) {
+        report += `... and ${missing.length - 10} more\n`;
+      }
+      report += '\n';
+    }
+
+    if (discrepancies.length > 0) {
+      report += `=== Field Discrepancies ===\n`;
+      const criticalCount = discrepancies.filter(d => d.severity === 'critical').length;
+      const minorCount = discrepancies.filter(d => d.severity === 'minor').length;
+      const infoCount = discrepancies.filter(d => d.severity === 'informational').length;
+
+      report += `Critical: ${criticalCount}, Minor: ${minorCount}, Informational: ${infoCount}\n`;
+
+      for (const disc of discrepancies.slice(0, 10)) { // Show first 10
+        report += `- ${disc.transactionId}.${disc.field}: ${JSON.stringify(disc.localValue)} vs ${JSON.stringify(disc.remoteValue)} (${disc.severity})\n`;
+      }
+      if (discrepancies.length > 10) {
+        report += `... and ${discrepancies.length - 10} more\n`;
+      }
+    }
+
+    return report;
+  }
+}
+
+export type { ComparisonResult, ComparisonOptions };

--- a/tools/lib/comparison-engine.ts
+++ b/tools/lib/comparison-engine.ts
@@ -109,7 +109,11 @@ export class ComparisonEngine {
     const intersection = new Set([...localIds].filter(id => remoteIds.has(id)));
 
     result.summary.totalMatched = intersection.size;
-    result.summary.duplicateCount = result.duplicates.length;
+    // Count unique duplicated ids: findDuplicatesInSet emits a 'local' and
+    // 'remote' entry for the same id, and findCrossSourcDuplicates adds a
+    // 'both' entry on top when the id appears on both sides. result.duplicates
+    // keeps all three for reporting; the summary should reflect ids.
+    result.summary.duplicateCount = new Set(result.duplicates.map(d => d.transactionId)).size;
     result.summary.missingCount = result.missing.length;
     result.summary.discrepancyCount = result.discrepancies.length;
 

--- a/tools/lib/graphql-client.ts
+++ b/tools/lib/graphql-client.ts
@@ -299,25 +299,28 @@ export class GraphQLClient {
     const { tags, owners, recipients, ids, pageSize, cursor, sortOrder, heightRange } = options;
 
     const filters: string[] = [];
+    // GraphQL strings need the same escaping rules as JSON strings for the
+    // subset of values we use, so JSON.stringify is a safe and minimal escaper.
+    const gqlString = (value: string): string => JSON.stringify(value);
 
     if (tags && tags.length > 0) {
       const tagsStr = tags.map(tag => `{
-        name: "${tag.name}"
-        values: [${tag.values.map(v => `"${v}"`).join(', ')}]
+        name: ${gqlString(tag.name)}
+        values: [${tag.values.map(gqlString).join(', ')}]
       }`).join(', ');
       filters.push(`tags: [${tagsStr}]`);
     }
 
     if (owners && owners.length > 0) {
-      filters.push(`owners: [${owners.map(o => `"${o}"`).join(', ')}]`);
+      filters.push(`owners: [${owners.map(gqlString).join(', ')}]`);
     }
 
     if (recipients && recipients.length > 0) {
-      filters.push(`recipients: [${recipients.map(r => `"${r}"`).join(', ')}]`);
+      filters.push(`recipients: [${recipients.map(gqlString).join(', ')}]`);
     }
 
     if (ids && ids.length > 0) {
-      filters.push(`ids: [${ids.map(id => `"${id}"`).join(', ')}]`);
+      filters.push(`ids: [${ids.map(gqlString).join(', ')}]`);
     }
 
     if (heightRange && (heightRange.minHeight !== undefined || heightRange.maxHeight !== undefined)) {
@@ -332,7 +335,7 @@ export class GraphQLClient {
     }
 
     const filtersStr = filters.length > 0 ? filters.join('\n    ') : '';
-    const afterClause = cursor ? `after: "${cursor}"` : '';
+    const afterClause = cursor ? `after: ${gqlString(cursor)}` : '';
 
     return `
       query {

--- a/tools/lib/graphql-client.ts
+++ b/tools/lib/graphql-client.ts
@@ -1,0 +1,488 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+interface GraphQLTransaction {
+  id: string;
+  height?: number;
+  owner: {
+    address: string;
+    key: string;
+  };
+  recipient: string;
+  tags: Array<{
+    name: string;
+    value: string;
+  }>;
+  block?: {
+    height: number;
+    timestamp: number;
+    id: string;
+  };
+  fee: {
+    winston: string;
+    ar: string;
+  };
+  quantity: {
+    winston: string;
+    ar: string;
+  };
+  data: {
+    size: string;
+    type?: string;
+  };
+  bundledIn?: {
+    id: string;
+  };
+}
+
+interface GraphQLResponse {
+  transactions: {
+    pageInfo: {
+      hasNextPage: boolean;
+    };
+    edges: Array<{
+      cursor: string;
+      node: GraphQLTransaction;
+    }>;
+  };
+}
+
+interface QueryResult {
+  transactions: GraphQLTransaction[];
+  hasNextPage: boolean;
+  nextCursor?: string;
+  queryTime: number;
+  totalPages: number;
+}
+
+export type SortOrder = 'HEIGHT_ASC' | 'HEIGHT_DESC';
+
+export class GraphQLClient {
+  private endpoint: string;
+  private timeout: number;
+  private verbose: boolean;
+
+  constructor(endpoint: string, timeout: number = 30000, verbose: boolean = false) {
+    this.endpoint = endpoint;
+    this.timeout = timeout;
+    this.verbose = verbose;
+  }
+
+  /**
+   * Query transactions by Drive-Id tag
+   */
+  async queryByDriveId(
+    driveId: string,
+    pageSize: number = 100,
+    cursor?: string,
+    sortOrder: SortOrder = 'HEIGHT_DESC',
+    heightRange?: { minHeight?: number; maxHeight?: number }
+  ): Promise<QueryResult> {
+    const query = this.buildTransactionsQuery({
+      tags: [{ name: 'Drive-Id', values: [driveId] }],
+      pageSize,
+      cursor,
+      sortOrder,
+      heightRange,
+    });
+
+    return this.executeQuery(query);
+  }
+
+  /**
+   * Query transactions by owner address
+   */
+  async queryByOwner(
+    ownerAddress: string,
+    pageSize: number = 100,
+    cursor?: string,
+    sortOrder: SortOrder = 'HEIGHT_DESC',
+    heightRange?: { minHeight?: number; maxHeight?: number }
+  ): Promise<QueryResult> {
+    const query = this.buildTransactionsQuery({
+      owners: [ownerAddress],
+      pageSize,
+      cursor,
+      sortOrder,
+      heightRange,
+    });
+
+    return this.executeQuery(query);
+  }
+
+  /**
+   * Query all transactions for an entity with pagination
+   */
+  async queryAllTransactions(
+    options: {
+      driveId?: string;
+      ownerAddress?: string;
+      maxPages?: number;
+      pageSize?: number;
+      sortOrder?: SortOrder;
+      heightRange?: { minHeight?: number; maxHeight?: number };
+    }
+  ): Promise<{
+    allTransactions: GraphQLTransaction[];
+    totalPages: number;
+    totalQueryTime: number;
+  }> {
+    const { driveId, ownerAddress, maxPages = 100, pageSize = 100, sortOrder = 'HEIGHT_DESC', heightRange } = options;
+
+    if (!driveId && !ownerAddress) {
+      throw new Error('Either driveId or ownerAddress must be provided');
+    }
+
+    const allTransactions: GraphQLTransaction[] = [];
+    let cursor: string | undefined;
+    let currentPage = 0;
+    let totalQueryTime = 0;
+
+    const heightRangeStr = heightRange ? ` (heights ${heightRange.minHeight}-${heightRange.maxHeight})` : '';
+    console.log(`   📄 Fetching all transactions (max ${maxPages} pages)${heightRangeStr}...`);
+
+    while (currentPage < maxPages) {
+      let result: QueryResult;
+
+      if (driveId) {
+        result = await this.queryByDriveId(driveId, pageSize, cursor, sortOrder, heightRange);
+      } else {
+        result = await this.queryByOwner(ownerAddress!, pageSize, cursor, sortOrder, heightRange);
+      }
+
+      allTransactions.push(...result.transactions);
+      totalQueryTime += result.queryTime;
+      currentPage++;
+
+      console.log(`   📄 Page ${currentPage}: ${result.transactions.length} transactions (${result.queryTime.toFixed(2)}ms)`);
+
+      if (!result.hasNextPage || result.transactions.length === 0) {
+        break;
+      }
+
+      cursor = result.nextCursor;
+    }
+
+    console.log(`   ✓ Fetched ${allTransactions.length} transactions in ${currentPage} pages (${totalQueryTime.toFixed(2)}ms total)`);
+
+    return {
+      allTransactions,
+      totalPages: currentPage,
+      totalQueryTime,
+    };
+  }
+
+  /**
+   * Test pagination consistency in both directions
+   */
+  async testPaginationConsistency(
+    options: {
+      driveId?: string;
+      ownerAddress?: string;
+      testPages?: number;
+      pageSize?: number;
+      heightRange?: { minHeight?: number; maxHeight?: number };
+    }
+  ): Promise<{
+    ascending: { consistent: boolean; errors: string[] };
+    descending: { consistent: boolean; errors: string[] };
+  }> {
+    const { driveId, ownerAddress, testPages = 3, pageSize = 50, heightRange } = options;
+
+    console.log(`   🔄 Testing pagination consistency (${testPages} pages each direction)...`);
+
+    const results = {
+      ascending: { consistent: true, errors: [] as string[] },
+      descending: { consistent: true, errors: [] as string[] },
+    };
+
+    // Test HEIGHT_ASC
+    try {
+      await this.testSingleDirection(
+        { driveId, ownerAddress },
+        'HEIGHT_ASC',
+        testPages,
+        pageSize,
+        results.ascending,
+        heightRange
+      );
+    } catch (error) {
+      results.ascending.consistent = false;
+      results.ascending.errors.push(`HEIGHT_ASC test failed: ${error}`);
+    }
+
+    // Test HEIGHT_DESC
+    try {
+      await this.testSingleDirection(
+        { driveId, ownerAddress },
+        'HEIGHT_DESC',
+        testPages,
+        pageSize,
+        results.descending,
+        heightRange
+      );
+    } catch (error) {
+      results.descending.consistent = false;
+      results.descending.errors.push(`HEIGHT_DESC test failed: ${error}`);
+    }
+
+    return results;
+  }
+
+  private async testSingleDirection(
+    entity: { driveId?: string; ownerAddress?: string },
+    sortOrder: SortOrder,
+    testPages: number,
+    pageSize: number,
+    result: { consistent: boolean; errors: string[] },
+    heightRange?: { minHeight?: number; maxHeight?: number }
+  ): Promise<void> {
+    let cursor: string | undefined;
+    let previousHeight: number | null = null;
+    let seenIds = new Set<string>();
+
+    for (let page = 0; page < testPages; page++) {
+      let queryResult: QueryResult;
+
+      if (entity.driveId) {
+        queryResult = await this.queryByDriveId(entity.driveId, pageSize, cursor, sortOrder, heightRange);
+      } else {
+        queryResult = await this.queryByOwner(entity.ownerAddress!, pageSize, cursor, sortOrder, heightRange);
+      }
+
+      // Check sorting order
+      for (const tx of queryResult.transactions) {
+        const currentHeight = tx.block?.height ?? 0;
+
+        if (previousHeight !== null) {
+          if (sortOrder === 'HEIGHT_ASC' && currentHeight < previousHeight) {
+            result.consistent = false;
+            result.errors.push(`HEIGHT_ASC order violation: ${currentHeight} < ${previousHeight}`);
+          } else if (sortOrder === 'HEIGHT_DESC' && currentHeight > previousHeight) {
+            result.consistent = false;
+            result.errors.push(`HEIGHT_DESC order violation: ${currentHeight} > ${previousHeight}`);
+          }
+        }
+
+        // Check for duplicates across pages
+        if (seenIds.has(tx.id)) {
+          result.consistent = false;
+          result.errors.push(`Duplicate transaction ID across pages: ${tx.id}`);
+        }
+        seenIds.add(tx.id);
+
+        previousHeight = currentHeight;
+      }
+
+      if (!queryResult.hasNextPage || queryResult.transactions.length === 0) {
+        break;
+      }
+
+      cursor = queryResult.nextCursor;
+    }
+  }
+
+  private buildTransactionsQuery(options: {
+    tags?: Array<{ name: string; values: string[] }>;
+    owners?: string[];
+    recipients?: string[];
+    ids?: string[];
+    pageSize: number;
+    cursor?: string;
+    sortOrder: SortOrder;
+    heightRange?: { minHeight?: number; maxHeight?: number };
+  }): string {
+    const { tags, owners, recipients, ids, pageSize, cursor, sortOrder, heightRange } = options;
+
+    const filters: string[] = [];
+
+    if (tags && tags.length > 0) {
+      const tagsStr = tags.map(tag => `{
+        name: "${tag.name}"
+        values: [${tag.values.map(v => `"${v}"`).join(', ')}]
+      }`).join(', ');
+      filters.push(`tags: [${tagsStr}]`);
+    }
+
+    if (owners && owners.length > 0) {
+      filters.push(`owners: [${owners.map(o => `"${o}"`).join(', ')}]`);
+    }
+
+    if (recipients && recipients.length > 0) {
+      filters.push(`recipients: [${recipients.map(r => `"${r}"`).join(', ')}]`);
+    }
+
+    if (ids && ids.length > 0) {
+      filters.push(`ids: [${ids.map(id => `"${id}"`).join(', ')}]`);
+    }
+
+    if (heightRange && (heightRange.minHeight !== undefined || heightRange.maxHeight !== undefined)) {
+      const blockFilter: string[] = [];
+      if (heightRange.minHeight !== undefined) {
+        blockFilter.push(`min: ${heightRange.minHeight}`);
+      }
+      if (heightRange.maxHeight !== undefined) {
+        blockFilter.push(`max: ${heightRange.maxHeight}`);
+      }
+      filters.push(`block: { ${blockFilter.join(', ')} }`);
+    }
+
+    const filtersStr = filters.length > 0 ? filters.join('\n    ') : '';
+    const afterClause = cursor ? `after: "${cursor}"` : '';
+
+    return `
+      query {
+        transactions(
+          ${filtersStr}
+          first: ${pageSize}
+          ${afterClause}
+          sort: ${sortOrder}
+        ) {
+          pageInfo {
+            hasNextPage
+          }
+          edges {
+            cursor
+            node {
+              id
+              owner {
+                address
+                key
+              }
+              recipient
+              tags {
+                name
+                value
+              }
+              block {
+                height
+                timestamp
+                id
+              }
+              fee {
+                winston
+                ar
+              }
+              quantity {
+                winston
+                ar
+              }
+              data {
+                size
+                type
+              }
+              bundledIn {
+                id
+              }
+            }
+          }
+        }
+      }
+    `;
+  }
+
+  private async executeQuery(query: string): Promise<QueryResult> {
+    const startTime = Date.now();
+
+    if (this.verbose) {
+      console.log(`\n📋 GraphQL Query to ${this.endpoint}:`);
+      console.log('─'.repeat(80));
+      console.log(query.trim());
+      console.log('─'.repeat(80));
+    }
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+      const response = await fetch(this.endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ query }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const result = await response.json();
+
+      if (result.errors) {
+        throw new Error(`GraphQL errors: ${JSON.stringify(result.errors)}`);
+      }
+
+      const data = result.data as GraphQLResponse;
+      const queryTime = Date.now() - startTime;
+
+      const transactions = data.transactions.edges.map(edge => edge.node);
+      const hasNextPage = data.transactions.pageInfo.hasNextPage;
+      const nextCursor = data.transactions.edges.length > 0
+        ? data.transactions.edges[data.transactions.edges.length - 1].cursor
+        : undefined;
+
+      if (this.verbose) {
+        console.log(`✅ Query completed: ${transactions.length} transactions returned in ${queryTime}ms`);
+        console.log(`   hasNextPage: ${hasNextPage}, nextCursor: ${nextCursor ? nextCursor.substring(0, 20) + '...' : 'none'}\n`);
+      }
+
+      return {
+        transactions,
+        hasNextPage,
+        nextCursor,
+        queryTime,
+        totalPages: 1, // Individual query always represents 1 page
+      };
+    } catch (error) {
+      const queryTime = Date.now() - startTime;
+
+      if (this.verbose) {
+        console.log(`❌ Query failed after ${queryTime}ms: ${error}\n`);
+      }
+
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error(`Query timeout after ${this.timeout}ms`);
+      }
+
+      throw new Error(`Query failed: ${error} (${queryTime}ms)`);
+    }
+  }
+
+  /**
+   * Test connection to the GraphQL endpoint
+   */
+  async testConnection(): Promise<boolean> {
+    try {
+      const query = `
+        query {
+          transactions(first: 1) {
+            pageInfo {
+              hasNextPage
+            }
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      `;
+
+      const result = await this.executeQuery(query);
+      return result.transactions.length >= 0; // Even 0 transactions is a valid response
+    } catch (error) {
+      console.error(`GraphQL endpoint connection test failed: ${error}`);
+      return false;
+    }
+  }
+}
+
+export type { GraphQLTransaction, QueryResult };

--- a/tools/lib/test-clickhouse-graphql.ts
+++ b/tools/lib/test-clickhouse-graphql.ts
@@ -1,0 +1,993 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { ClickHouseAnalysisClient, type DriveCount, type OwnerCount } from './clickhouse-client.js';
+import { GraphQLClient, type GraphQLTransaction } from './graphql-client.js';
+import { ComparisonEngine } from './comparison-engine.js';
+import { ClickHouseIntegrityCheck, type DatabaseIntegrityResult } from './clickhouse-integrity.js';
+
+// The bash wrapper cd's to the repo root before exec, so process.cwd() is
+// the project root and relative paths below resolve there.
+
+// Types
+interface TestConfig {
+  clickhouse: {
+    url: string;
+    user?: string;
+    password?: string;
+  };
+  endpoints: {
+    local: string;
+    remote: string;
+  };
+  discovery: {
+    topDrives: number;
+    topOwners: number;
+    minTransactionCount: number;
+  };
+  testing: {
+    pageSize: number;
+    maxPagesPerTest: number;
+    testBothDirections: boolean;
+    maxTransactionsPerEntity?: number;
+    allowPartialComparisons?: boolean;
+  };
+  databaseIntegrity?: {
+    enabled?: boolean;
+    enableDuplicateCheck?: boolean;
+    enableMissingCheck?: boolean;
+    sampleSize?: number;
+    checkRemoteGraphql?: boolean;
+  };
+}
+
+interface TestResult {
+  entity: {
+    type: 'drive' | 'owner';
+    id: string;
+    transactionCount: number;
+  };
+  comparison: {
+    local: {
+      totalFound: number;
+      queryTime: number;
+      pagesQueried: number;
+    };
+    remote: {
+      totalFound: number;
+      queryTime: number;
+      pagesQueried: number;
+    };
+  };
+  issues: {
+    duplicates: Array<{
+      transactionId: string;
+      occurrences: number;
+      source: 'local' | 'remote' | 'both';
+    }>;
+    missing: Array<{
+      transactionId: string;
+      presentIn: 'local' | 'remote';
+      height: number;
+      tags: Array<{ name: string; value: string }>;
+    }>;
+    discrepancies: Array<{
+      transactionId: string;
+      field: string;
+      localValue: any;
+      remoteValue: any;
+      severity: 'critical' | 'minor' | 'informational';
+    }>;
+  };
+  pagination: {
+    ascending: {
+      tested: boolean;
+      consistent: boolean;
+      errors: string[];
+    };
+    descending: {
+      tested: boolean;
+      consistent: boolean;
+      errors: string[];
+    };
+  };
+  databaseIntegrity?: DatabaseIntegrityResult;
+  completeness: {
+    isComplete: boolean;
+    maxFetchableTransactions: number;
+    localCoverage: number; // percentage (0-100)
+    remoteCoverage: number; // percentage (0-100)
+    explanation: string;
+  };
+}
+
+// DriveCount and OwnerCount are imported from clickhouse-client
+
+// Load environment variables with defaults.
+// Canonical env var names match the rest of the project (see docker-compose.yaml
+// and tools/queue-missing-bundles): CORE_PORT, CLICKHOUSE_HOST, CLICKHOUSE_PORT_2,
+// CLICKHOUSE_USER, CLICKHOUSE_PASSWORD.
+function getDefaultConfig(): TestConfig {
+  const corePort = process.env.CORE_PORT ?? '4000';
+  const clickhouseHost = process.env.CLICKHOUSE_HOST ?? 'localhost';
+  const clickhousePort = process.env.CLICKHOUSE_PORT_2 ?? '8123';
+
+  return {
+    clickhouse: {
+      url: `http://${clickhouseHost}:${clickhousePort}`,
+      user: process.env.CLICKHOUSE_USER || 'default',
+      password: process.env.CLICKHOUSE_PASSWORD || '',
+    },
+    endpoints: {
+      local: `http://localhost:${corePort}/graphql`,
+      remote: 'https://arweave.net/graphql',
+    },
+    discovery: {
+      topDrives: parseInt(process.env.TOP_DRIVES || '10', 10),
+      topOwners: parseInt(process.env.TOP_OWNERS || '10', 10),
+      minTransactionCount: parseInt(process.env.MIN_TRANSACTION_COUNT || '100', 10),
+    },
+    testing: {
+      pageSize: parseInt(process.env.PAGE_SIZE || '100', 10),
+      maxPagesPerTest: parseInt(process.env.MAX_PAGES_PER_TEST || '100', 10), // Increased default for better coverage
+      testBothDirections: process.env.TEST_BOTH_DIRECTIONS !== 'false',
+      maxTransactionsPerEntity: process.env.MAX_TRANSACTIONS_PER_ENTITY ?
+        parseInt(process.env.MAX_TRANSACTIONS_PER_ENTITY, 10) : undefined,
+      allowPartialComparisons: process.env.ALLOW_PARTIAL_COMPARISONS === 'true',
+    },
+    databaseIntegrity: {
+      enabled: process.env.DATABASE_INTEGRITY_ENABLED !== 'false',
+      enableDuplicateCheck: process.env.DATABASE_INTEGRITY_DUPLICATE_CHECK !== 'false',
+      enableMissingCheck: process.env.DATABASE_INTEGRITY_MISSING_CHECK !== 'false',
+      sampleSize: parseInt(process.env.DATABASE_INTEGRITY_SAMPLE_SIZE || '1000', 10),
+      checkRemoteGraphql: process.env.DATABASE_INTEGRITY_CHECK_REMOTE !== 'false',
+    },
+  };
+}
+
+class ClickHouseGraphQLTester {
+  private config: TestConfig;
+  private outputDir: string;
+  private clickhouseClient: ClickHouseAnalysisClient;
+  private localGraphQLClient: GraphQLClient;
+  private remoteGraphQLClient: GraphQLClient;
+  private comparisonEngine: ComparisonEngine;
+  private integrityChecker?: ClickHouseIntegrityCheck;
+
+  constructor(config: TestConfig, verbose: boolean = false) {
+    this.config = config;
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-').split('T')[0] + '-' +
+                     new Date().toTimeString().split(' ')[0].replace(/:/g, '-');
+    this.outputDir = path.join(process.cwd(), 'test-results', 'runs', timestamp);
+
+    // Initialize clients
+    this.clickhouseClient = new ClickHouseAnalysisClient(config.clickhouse);
+    this.localGraphQLClient = new GraphQLClient(config.endpoints.local, 30000, verbose);
+    this.remoteGraphQLClient = new GraphQLClient(config.endpoints.remote, 30000, verbose);
+    this.comparisonEngine = new ComparisonEngine({
+      strictComparison: false,
+      checkOwnerKeys: false,
+      tolerateTimestampDifference: 1000,
+    });
+
+    // Initialize database integrity checker if enabled
+    if (config.databaseIntegrity?.enabled) {
+      this.integrityChecker = new ClickHouseIntegrityCheck(this.clickhouseClient, {
+        enableDuplicateCheck: config.databaseIntegrity.enableDuplicateCheck,
+        enableMissingCheck: config.databaseIntegrity.enableMissingCheck,
+        sampleSize: config.databaseIntegrity.sampleSize,
+        checkRemoteGraphql: config.databaseIntegrity.checkRemoteGraphql,
+      });
+    }
+  }
+
+  async initialize(): Promise<void> {
+    // Test connections first
+    console.log('🔌 Testing connections...');
+
+    const clickhouseOk = await this.clickhouseClient.testConnection();
+    const localOk = await this.localGraphQLClient.testConnection();
+    const remoteOk = await this.remoteGraphQLClient.testConnection();
+
+    if (!clickhouseOk) {
+      throw new Error('❌ ClickHouse connection failed');
+    }
+    if (!localOk) {
+      throw new Error('❌ Local GraphQL endpoint connection failed');
+    }
+    if (!remoteOk) {
+      throw new Error('❌ Remote GraphQL endpoint connection failed');
+    }
+
+    console.log('✅ All connections successful');
+
+    // Create output directory structure
+    await fs.mkdir(this.outputDir, { recursive: true });
+    await fs.mkdir(path.join(this.outputDir, 'discovery'), { recursive: true });
+    await fs.mkdir(path.join(this.outputDir, 'tests', 'drives'), { recursive: true });
+    await fs.mkdir(path.join(this.outputDir, 'tests', 'owners'), { recursive: true });
+    await fs.mkdir(path.join(this.outputDir, 'comparisons'), { recursive: true });
+    await fs.mkdir(path.join(this.outputDir, 'database-integrity'), { recursive: true });
+
+    // Save config snapshot
+    await fs.writeFile(
+      path.join(this.outputDir, 'config.json'),
+      JSON.stringify(this.config, null, 2)
+    );
+
+    // Create/update latest symlink
+    const latestPath = path.join(process.cwd(), 'test-results', 'latest');
+    try {
+      await fs.unlink(latestPath);
+    } catch {
+      // Ignore if symlink doesn't exist
+    }
+    await fs.symlink(this.outputDir, latestPath);
+
+    console.log(`✓ Initialized test run in: ${this.outputDir}`);
+  }
+
+  /**
+   * Calculate the maximum number of transactions we can fetch for complete comparison
+   */
+  private getMaxFetchableTransactions(): number {
+    // Use explicit config value if set, otherwise calculate from page settings
+    return this.config.testing.maxTransactionsPerEntity ||
+           (this.config.testing.pageSize * this.config.testing.maxPagesPerTest);
+  }
+
+  /**
+   * Filter entities to only include those where we can fetch all transactions
+   */
+  private filterCompletableEntities<T extends { transactionCount: number }>(
+    entities: T[],
+    entityType: string
+  ): { complete: T[]; filtered: T[] } {
+    if (this.config.testing.allowPartialComparisons) {
+      return { complete: entities, filtered: [] };
+    }
+
+    const maxFetchable = this.getMaxFetchableTransactions();
+    const complete = entities.filter(e => e.transactionCount <= maxFetchable);
+    const filtered = entities.filter(e => e.transactionCount > maxFetchable);
+
+    if (filtered.length > 0) {
+      console.log(`   ⚠️  Filtered out ${filtered.length} ${entityType}s with > ${maxFetchable} transactions (incomplete comparison)`);
+      console.log(`   📊 Use --allow-partial or increase maxPagesPerTest to include them`);
+    }
+
+    return { complete, filtered };
+  }
+
+  async discoverEntities(): Promise<{ drives: DriveCount[]; owners: OwnerCount[] }> {
+    console.log('\n📊 Discovering entities by transaction count...');
+
+    // Get database statistics first
+    const stats = await this.clickhouseClient.getStats();
+    console.log(`   📈 Database stats: ${stats.totalTransactions} transactions, ~${stats.totalDrives} drives, ${stats.totalOwners} owners`);
+    console.log(`   📊 ClickHouse height range: ${stats.heightRange.minHeight} - ${stats.heightRange.maxHeight}`);
+
+    // Get drive transaction counts
+    console.log('   🔍 Querying Drive-Id transaction counts...');
+    const allDrives = await this.clickhouseClient.getDriveTransactionCounts(this.config.discovery.minTransactionCount);
+    console.log(`   ✓ Found ${allDrives.length} drives with >= ${this.config.discovery.minTransactionCount} transactions`);
+
+    // Filter drives for complete comparison
+    const driveFilter = this.filterCompletableEntities(allDrives, 'drive');
+    const drives = driveFilter.complete;
+
+    // Get owner transaction counts
+    console.log('   🔍 Querying owner transaction counts...');
+    const allOwners = await this.clickhouseClient.getOwnerTransactionCounts(this.config.discovery.minTransactionCount);
+    console.log(`   ✓ Found ${allOwners.length} owners with >= ${this.config.discovery.minTransactionCount} transactions`);
+
+    // Filter owners for complete comparison
+    const ownerFilter = this.filterCompletableEntities(allOwners, 'owner');
+    const owners = ownerFilter.complete;
+
+    // Save discovery results
+    await fs.writeFile(
+      path.join(this.outputDir, 'discovery', 'drive-counts.json'),
+      JSON.stringify(drives, null, 2)
+    );
+    await fs.writeFile(
+      path.join(this.outputDir, 'discovery', 'owner-counts.json'),
+      JSON.stringify(owners, null, 2)
+    );
+
+    // Save filtered entities for reference
+    if (driveFilter.filtered.length > 0) {
+      await fs.writeFile(
+        path.join(this.outputDir, 'discovery', 'drive-counts-filtered.json'),
+        JSON.stringify(driveFilter.filtered, null, 2)
+      );
+    }
+    if (ownerFilter.filtered.length > 0) {
+      await fs.writeFile(
+        path.join(this.outputDir, 'discovery', 'owner-counts-filtered.json'),
+        JSON.stringify(ownerFilter.filtered, null, 2)
+      );
+    }
+
+    const maxFetchable = this.getMaxFetchableTransactions();
+    const summary = {
+      databaseStats: stats,
+      maxFetchableTransactions: maxFetchable,
+      allowPartialComparisons: this.config.testing.allowPartialComparisons,
+      totalDrives: drives.length,
+      totalOwners: owners.length,
+      filteredDrives: driveFilter.filtered.length,
+      filteredOwners: ownerFilter.filtered.length,
+      topDrives: drives.slice(0, this.config.discovery.topDrives),
+      topOwners: owners.slice(0, this.config.discovery.topOwners),
+      timestamp: new Date().toISOString(),
+    };
+
+    await fs.writeFile(
+      path.join(this.outputDir, 'discovery', 'summary.json'),
+      JSON.stringify(summary, null, 2)
+    );
+
+    const filterMsg = (driveFilter.filtered.length + ownerFilter.filtered.length) > 0 ?
+      ` (${driveFilter.filtered.length + ownerFilter.filtered.length} filtered)` : '';
+    console.log(`✓ Discovery complete: ${drives.length} drives, ${owners.length} owners${filterMsg}`);
+    console.log(`   📏 Max fetchable transactions per entity: ${maxFetchable}`);
+
+    return { drives, owners };
+  }
+
+  async testEntity(entity: { type: 'drive' | 'owner'; id: string; transactionCount: number }): Promise<TestResult> {
+    console.log(`\n🧪 Testing ${entity.type}: ${entity.id} (${entity.transactionCount} transactions)`);
+
+    // Get actual transaction count if not provided
+    let actualCount = entity.transactionCount;
+    if (actualCount === 0) {
+      if (entity.type === 'drive') {
+        actualCount = await this.clickhouseClient.getDriveTransactionCount(entity.id);
+      } else {
+        actualCount = await this.clickhouseClient.getOwnerTransactionCount(entity.id);
+      }
+      console.log(`   📊 Found ${actualCount} transactions in ClickHouse`);
+    }
+
+    const result: TestResult = {
+      entity: { ...entity, transactionCount: actualCount },
+      comparison: {
+        local: { totalFound: 0, queryTime: 0, pagesQueried: 0 },
+        remote: { totalFound: 0, queryTime: 0, pagesQueried: 0 },
+      },
+      issues: {
+        duplicates: [],
+        missing: [],
+        discrepancies: [],
+      },
+      pagination: {
+        ascending: { tested: false, consistent: true, errors: [] },
+        descending: { tested: false, consistent: true, errors: [] },
+      },
+      completeness: {
+        isComplete: false,
+        maxFetchableTransactions: 0,
+        localCoverage: 0,
+        remoteCoverage: 0,
+        explanation: '',
+      },
+    };
+
+    try {
+      // Get ClickHouse height range to filter queries
+      const heightRange = await this.clickhouseClient.getHeightRange();
+      console.log(`   📊 Filtering to ClickHouse height range: ${heightRange.minHeight} - ${heightRange.maxHeight}`);
+
+      // Query both endpoints for all transactions
+      console.log('   🔄 Querying local GraphQL endpoint...');
+      const localResults = await this.queryEntityTransactions('local', entity, heightRange);
+      result.comparison.local = {
+        totalFound: localResults.allTransactions.length,
+        queryTime: localResults.totalQueryTime,
+        pagesQueried: localResults.totalPages,
+      };
+
+      console.log('   🔄 Querying remote GraphQL endpoint...');
+      const remoteResults = await this.queryEntityTransactions('remote', entity, heightRange);
+      result.comparison.remote = {
+        totalFound: remoteResults.allTransactions.length,
+        queryTime: remoteResults.totalQueryTime,
+        pagesQueried: remoteResults.totalPages,
+      };
+
+      // Compare the results
+      console.log('   🔍 Comparing results...');
+      const comparison = this.comparisonEngine.compareTransactionSets(
+        localResults.allTransactions,
+        remoteResults.allTransactions
+      );
+
+      result.issues = {
+        duplicates: comparison.duplicates,
+        missing: comparison.missing,
+        discrepancies: comparison.discrepancies,
+      };
+
+      // Calculate completeness information
+      const maxFetchable = this.getMaxFetchableTransactions();
+      const localCoverage = actualCount > 0 ? Math.min(100, (result.comparison.local.totalFound / actualCount) * 100) : 100;
+      const remoteCoverage = actualCount > 0 ? Math.min(100, (result.comparison.remote.totalFound / actualCount) * 100) : 100;
+      const isComplete = actualCount <= maxFetchable && localCoverage >= 99.9 && remoteCoverage >= 99.9;
+
+      let explanation = '';
+      if (actualCount > maxFetchable) {
+        explanation = `Entity has ${actualCount} transactions, but only ${maxFetchable} can be fetched. Increase maxPagesPerTest or use --max-transactions.`;
+      } else if (localCoverage < 99.9 || remoteCoverage < 99.9) {
+        explanation = `Incomplete coverage: local ${localCoverage.toFixed(1)}%, remote ${remoteCoverage.toFixed(1)}%. Some transactions may not be accessible.`;
+      } else {
+        explanation = 'Complete comparison - all transactions fetched and compared.';
+      }
+
+      result.completeness = {
+        isComplete,
+        maxFetchableTransactions: maxFetchable,
+        localCoverage,
+        remoteCoverage,
+        explanation,
+      };
+
+      // Test pagination if enabled
+      if (this.config.testing.testBothDirections) {
+        console.log('   🔄 Testing pagination consistency...');
+        const paginationTest = await this.testPaginationForEntity(entity);
+        result.pagination = paginationTest;
+      }
+
+      // Perform database integrity check if enabled
+      if (this.integrityChecker) {
+        console.log('   🔍 Checking database integrity...');
+        const integrityResult = await this.integrityChecker.checkIntegrity(
+          entity,
+          localResults.allTransactions,
+          remoteResults.allTransactions
+        );
+        result.databaseIntegrity = integrityResult;
+      }
+
+      // Save detailed transaction logs
+      await this.saveTransactionDetails(entity, localResults.allTransactions, remoteResults.allTransactions);
+
+      const totalIssues = result.issues.missing.length + result.issues.duplicates.length + result.issues.discrepancies.length;
+      const dbIssues = result.databaseIntegrity ?
+        (result.databaseIntegrity.summary.criticalIssues + result.databaseIntegrity.summary.warningIssues) : 0;
+
+      const completenessIcon = result.completeness.isComplete ? '✅' : '⚠️ ';
+      console.log(`   ${completenessIcon} Test complete: ${result.comparison.local.totalFound} local, ${result.comparison.remote.totalFound} remote, ${totalIssues} GraphQL issues, ${dbIssues} DB issues`);
+      if (!result.completeness.isComplete) {
+        console.log(`   📊 ${result.completeness.explanation}`);
+      }
+
+    } catch (error) {
+      console.error(`   ❌ Test failed: ${error}`);
+      result.issues.discrepancies.push({
+        transactionId: 'N/A',
+        field: 'test_error',
+        localValue: null,
+        remoteValue: null,
+        severity: 'critical',
+      });
+    }
+
+    // Save individual test result
+    const filename = `${entity.type}_${entity.id.replace(/[^a-zA-Z0-9]/g, '_')}_test.json`;
+    await fs.writeFile(
+      path.join(this.outputDir, 'tests', `${entity.type}s`, filename),
+      JSON.stringify(result, null, 2)
+    );
+
+    return result;
+  }
+
+  private async queryEntityTransactions(
+    endpoint: 'local' | 'remote',
+    entity: { type: 'drive' | 'owner'; id: string; transactionCount: number },
+    heightRange?: { minHeight: number; maxHeight: number }
+  ): Promise<{
+    allTransactions: GraphQLTransaction[];
+    totalPages: number;
+    totalQueryTime: number;
+  }> {
+    const client = endpoint === 'local' ? this.localGraphQLClient : this.remoteGraphQLClient;
+    const maxPages = this.config.testing.maxPagesPerTest;
+    const pageSize = this.config.testing.pageSize;
+
+    if (entity.type === 'drive') {
+      return client.queryAllTransactions({
+        driveId: entity.id,
+        maxPages,
+        pageSize,
+        sortOrder: 'HEIGHT_DESC',
+        heightRange,
+      });
+    } else {
+      return client.queryAllTransactions({
+        ownerAddress: entity.id,
+        maxPages,
+        pageSize,
+        sortOrder: 'HEIGHT_DESC',
+        heightRange,
+      });
+    }
+  }
+
+  private async testPaginationForEntity(entity: { type: 'drive' | 'owner'; id: string; transactionCount: number }): Promise<{
+    ascending: { tested: boolean; consistent: boolean; errors: string[] };
+    descending: { tested: boolean; consistent: boolean; errors: string[] };
+  }> {
+    const testPages = Math.min(3, this.config.testing.maxPagesPerTest);
+    const pageSize = Math.min(50, this.config.testing.pageSize);
+
+    // Get ClickHouse height range to filter queries
+    const heightRange = await this.clickhouseClient.getHeightRange();
+
+    // Test local endpoint pagination
+    const localPagination = await this.localGraphQLClient.testPaginationConsistency({
+      ...(entity.type === 'drive' ? { driveId: entity.id } : { ownerAddress: entity.id }),
+      testPages,
+      pageSize,
+      heightRange,
+    });
+
+    // Test remote endpoint pagination
+    const remotePagination = await this.remoteGraphQLClient.testPaginationConsistency({
+      ...(entity.type === 'drive' ? { driveId: entity.id } : { ownerAddress: entity.id }),
+      testPages,
+      pageSize,
+      heightRange,
+    });
+
+    // Combine results (both endpoints must be consistent)
+    return {
+      ascending: {
+        tested: true,
+        consistent: localPagination.ascending.consistent && remotePagination.ascending.consistent,
+        errors: [
+          ...localPagination.ascending.errors.map(e => `Local: ${e}`),
+          ...remotePagination.ascending.errors.map(e => `Remote: ${e}`),
+        ],
+      },
+      descending: {
+        tested: true,
+        consistent: localPagination.descending.consistent && remotePagination.descending.consistent,
+        errors: [
+          ...localPagination.descending.errors.map(e => `Local: ${e}`),
+          ...remotePagination.descending.errors.map(e => `Remote: ${e}`),
+        ],
+      },
+    };
+  }
+
+  private async saveTransactionDetails(
+    entity: { type: 'drive' | 'owner'; id: string },
+    localTransactions: GraphQLTransaction[],
+    remoteTransactions: GraphQLTransaction[]
+  ): Promise<void> {
+    const filename = `${entity.type}_${entity.id.replace(/[^a-zA-Z0-9]/g, '_')}_details.jsonl`;
+    const filePath = path.join(this.outputDir, 'tests', `${entity.type}s`, filename);
+
+    const lines: string[] = [];
+
+    // Log all local transactions
+    for (const tx of localTransactions) {
+      lines.push(JSON.stringify({
+        timestamp: new Date().toISOString(),
+        action: 'query',
+        source: 'local',
+        transactionId: tx.id,
+        data: tx,
+      }));
+    }
+
+    // Log all remote transactions
+    for (const tx of remoteTransactions) {
+      lines.push(JSON.stringify({
+        timestamp: new Date().toISOString(),
+        action: 'query',
+        source: 'remote',
+        transactionId: tx.id,
+        data: tx,
+      }));
+    }
+
+    await fs.writeFile(filePath, lines.join('\n'));
+  }
+
+  async generateReports(results: TestResult[]): Promise<void> {
+    console.log('\n📋 Generating reports...');
+
+    // Aggregate all issues
+    const allDuplicates = results.flatMap(r => r.issues.duplicates);
+    const allMissing = results.flatMap(r => r.issues.missing);
+    const allDiscrepancies = results.flatMap(r => r.issues.discrepancies);
+
+    // Aggregate database integrity issues
+    const allDbDuplicates = results.flatMap(r => r.databaseIntegrity?.clickhouseDuplicates || []);
+    const allDbGraphqlToClickhouseMissing = results.flatMap(r => r.databaseIntegrity?.graphqlToClickhouseMissing || []);
+    const allDbClickhouseToGraphqlMissing = results.flatMap(r => r.databaseIntegrity?.clickhouseToGraphqlMissing || []);
+
+    await fs.writeFile(
+      path.join(this.outputDir, 'comparisons', 'duplicates.json'),
+      JSON.stringify(allDuplicates, null, 2)
+    );
+    await fs.writeFile(
+      path.join(this.outputDir, 'comparisons', 'missing.json'),
+      JSON.stringify(allMissing, null, 2)
+    );
+    await fs.writeFile(
+      path.join(this.outputDir, 'comparisons', 'discrepancies.json'),
+      JSON.stringify(allDiscrepancies, null, 2)
+    );
+
+    // Save database integrity issues
+    await fs.writeFile(
+      path.join(this.outputDir, 'database-integrity', 'clickhouse-duplicates.json'),
+      JSON.stringify(allDbDuplicates, null, 2)
+    );
+    await fs.writeFile(
+      path.join(this.outputDir, 'database-integrity', 'graphql-to-clickhouse-missing.json'),
+      JSON.stringify(allDbGraphqlToClickhouseMissing, null, 2)
+    );
+    await fs.writeFile(
+      path.join(this.outputDir, 'database-integrity', 'clickhouse-to-graphql-missing.json'),
+      JSON.stringify(allDbClickhouseToGraphqlMissing, null, 2)
+    );
+
+    // Generate summary report
+    const summary = {
+      timestamp: new Date().toISOString(),
+      totalEntitiesTested: results.length,
+      totalTransactionsCompared: results.reduce((sum, r) => sum + r.entity.transactionCount, 0),
+      issuesSummary: {
+        duplicates: allDuplicates.length,
+        missing: allMissing.length,
+        discrepancies: allDiscrepancies.length,
+      },
+      databaseIntegrityIssues: {
+        clickhouseDuplicates: allDbDuplicates.length,
+        graphqlToClickhouseMissing: allDbGraphqlToClickhouseMissing.length,
+        clickhouseToGraphqlMissing: allDbClickhouseToGraphqlMissing.length,
+        totalCritical: [...allDbDuplicates, ...allDbGraphqlToClickhouseMissing, ...allDbClickhouseToGraphqlMissing]
+          .filter(issue => issue.severity === 'critical').length,
+        totalWarnings: [...allDbDuplicates, ...allDbGraphqlToClickhouseMissing, ...allDbClickhouseToGraphqlMissing]
+          .filter(issue => issue.severity === 'warning').length,
+      },
+      performanceMetrics: {
+        averageLocalQueryTime: results.reduce((sum, r) => sum + r.comparison.local.queryTime, 0) / results.length,
+        averageRemoteQueryTime: results.reduce((sum, r) => sum + r.comparison.remote.queryTime, 0) / results.length,
+      },
+      results,
+    };
+
+    await fs.writeFile(
+      path.join(this.outputDir, 'report.json'),
+      JSON.stringify(summary, null, 2)
+    );
+
+    // Generate HTML report
+    const htmlReport = this.generateHTMLReport(summary);
+    await fs.writeFile(path.join(this.outputDir, 'report.html'), htmlReport);
+
+    const totalGraphqlIssues = allDuplicates.length + allMissing.length + allDiscrepancies.length;
+    const totalDbIssues = allDbDuplicates.length + allDbGraphqlToClickhouseMissing.length + allDbClickhouseToGraphqlMissing.length;
+
+    console.log(`✓ Reports saved to: ${this.outputDir}`);
+    console.log(`📊 Summary: ${results.length} entities tested, ${totalGraphqlIssues} GraphQL issues, ${totalDbIssues} DB integrity issues found`);
+  }
+
+  private generateHTMLReport(summary: any): string {
+    return `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ClickHouse GraphQL Test Report</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .summary { background: #f5f5f5; padding: 15px; border-radius: 5px; margin-bottom: 20px; }
+        .issue { background: #fff3cd; padding: 10px; margin: 5px 0; border-radius: 3px; }
+        .error { background: #f8d7da; }
+        .success { background: #d4edda; }
+        table { border-collapse: collapse; width: 100%; margin: 10px 0; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        th { background-color: #f2f2f2; }
+    </style>
+</head>
+<body>
+    <h1>ClickHouse GraphQL Test Report</h1>
+    <div class="summary">
+        <h2>Summary</h2>
+        <p><strong>Timestamp:</strong> ${summary.timestamp}</p>
+        <p><strong>Entities Tested:</strong> ${summary.totalEntitiesTested}</p>
+        <p><strong>Transactions Compared:</strong> ${summary.totalTransactionsCompared}</p>
+        <p><strong>GraphQL Issues Found:</strong> ${summary.issuesSummary.duplicates + summary.issuesSummary.missing + summary.issuesSummary.discrepancies}</p>
+        <ul>
+            <li>Duplicates: ${summary.issuesSummary.duplicates}</li>
+            <li>Missing: ${summary.issuesSummary.missing}</li>
+            <li>Discrepancies: ${summary.issuesSummary.discrepancies}</li>
+        </ul>
+        <p><strong>Database Integrity Issues:</strong> ${summary.databaseIntegrityIssues?.clickhouseDuplicates + summary.databaseIntegrityIssues?.graphqlToClickhouseMissing + summary.databaseIntegrityIssues?.clickhouseToGraphqlMissing || 0}</p>
+        <ul>
+            <li>ClickHouse Duplicates: ${summary.databaseIntegrityIssues?.clickhouseDuplicates || 0}</li>
+            <li>GraphQL→ClickHouse Missing: ${summary.databaseIntegrityIssues?.graphqlToClickhouseMissing || 0}</li>
+            <li>ClickHouse→GraphQL Missing: ${summary.databaseIntegrityIssues?.clickhouseToGraphqlMissing || 0}</li>
+            <li>Critical Issues: ${summary.databaseIntegrityIssues?.totalCritical || 0}</li>
+            <li>Warning Issues: ${summary.databaseIntegrityIssues?.totalWarnings || 0}</li>
+        </ul>
+    </div>
+
+    <h2>Performance Metrics</h2>
+    <table>
+        <tr><th>Metric</th><th>Value</th></tr>
+        <tr><td>Average Local Query Time</td><td>${summary.performanceMetrics.averageLocalQueryTime.toFixed(2)}ms</td></tr>
+        <tr><td>Average Remote Query Time</td><td>${summary.performanceMetrics.averageRemoteQueryTime.toFixed(2)}ms</td></tr>
+    </table>
+
+    <h2>Test Results</h2>
+    <table>
+        <tr><th>Entity Type</th><th>Entity ID</th><th>Transaction Count</th><th>Coverage</th><th>Complete</th><th>GraphQL Issues</th><th>DB Issues</th></tr>
+        ${summary.results.map((result: TestResult) => `
+            <tr>
+                <td>${result.entity.type}</td>
+                <td>${result.entity.id}</td>
+                <td>${result.entity.transactionCount}</td>
+                <td>${result.completeness.localCoverage.toFixed(1)}% / ${result.completeness.remoteCoverage.toFixed(1)}%</td>
+                <td>${result.completeness.isComplete ? '✅' : '⚠️'}</td>
+                <td>${result.issues.duplicates.length + result.issues.missing.length + result.issues.discrepancies.length}</td>
+                <td>${result.databaseIntegrity ? (result.databaseIntegrity.summary.criticalIssues + result.databaseIntegrity.summary.warningIssues) : 0}</td>
+            </tr>
+        `).join('')}
+    </table>
+</body>
+</html>`;
+  }
+
+  async run(options: {
+    driveIds?: string[];
+    ownerAddresses?: string[];
+    autoDiscover?: boolean;
+    topEntities?: number;
+    verbose?: boolean;
+  }): Promise<void> {
+    console.log('🚀 Starting ClickHouse GraphQL testing...');
+
+    await this.initialize();
+
+    let entitiesToTest: Array<{ type: 'drive' | 'owner'; id: string; transactionCount: number }> = [];
+
+    if (options.autoDiscover) {
+      const { drives, owners } = await this.discoverEntities();
+      const topCount = options.topEntities || Math.min(this.config.discovery.topDrives, this.config.discovery.topOwners);
+
+      entitiesToTest = [
+        ...drives.slice(0, topCount).map(d => ({ type: 'drive' as const, id: d.driveId, transactionCount: d.transactionCount })),
+        ...owners.slice(0, topCount).map(o => ({ type: 'owner' as const, id: o.ownerAddress, transactionCount: o.transactionCount })),
+      ];
+    } else {
+      // Manual testing mode
+      if (options.driveIds) {
+        for (const driveId of options.driveIds) {
+          entitiesToTest.push({ type: 'drive', id: driveId, transactionCount: 0 }); // Count will be determined during testing
+        }
+      }
+      if (options.ownerAddresses) {
+        for (const ownerAddress of options.ownerAddresses) {
+          entitiesToTest.push({ type: 'owner', id: ownerAddress, transactionCount: 0 });
+        }
+      }
+    }
+
+    const results: TestResult[] = [];
+    for (const entity of entitiesToTest) {
+      const result = await this.testEntity(entity);
+      results.push(result);
+    }
+
+    await this.generateReports(results);
+    console.log('\n✅ Testing completed!');
+  }
+}
+
+// CLI parsing and main function
+async function main() {
+  const args = process.argv.slice(2);
+  let config = getDefaultConfig();
+
+  // Parse command line arguments
+  const options: {
+    driveIds?: string[];
+    ownerAddresses?: string[];
+    autoDiscover?: boolean;
+    topEntities?: number;
+    configFile?: string;
+    exportCsv?: string;
+    verbose?: boolean;
+  } = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const nextArg = args[i + 1];
+
+    switch (arg) {
+      case '--config':
+        if (nextArg) {
+          options.configFile = nextArg;
+          i++;
+        }
+        break;
+      case '--drive-id':
+        if (nextArg) {
+          options.driveIds = options.driveIds || [];
+          options.driveIds.push(nextArg);
+          i++;
+        }
+        break;
+      case '--owner':
+        if (nextArg) {
+          options.ownerAddresses = options.ownerAddresses || [];
+          options.ownerAddresses.push(nextArg);
+          i++;
+        }
+        break;
+      case '--auto-discover':
+        options.autoDiscover = true;
+        break;
+      case '--discover-drives':
+        options.autoDiscover = true;
+        // Could add logic to only discover drives
+        break;
+      case '--discover-owners':
+        options.autoDiscover = true;
+        // Could add logic to only discover owners
+        break;
+      case '--top':
+        if (nextArg) {
+          options.topEntities = parseInt(nextArg, 10);
+          i++;
+        }
+        break;
+      case '--sample-size':
+        if (nextArg) {
+          options.topEntities = parseInt(nextArg, 10);
+          i++;
+        }
+        break;
+      case '--clickhouse-url':
+        if (nextArg) {
+          config.clickhouse.url = nextArg;
+          i++;
+        }
+        break;
+      case '--clickhouse-user':
+        if (nextArg) {
+          config.clickhouse.user = nextArg;
+          i++;
+        }
+        break;
+      case '--clickhouse-password':
+        if (nextArg) {
+          config.clickhouse.password = nextArg;
+          i++;
+        }
+        break;
+      case '--local-endpoint':
+        if (nextArg) {
+          config.endpoints.local = nextArg;
+          i++;
+        }
+        break;
+      case '--remote-endpoint':
+        if (nextArg) {
+          config.endpoints.remote = nextArg;
+          i++;
+        }
+        break;
+      case '--export-csv':
+        if (nextArg) {
+          options.exportCsv = nextArg;
+          i++;
+        }
+        break;
+      case '--max-transactions':
+        if (nextArg) {
+          config.testing.maxTransactionsPerEntity = parseInt(nextArg, 10);
+          i++;
+        }
+        break;
+      case '--allow-partial':
+        config.testing.allowPartialComparisons = true;
+        break;
+      case '--complete-only':
+        config.testing.allowPartialComparisons = false;
+        break;
+      case '--verbose':
+      case '-v':
+        options.verbose = true;
+        break;
+      case '--help':
+        console.log(`
+Usage: test-clickhouse-graphql [options]
+
+Environment Variables (read from .env by the wrapper):
+  CORE_PORT                    Local service port (default: 4000)
+                               Used to build http://localhost:\${CORE_PORT}/graphql
+  CLICKHOUSE_HOST              ClickHouse host (default: localhost)
+  CLICKHOUSE_PORT_2            ClickHouse HTTP port (default: 8123)
+  CLICKHOUSE_USER              ClickHouse user (default: default)
+  CLICKHOUSE_PASSWORD          ClickHouse password (no default)
+
+Options:
+  --config <file>              Use configuration file
+  --drive-id <id>              Test specific drive ID
+  --owner <address>            Test specific owner address
+  --auto-discover              Auto-discover entities by transaction count
+  --discover-drives            Discover and test drives
+  --discover-owners            Discover and test owners
+  --top <n>                    Number of top entities to test
+  --sample-size <n>            Alias for --top
+  --clickhouse-url <url>       ClickHouse URL (overrides env var)
+  --clickhouse-user <user>     ClickHouse user (overrides env var)
+  --clickhouse-password <pwd>  ClickHouse password (overrides env var)
+  --local-endpoint <url>       Local GraphQL endpoint (overrides env var)
+  --remote-endpoint <url>      Remote GraphQL endpoint (overrides env var)
+  --export-csv <file>          Export results to CSV file
+  --max-transactions <n>       Override max transactions per entity for complete comparison
+  --allow-partial              Allow partial comparisons (include entities with many transactions)
+  --complete-only              Only test entities where all transactions can be fetched (default)
+  --verbose, -v                Enable verbose mode (show GraphQL queries)
+  --help                       Show this help message
+
+Examples:
+  # Auto-discover and test top 10 entities (uses .env for credentials)
+  test-clickhouse-graphql --auto-discover --top 10
+
+  # Test specific drive with verbose GraphQL query logging
+  test-clickhouse-graphql --drive-id abc123 --verbose
+
+  # Allow partial comparisons for entities with many transactions
+  test-clickhouse-graphql --auto-discover --allow-partial
+
+  # Set custom max transactions per entity for complete comparisons
+  test-clickhouse-graphql --auto-discover --max-transactions 5000
+
+  # Use custom configuration with verbose mode
+  test-clickhouse-graphql --config my-config.json --verbose
+
+Note: The script automatically loads configuration from .env file in the project root.
+        `);
+        process.exit(0);
+        break;
+    }
+  }
+
+  // Load config file if specified
+  if (options.configFile) {
+    try {
+      const configContent = await fs.readFile(options.configFile, 'utf-8');
+      const fileConfig = JSON.parse(configContent);
+      config = { ...config, ...fileConfig };
+    } catch (error) {
+      console.error(`Error loading config file: ${error}`);
+      process.exit(1);
+    }
+  }
+
+  const tester = new ClickHouseGraphQLTester(config, options.verbose);
+  await tester.run(options);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(console.error);
+}
+
+export { ClickHouseGraphQLTester, type TestConfig, type TestResult };

--- a/tools/lib/test-clickhouse-graphql.ts
+++ b/tools/lib/test-clickhouse-graphql.ts
@@ -756,6 +756,8 @@ class ClickHouseGraphQLTester {
     driveIds?: string[];
     ownerAddresses?: string[];
     autoDiscover?: boolean;
+    discoverDrives?: boolean;
+    discoverOwners?: boolean;
     topEntities?: number;
     verbose?: boolean;
   }): Promise<void> {
@@ -765,14 +767,25 @@ class ClickHouseGraphQLTester {
 
     let entitiesToTest: Array<{ type: 'drive' | 'owner'; id: string; transactionCount: number }> = [];
 
-    if (options.autoDiscover) {
+    const anyDiscovery = options.autoDiscover || options.discoverDrives || options.discoverOwners;
+    if (anyDiscovery) {
+      // --auto-discover implies both. --discover-drives / --discover-owners filter to one.
+      const includeDrives = options.autoDiscover || options.discoverDrives;
+      const includeOwners = options.autoDiscover || options.discoverOwners;
+
       const { drives, owners } = await this.discoverEntities();
       const topCount = options.topEntities || Math.min(this.config.discovery.topDrives, this.config.discovery.topOwners);
 
-      entitiesToTest = [
-        ...drives.slice(0, topCount).map(d => ({ type: 'drive' as const, id: d.driveId, transactionCount: d.transactionCount })),
-        ...owners.slice(0, topCount).map(o => ({ type: 'owner' as const, id: o.ownerAddress, transactionCount: o.transactionCount })),
-      ];
+      if (includeDrives) {
+        entitiesToTest.push(
+          ...drives.slice(0, topCount).map(d => ({ type: 'drive' as const, id: d.driveId, transactionCount: d.transactionCount })),
+        );
+      }
+      if (includeOwners) {
+        entitiesToTest.push(
+          ...owners.slice(0, topCount).map(o => ({ type: 'owner' as const, id: o.ownerAddress, transactionCount: o.transactionCount })),
+        );
+      }
     } else {
       // Manual testing mode
       if (options.driveIds) {
@@ -785,6 +798,12 @@ class ClickHouseGraphQLTester {
           entitiesToTest.push({ type: 'owner', id: ownerAddress, transactionCount: 0 });
         }
       }
+    }
+
+    if (entitiesToTest.length === 0) {
+      throw new Error(
+        'No entities selected. Pass --auto-discover, --discover-drives, --discover-owners, --drive-id, or --owner.',
+      );
     }
 
     const results: TestResult[] = [];
@@ -808,9 +827,10 @@ async function main() {
     driveIds?: string[];
     ownerAddresses?: string[];
     autoDiscover?: boolean;
+    discoverDrives?: boolean;
+    discoverOwners?: boolean;
     topEntities?: number;
     configFile?: string;
-    exportCsv?: string;
     verbose?: boolean;
   } = {};
 
@@ -843,12 +863,10 @@ async function main() {
         options.autoDiscover = true;
         break;
       case '--discover-drives':
-        options.autoDiscover = true;
-        // Could add logic to only discover drives
+        options.discoverDrives = true;
         break;
       case '--discover-owners':
-        options.autoDiscover = true;
-        // Could add logic to only discover owners
+        options.discoverOwners = true;
         break;
       case '--top':
         if (nextArg) {
@@ -889,12 +907,6 @@ async function main() {
       case '--remote-endpoint':
         if (nextArg) {
           config.endpoints.remote = nextArg;
-          i++;
-        }
-        break;
-      case '--export-csv':
-        if (nextArg) {
-          options.exportCsv = nextArg;
           i++;
         }
         break;
@@ -940,7 +952,6 @@ Options:
   --clickhouse-password <pwd>  ClickHouse password (overrides env var)
   --local-endpoint <url>       Local GraphQL endpoint (overrides env var)
   --remote-endpoint <url>      Remote GraphQL endpoint (overrides env var)
-  --export-csv <file>          Export results to CSV file
   --max-transactions <n>       Override max transactions per entity for complete comparison
   --allow-partial              Allow partial comparisons (include entities with many transactions)
   --complete-only              Only test entities where all transactions can be fetched (default)
@@ -974,8 +985,19 @@ Note: The script automatically loads configuration from .env file in the project
   if (options.configFile) {
     try {
       const configContent = await fs.readFile(options.configFile, 'utf-8');
-      const fileConfig = JSON.parse(configContent);
-      config = { ...config, ...fileConfig };
+      const fileConfig = JSON.parse(configContent) as Partial<TestConfig>;
+      // Deep-merge each known section so partial config files don't wipe out
+      // sibling defaults (e.g. testing: { pageSize: 50 } should keep the
+      // default maxPagesPerTest etc.).
+      config = {
+        ...config,
+        ...fileConfig,
+        clickhouse: { ...config.clickhouse, ...fileConfig.clickhouse },
+        endpoints: { ...config.endpoints, ...fileConfig.endpoints },
+        discovery: { ...config.discovery, ...fileConfig.discovery },
+        testing: { ...config.testing, ...fileConfig.testing },
+        databaseIntegrity: { ...config.databaseIntegrity, ...fileConfig.databaseIntegrity },
+      };
     } catch (error) {
       console.error(`Error loading config file: ${error}`);
       process.exit(1);
@@ -987,7 +1009,10 @@ Note: The script automatically loads configuration from .env file in the project
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch(console.error);
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
 }
 
 export { ClickHouseGraphQLTester, type TestConfig, type TestResult };

--- a/tools/lib/test-clickhouse-graphql.ts
+++ b/tools/lib/test-clickhouse-graphql.ts
@@ -687,6 +687,23 @@ class ClickHouseGraphQLTester {
   }
 
   private generateHTMLReport(summary: any): string {
+    // Entity IDs (Drive-Id tag values, owner addresses) are attacker-controlled
+    // on-chain data. Escape everything interpolated as text so the report is
+    // safe to open in a browser.
+    const escapeHtml = (value: unknown): string =>
+      String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+
+    const dbIssues = summary.databaseIntegrityIssues;
+    const dbIssuesTotal =
+      (dbIssues?.clickhouseDuplicates ?? 0) +
+      (dbIssues?.graphqlToClickhouseMissing ?? 0) +
+      (dbIssues?.clickhouseToGraphqlMissing ?? 0);
+
     return `
 <!DOCTYPE html>
 <html>
@@ -707,22 +724,22 @@ class ClickHouseGraphQLTester {
     <h1>ClickHouse GraphQL Test Report</h1>
     <div class="summary">
         <h2>Summary</h2>
-        <p><strong>Timestamp:</strong> ${summary.timestamp}</p>
-        <p><strong>Entities Tested:</strong> ${summary.totalEntitiesTested}</p>
-        <p><strong>Transactions Compared:</strong> ${summary.totalTransactionsCompared}</p>
+        <p><strong>Timestamp:</strong> ${escapeHtml(summary.timestamp)}</p>
+        <p><strong>Entities Tested:</strong> ${escapeHtml(summary.totalEntitiesTested)}</p>
+        <p><strong>Transactions Compared:</strong> ${escapeHtml(summary.totalTransactionsCompared)}</p>
         <p><strong>GraphQL Issues Found:</strong> ${summary.issuesSummary.duplicates + summary.issuesSummary.missing + summary.issuesSummary.discrepancies}</p>
         <ul>
-            <li>Duplicates: ${summary.issuesSummary.duplicates}</li>
-            <li>Missing: ${summary.issuesSummary.missing}</li>
-            <li>Discrepancies: ${summary.issuesSummary.discrepancies}</li>
+            <li>Duplicates: ${escapeHtml(summary.issuesSummary.duplicates)}</li>
+            <li>Missing: ${escapeHtml(summary.issuesSummary.missing)}</li>
+            <li>Discrepancies: ${escapeHtml(summary.issuesSummary.discrepancies)}</li>
         </ul>
-        <p><strong>Database Integrity Issues:</strong> ${summary.databaseIntegrityIssues?.clickhouseDuplicates + summary.databaseIntegrityIssues?.graphqlToClickhouseMissing + summary.databaseIntegrityIssues?.clickhouseToGraphqlMissing || 0}</p>
+        <p><strong>Database Integrity Issues:</strong> ${dbIssuesTotal}</p>
         <ul>
-            <li>ClickHouse Duplicates: ${summary.databaseIntegrityIssues?.clickhouseDuplicates || 0}</li>
-            <li>GraphQL→ClickHouse Missing: ${summary.databaseIntegrityIssues?.graphqlToClickhouseMissing || 0}</li>
-            <li>ClickHouse→GraphQL Missing: ${summary.databaseIntegrityIssues?.clickhouseToGraphqlMissing || 0}</li>
-            <li>Critical Issues: ${summary.databaseIntegrityIssues?.totalCritical || 0}</li>
-            <li>Warning Issues: ${summary.databaseIntegrityIssues?.totalWarnings || 0}</li>
+            <li>ClickHouse Duplicates: ${escapeHtml(dbIssues?.clickhouseDuplicates ?? 0)}</li>
+            <li>GraphQL→ClickHouse Missing: ${escapeHtml(dbIssues?.graphqlToClickhouseMissing ?? 0)}</li>
+            <li>ClickHouse→GraphQL Missing: ${escapeHtml(dbIssues?.clickhouseToGraphqlMissing ?? 0)}</li>
+            <li>Critical Issues: ${escapeHtml(dbIssues?.totalCritical ?? 0)}</li>
+            <li>Warning Issues: ${escapeHtml(dbIssues?.totalWarnings ?? 0)}</li>
         </ul>
     </div>
 
@@ -738,9 +755,9 @@ class ClickHouseGraphQLTester {
         <tr><th>Entity Type</th><th>Entity ID</th><th>Transaction Count</th><th>Coverage</th><th>Complete</th><th>GraphQL Issues</th><th>DB Issues</th></tr>
         ${summary.results.map((result: TestResult) => `
             <tr>
-                <td>${result.entity.type}</td>
-                <td>${result.entity.id}</td>
-                <td>${result.entity.transactionCount}</td>
+                <td>${escapeHtml(result.entity.type)}</td>
+                <td>${escapeHtml(result.entity.id)}</td>
+                <td>${escapeHtml(result.entity.transactionCount)}</td>
                 <td>${result.completeness.localCoverage.toFixed(1)}% / ${result.completeness.remoteCoverage.toFixed(1)}%</td>
                 <td>${result.completeness.isComplete ? '✅' : '⚠️'}</td>
                 <td>${result.issues.duplicates.length + result.issues.missing.length + result.issues.discrepancies.length}</td>

--- a/tools/test-clickhouse-graphql
+++ b/tools/test-clickhouse-graphql
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# AR.IO Gateway
+# Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# ClickHouse GraphQL Testing Tool
+#
+# Compares the local AR.IO node GraphQL endpoint against arweave.net for
+# Drive-Id and owner-address queries, and runs database-level integrity
+# checks against the local ClickHouse instance. Generates HTML, JSON, and
+# CSV reports under test-results/runs/<timestamp>/.
+#
+# Usage: ./tools/test-clickhouse-graphql [options]
+# Run with --help for all options.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+
+env_file_args=()
+if [ -f .env ]; then
+  env_file_args=(--env-file=.env)
+fi
+
+exec node "${env_file_args[@]}" --import ./register.js tools/lib/test-clickhouse-graphql.ts "$@"


### PR DESCRIPTION
## Summary

- Adds `./tools/test-clickhouse-graphql`, a tool that diffs the local AR.IO node's GraphQL output against `arweave.net` for Drive-Id and owner-address queries, tests pagination consistency, and runs DB-level integrity checks. Reports written as HTML/JSON/CSV under `test-results/runs/<timestamp>/`.
- Revives the implementation from unmerged branch `PE-8522-automated-indexing-and-graphql-testing` (commit `949f1c1f`, Sep 2025). The doc `tools/CLICKHOUSE_TESTING.md` landed on develop at the time but the code did not — until now it's been orphaned.
- Rewritten to match current ClickHouse schema (no `owner_transactions` table) and current repo conventions (main script in `tools/lib/`, bash wrapper using `node --env-file`, canonical env var names matching `queue-missing-bundles`).

## Why now

Useful for hand-off: weekly-cadence "run this and triage anything red" artifact that surfaces drift between the gateway's ClickHouse-backed GraphQL and the reference arweave.net implementation. Unique in the codebase — the closest analog (`src/tests/auto-verify/`) compares local backends, not cross-endpoint.

## Key changes vs. the original WIP

- **Schema drift fix.** `owner_transactions` doesn't exist in the current schema. Owner discovery / counting / id-listing queries rewritten to aggregate from `transactions` directly; cross-table duplicate detection reduced to a single-table `GROUP BY id HAVING count() > 1`.
- **Repo-convention alignment.** Main `.ts` moved to `tools/lib/`. Wrapper is now a bash one-liner (matches `queue-missing-bundles` et al). Hand-rolled `.env` parser removed in favor of `node --env-file`.
- **Canonical env vars.** Reads `CORE_PORT`, `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT_2`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD` (matching `docker-compose.yaml`). CLI flags still override.
- **TS strict-mode clean.** Typed `@clickhouse/client` response reads; removed unused imports/fields; fixed a `severity` field mismatch.
- **Docs rewritten.** `CLICKHOUSE_TESTING.md` updated to the current flag surface and env vars. `tools/README.md` now links to it.

## Test plan

- [x] `yarn lint:check` clean on `src`/`test`
- [x] `tsc --noEmit` clean on the new `tools/lib/*.ts` files under project's strict config
- [x] `./tools/test-clickhouse-graphql --help` runs end-to-end (wrapper → env → node → main → arg parse → exit)
- [ ] Smoke run against a local ClickHouse + running gateway: `./tools/test-clickhouse-graphql --auto-discover --top 3`
- [ ] Verify `test-results/latest/report.html` renders and `latest` symlink updates between runs

## Follow-ups / known limitations

- No Jira ticket was created; add one after merge if desired.
- Live smoke tests deferred to reviewer (needs a populated local ClickHouse and running gateway).
- Severity heuristic in `ClickHouseIntegrityCheck.checkClickhouseDuplicates` still references `dup.tables.length > 1` — with a single-table query that branch is dead; left as-is since the `count > 2 → critical` heuristic still escalates the interesting cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)