### PR TITLE
fix(deps): move @ardrive/turbo-sdk to dependencies (PE-9074)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@ar.io/sdk": "3.20.0",
     "@ardrive/ardrive-promise-cache": "^1.4.0",
+    "@ardrive/turbo-sdk": "^1.40.2",
     "@aws-lite/client": "^0.23.2",
     "@aws-lite/s3": "^0.2.6",
     "@aws-sdk/client-dynamodb": "^3.968.0",
@@ -115,7 +116,6 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@ardrive/turbo-sdk": "^1.40.2",
     "@aws-lite/s3-types": "^0.2.6",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.36.0",


### PR DESCRIPTION
## Summary

- Move `@ardrive/turbo-sdk@^1.40.2` from `devDependencies` to `dependencies` so it survives the production Docker image's `yarn install --production` prune step.
- The SDK is required at runtime by the HTTPSIG attestation upload path (`src/lib/httpsig-upload.ts`); without this fix `require('@ardrive/turbo-sdk')` throws `MODULE_NOT_FOUND` and the code silently falls back to L1 upload, which fails for gateways without an AR-funded wallet.
- HTTPSIG (r76) is the first runtime use of the SDK in this repo — earlier usage was test-only, which is why the dev-dep classification went unnoticed.

## Test plan

- [x] Local rebuild on a production gateway: `docker compose build core && docker compose up -d core envoy`.
- [x] `docker cp ar-io-node-core-1:/app/node_modules/@ardrive` shows both `ardrive-promise-cache` and `turbo-sdk`.
- [x] HTTPSIG starts clean: `HTTPSIG response signing enabled` followed by `HTTPSIG attestation ready`.
- [x] Signed responses on data endpoints: `signature-input` + `signature` headers present on `/<txId>` responses (verified RFC 9421 sig1, ed25519).
- [x] Existing cached attestation `txId` resolves on `arweave.net` (HTTP 302 → sandbox subdomain).
- [ ] CI green.
- [ ] Reviewer confirms no other code paths in `src/` or `tools/` import `@ardrive/turbo-sdk` only at test time (i.e., the move doesn't pull anything new into the production image that wasn't intended).

Refs: PE-9074

🤖 Generated with [Claude Code](https://claude.com/claude-code)