### PR TITLE
docs(deployment): stop recommending START_WRITERS=false for readers

### DIFF
--- a/docs/deployment-topologies.md
+++ b/docs/deployment-topologies.md
@@ -9,10 +9,6 @@ code changes. The wiring is driven by a handful of env vars:
   indexer writes. Supports a `hashPartition` operator (see
   [Filters](filters.md#hash-partition-filter)) for deterministic splits
   by TX ID, owner, etc.
-- `START_WRITERS=false` — disables block/transaction/bundle indexing
-  workers. Appropriate for read-replica roles that consume a shared
-  ClickHouse cluster and accept having no local speed layer above the
-  composite boundary.
 - `CLICKHOUSE_URL` — when set, wraps the SQLite GraphQL queryable with
   `CompositeClickHouseDatabase` (see [ClickHouse Pipeline](clickhouse-pipeline.md)).
   The gateway only knows a single endpoint; replication or sharding is
@@ -83,8 +79,8 @@ flowchart LR
   end
 
   subgraph Readers["Reader gateways"]
-    R1["ar-io-node<br/>START_WRITERS=false<br/>CLICKHOUSE_URL=cluster"]
-    R2["ar-io-node<br/>START_WRITERS=false<br/>CLICKHOUSE_URL=cluster"]
+    R1["ar-io-node<br/>CLICKHOUSE_URL=cluster"]
+    R2["ar-io-node<br/>CLICKHOUSE_URL=cluster"]
   end
 
   subgraph CH["ClickHouse cluster (ReplicatedMergeTree + Keeper)"]
@@ -101,9 +97,11 @@ flowchart LR
   R2 -->|reads| N3
 ```
 
-**When to use.** You want a single authoritative batch layer shared
-across gateways and can afford the Keeper-quorum operational cost.
-Readers scale horizontally without re-indexing.
+**When to use.** You want a single authoritative GraphQL batch layer
+shared across gateways — readers answer `/graphql` out of the cluster
+instead of building their own ClickHouse — and can afford the
+Keeper-quorum operational cost. Readers still index the chain locally
+(see the note below).
 
 **Notes.**
 - ar-io-node itself has no notion of cluster topology — `CLICKHOUSE_URL`
@@ -114,12 +112,13 @@ Readers scale horizontally without re-indexing.
   cluster to avoid redundant imports. The staging/final migration is
   per-partition idempotent, so a duplicate run is recoverable but
   wasteful.
-- Readers with `START_WRITERS=false` have no local speed layer, so
-  heights above the composite boundary are not served at all — there
-  is a gap between the ClickHouse tip and the chain tip bounded by
-  the auto-import sleep interval. Operators who need recent-height
-  coverage on readers should leave writers enabled and accept the
-  duplicated ingest work locally.
+- Readers should keep writers enabled (the default). `START_WRITERS`
+  also gates the chain index (blocks, L1 transactions, bundle
+  membership, data-item → root-TX mappings, offsets), which data
+  retrieval paths like `/raw`, `/ar`, and `/tx/:id` depend on — not
+  just GraphQL. Shared ClickHouse scales query-serving capacity; it
+  does not replace the local SQLite index. The cost is duplicated
+  ingest work on each reader, which is the intended tradeoff.
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove `START_WRITERS=false` from the shared-ClickHouse reader recommendation in `docs/deployment-topologies.md`.
- `START_WRITERS` also gates the chain index (blocks, L1 transactions, bundle membership, data-item → root-TX mappings, offsets), which data retrieval paths like `/raw`, `/ar`, and `/tx/:id` depend on — not just GraphQL.
- Reframe §2 so shared ClickHouse scales GraphQL query capacity; readers keep writers enabled and accept duplicated ingest locally.

## Test plan
- [ ] Render `docs/deployment-topologies.md` on GitHub and confirm §2 diagram and notes read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)