### PR TITLE
fix(bundles): preserve optimistic data item back-fill (PE-9073)

### DIFF
--- a/src/database/sql/bundles/flush.sql
+++ b/src/database/sql/bundles/flush.sql
@@ -21,6 +21,8 @@ FROM new_data_items ndi
 JOIN core.stable_block_transactions sbt
   ON ndi.root_transaction_id = sbt.transaction_id
 WHERE ndi.height < @end_height
+  AND ndi.parent_id           IS NOT NULL
+  AND ndi.root_transaction_id IS NOT NULL
 ON CONFLICT DO NOTHING;
 
 -- insertOrIgnoreStableDataItemTags
@@ -40,4 +42,6 @@ JOIN new_data_items ndi
 JOIN core.stable_block_transactions sbt
   ON ndit.root_transaction_id = sbt.transaction_id
 WHERE ndit.height < @end_height
+  AND ndi.parent_id           IS NOT NULL
+  AND ndi.root_transaction_id IS NOT NULL
 ON CONFLICT DO NOTHING;

--- a/src/database/sql/bundles/import.sql
+++ b/src/database/sql/bundles/import.sql
@@ -134,7 +134,7 @@ INSERT INTO new_data_items (
   @root_parent_offset
 ) ON CONFLICT DO
 UPDATE SET
-  height = IFNULL(@height, height),
-  root_transaction_id = @root_transaction_id,
-  parent_id = @parent_id,
-  data_offset = @data_offset
+  height              = IFNULL(@height,              height),
+  root_transaction_id = COALESCE(@root_transaction_id, root_transaction_id),
+  parent_id           = COALESCE(@parent_id,           parent_id),
+  data_offset         = COALESCE(@data_offset,         data_offset)

--- a/src/database/sql/bundles/import.sql
+++ b/src/database/sql/bundles/import.sql
@@ -120,6 +120,18 @@ UPDATE SET
   last_indexed_at = @indexed_at
 
 -- upsertNewDataItem
+--
+-- Tuple consistency note: the fields {parent_id, root_transaction_id,
+-- root_parent_offset, data_offset, offset, size, signature_offset,
+-- signature_size, owner_offset, owner_size, signature_type} describe a
+-- single bundling ("root atom") and ought to move atomically. The
+-- COALESCE clauses below cover only the three immediately involved in
+-- the PE-9073 chain-stall (parent_id, root_transaction_id, data_offset)
+-- plus the IFNULL on height. The remaining root-atom fields are
+-- INSERT-only — an admin POST that arrives before the unbundle path
+-- will leave them NULL on later unbundle writes. The structural fix
+-- (split this statement into an optimistic-only insert and a
+-- root-atom upsert) is tracked as a follow-up to PE-9073.
 INSERT INTO new_data_items (
   id, parent_id, root_transaction_id, height, signature, anchor,
   owner_address, target, data_offset, data_size, content_type,

--- a/src/database/standalone-sqlite.test.ts
+++ b/src/database/standalone-sqlite.test.ts
@@ -1599,11 +1599,47 @@ describe('StandaloneSqliteDatabase', () => {
         'data_offset must survive optimistic re-POST',
       );
       assert.deepEqual(row!.parent_id, fromB64Url(bundleParentId));
-      assert.deepEqual(
-        row!.root_transaction_id,
-        fromB64Url(bundleRootTxId),
-      );
+      assert.deepEqual(row!.root_transaction_id, fromB64Url(bundleRootTxId));
       assert.equal(row!.data_offset, 100);
+
+      // Now exercise the flush path that previously hit
+      // SQLITE_CONSTRAINT_NOTNULL on stable_data_item_tags.parent_id
+      // (Defect A). Force heights non-NULL on both the data item and
+      // its tag rows, then make bundleRootTxId stable so the flush JOINs
+      // match.
+      const dataItemHeight = 100;
+      bundlesDb
+        .prepare('UPDATE new_data_items SET height = @h WHERE id = @id')
+        .run({ h: dataItemHeight, id: fromB64Url(itemId) });
+      bundlesDb
+        .prepare(
+          'UPDATE new_data_item_tags SET height = @h WHERE data_item_id = @id',
+        )
+        .run({ h: dataItemHeight, id: fromB64Url(itemId) });
+      coreDb
+        .prepare(
+          `INSERT INTO stable_block_transactions (
+             block_indep_hash, transaction_id, block_transaction_index
+           ) VALUES (@hash, @tx, 0)`,
+        )
+        .run({
+          hash: crypto.randomBytes(32),
+          tx: fromB64Url(bundleRootTxId),
+        });
+
+      // Pre-fix this throws inside the worker transaction. With the fix
+      // (back-fill preserved by COALESCE; flush guarded by IS NOT NULL),
+      // it completes and the row lands in stable_data_items.
+      await db.flushStableDataItems(dataItemHeight + 1, Date.now());
+
+      const stableRow = bundlesDb
+        .prepare('SELECT id FROM stable_data_items WHERE id = @id')
+        .get({ id: fromB64Url(itemId) });
+      assert.notEqual(
+        stableRow,
+        undefined,
+        'data item should land in stable_data_items after flush',
+      );
     });
   });
 

--- a/src/database/standalone-sqlite.test.ts
+++ b/src/database/standalone-sqlite.test.ts
@@ -1506,6 +1506,107 @@ describe('StandaloneSqliteDatabase', () => {
     });
   });
 
+  describe('upsertNewDataItem clobber resistance (PE-9073)', () => {
+    // Regression: after the unbundle path back-fills parent_id /
+    // root_transaction_id / data_offset on a previously-optimistic data item,
+    // a subsequent optimistic re-POST (which passes NULL for those fields)
+    // must NOT clobber the back-filled values. Without this, a follow-up
+    // flushStableDataItems would crash on stable_data_item_tags.parent_id
+    // NOT NULL.
+    const itemId = 'PE9073RegressionTestPE9073RegressionTestAAA';
+    const bundleParentId = '2222222222222222222222222222222222222222222';
+    const bundleRootTxId = '3333333333333333333333333333333333333333333';
+
+    const optimisticItem = {
+      anchor: 'YW5jaG9y',
+      data_hash: null,
+      data_offset: null,
+      data_size: 1234,
+      id: itemId,
+      index: null,
+      offset: null,
+      owner: 'b3duZXI',
+      owner_address: 'b3duZXJfYWRkcmVzcw',
+      owner_offset: null,
+      owner_size: null,
+      parent_id: null,
+      parent_index: null,
+      root_parent_offset: null,
+      root_tx_id: null,
+      signature: 'c2lnbmF0dXJl',
+      signature_offset: null,
+      signature_size: null,
+      signature_type: null,
+      size: null,
+      tags: [],
+      target: 'dGFyZ2V0',
+    } as unknown as NormalizedDataItem;
+
+    const bundleBackfillItem = {
+      ...optimisticItem,
+      data_offset: 100,
+      filter: '{"always": true}',
+      index: 0,
+      offset: 200,
+      owner_offset: 50,
+      owner_size: 32,
+      parent_id: bundleParentId,
+      parent_index: 0,
+      root_parent_offset: 300,
+      root_tx_id: bundleRootTxId,
+      signature_offset: 60,
+      signature_size: 32,
+      signature_type: 1,
+      size: 1234,
+    } as unknown as NormalizedDataItem;
+
+    it('preserves back-filled parent_id, root_transaction_id, data_offset on optimistic re-POST', async () => {
+      // 1. Optimistic POST: row inserted with NULL parent_id / root_transaction_id / data_offset.
+      await db.saveDataItem(optimisticItem);
+
+      // 2. Unbundle back-fill: same id, non-NULL values via upsert.
+      await db.saveDataItem(bundleBackfillItem);
+
+      // 3. Optimistic re-POST. Pre-fix this clobbered values back to NULL.
+      await db.saveDataItem(optimisticItem);
+
+      const row = bundlesDb
+        .prepare(
+          'SELECT parent_id, root_transaction_id, data_offset FROM new_data_items WHERE id = @id',
+        )
+        .get({ id: fromB64Url(itemId) }) as
+        | {
+            parent_id: Buffer | null;
+            root_transaction_id: Buffer | null;
+            data_offset: number | null;
+          }
+        | undefined;
+
+      assert.notEqual(row, undefined, 'data item row should exist');
+      assert.notEqual(
+        row!.parent_id,
+        null,
+        'parent_id must survive optimistic re-POST',
+      );
+      assert.notEqual(
+        row!.root_transaction_id,
+        null,
+        'root_transaction_id must survive optimistic re-POST',
+      );
+      assert.notEqual(
+        row!.data_offset,
+        null,
+        'data_offset must survive optimistic re-POST',
+      );
+      assert.deepEqual(row!.parent_id, fromB64Url(bundleParentId));
+      assert.deepEqual(
+        row!.root_transaction_id,
+        fromB64Url(bundleRootTxId),
+      );
+      assert.equal(row!.data_offset, 100);
+    });
+  });
+
   // skipping for now as it works when running the test individually
   describe.skip('saveVerificationStatus', () => {
     const dataItemRootTxId = '0000000000000000000000000000000000000000000';

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -439,21 +439,45 @@ export interface QueueDataItemHeaders {
   content_type?: string;
   target?: string;
   anchor?: string;
+  // Optional. Caller may pre-populate these when known (e.g., a partial
+  // re-POST after the unbundle path has back-filled). Forwarded to
+  // upsertNewDataItem; null/undefined leaves the columns alone (preserves
+  // back-fill via COALESCE).
+  data_offset?: number | null;
+  parent_id?: string | null;
+  root_tx_id?: string | null;
 }
 
 /** Type guard for ensuring required fields on incoming data item headers */
 export function isDataItemHeaders(
   dataItemHeader: unknown,
 ): dataItemHeader is QueueDataItemHeaders {
-  return (
-    typeof dataItemHeader === 'object' &&
-    dataItemHeader !== null &&
-    'data_size' in dataItemHeader &&
-    'id' in dataItemHeader &&
-    'owner' in dataItemHeader &&
-    'owner_address' in dataItemHeader &&
-    'signature' in dataItemHeader
-  );
+  if (
+    typeof dataItemHeader !== 'object' ||
+    dataItemHeader === null ||
+    !('data_size' in dataItemHeader) ||
+    !('id' in dataItemHeader) ||
+    !('owner' in dataItemHeader) ||
+    !('owner_address' in dataItemHeader) ||
+    !('signature' in dataItemHeader)
+  ) {
+    return false;
+  }
+
+  // Optional fields newly forwarded to upsertNewDataItem must be the
+  // expected type when present, else SQLite type coercion accepts garbage
+  // that downstream code reads as the wrong type.
+  const h = dataItemHeader as Record<string, unknown>;
+  if (h.data_offset != null && typeof h.data_offset !== 'number') {
+    return false;
+  }
+  if (h.parent_id != null && typeof h.parent_id !== 'string') {
+    return false;
+  }
+  if (h.root_tx_id != null && typeof h.root_tx_id !== 'string') {
+    return false;
+  }
+  return true;
 }
 
 // Queue a bundle data item for processing

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -487,18 +487,21 @@ arIoRouter.post(
             tags: dataItemHeader.tags ?? [],
             target: dataItemHeader.target ?? '',
             anchor: dataItemHeader.anchor ?? '',
+            // Default null when caller omits; preserved by COALESCE in
+            // upsertNewDataItem so subsequent re-POSTs don't clobber values
+            // backfilled by the unbundle path.
+            data_offset: dataItemHeader.data_offset ?? null,
+            parent_id: dataItemHeader.parent_id ?? null,
+            root_tx_id: dataItemHeader.root_tx_id ?? null,
             // These fields are not yet known, to be backfilled
             data_hash: null,
-            data_offset: null,
             filter: config.ANS104_INDEX_FILTER_STRING,
             index: null,
             offset: null,
             owner_offset: null,
             owner_size: null,
-            parent_id: null,
             parent_index: null,
             root_parent_offset: null,
-            root_tx_id: null,
             signature_offset: null,
             signature_size: null,
             signature_type: null,

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -439,45 +439,21 @@ export interface QueueDataItemHeaders {
   content_type?: string;
   target?: string;
   anchor?: string;
-  // Optional. Caller may pre-populate these when known (e.g., a partial
-  // re-POST after the unbundle path has back-filled). Forwarded to
-  // upsertNewDataItem; null/undefined leaves the columns alone (preserves
-  // back-fill via COALESCE).
-  data_offset?: number | null;
-  parent_id?: string | null;
-  root_tx_id?: string | null;
 }
 
 /** Type guard for ensuring required fields on incoming data item headers */
 export function isDataItemHeaders(
   dataItemHeader: unknown,
 ): dataItemHeader is QueueDataItemHeaders {
-  if (
-    typeof dataItemHeader !== 'object' ||
-    dataItemHeader === null ||
-    !('data_size' in dataItemHeader) ||
-    !('id' in dataItemHeader) ||
-    !('owner' in dataItemHeader) ||
-    !('owner_address' in dataItemHeader) ||
-    !('signature' in dataItemHeader)
-  ) {
-    return false;
-  }
-
-  // Optional fields newly forwarded to upsertNewDataItem must be the
-  // expected type when present, else SQLite type coercion accepts garbage
-  // that downstream code reads as the wrong type.
-  const h = dataItemHeader as Record<string, unknown>;
-  if (h.data_offset != null && typeof h.data_offset !== 'number') {
-    return false;
-  }
-  if (h.parent_id != null && typeof h.parent_id !== 'string') {
-    return false;
-  }
-  if (h.root_tx_id != null && typeof h.root_tx_id !== 'string') {
-    return false;
-  }
-  return true;
+  return (
+    typeof dataItemHeader === 'object' &&
+    dataItemHeader !== null &&
+    'data_size' in dataItemHeader &&
+    'id' in dataItemHeader &&
+    'owner' in dataItemHeader &&
+    'owner_address' in dataItemHeader &&
+    'signature' in dataItemHeader
+  );
 }
 
 // Queue a bundle data item for processing
@@ -511,21 +487,21 @@ arIoRouter.post(
             tags: dataItemHeader.tags ?? [],
             target: dataItemHeader.target ?? '',
             anchor: dataItemHeader.anchor ?? '',
-            // Default null when caller omits; preserved by COALESCE in
-            // upsertNewDataItem so subsequent re-POSTs don't clobber values
-            // backfilled by the unbundle path.
-            data_offset: dataItemHeader.data_offset ?? null,
-            parent_id: dataItemHeader.parent_id ?? null,
-            root_tx_id: dataItemHeader.root_tx_id ?? null,
-            // These fields are not yet known, to be backfilled
+            // These fields are not yet known, to be backfilled. Re-POSTs
+            // pass NULL here and rely on the COALESCE in upsertNewDataItem
+            // (PE-9073) to preserve any values back-filled by the unbundle
+            // path.
             data_hash: null,
+            data_offset: null,
             filter: config.ANS104_INDEX_FILTER_STRING,
             index: null,
             offset: null,
             owner_offset: null,
             owner_size: null,
+            parent_id: null,
             parent_index: null,
             root_parent_offset: null,
+            root_tx_id: null,
             signature_offset: null,
             signature_size: null,
             signature_type: null,


### PR DESCRIPTION
## Summary

Two interacting defects in `bundles.db` cause the indexer SQLite worker to crash and silently regress correctly back-filled state when the optimistic data-item admin endpoint (`/ar-io/admin/queue-data-item`, used by Turbo) is in use. Result on a live gateway: chain ingestion blocked at every flush-trigger height; 246k+ orphaned rows with NULL `parent_id`; 5.3 GB WAL.

### Defect A — flush violates NOT NULL on `stable_data_item_tags.parent_id`

`bundles/flush.sql:insertOrIgnoreStableDataItemTags` selected `new_data_items.parent_id` (nullable since the 2024-06-13 nullable-parent-and-root migration) into `stable_data_item_tags.parent_id` (NOT NULL, never relaxed). Whenever a tag row had a non-NULL `root_transaction_id` pointing at a now-stable block but the parent data item had `parent_id IS NULL`, `flushStableDataItems` raised `SQLITE_CONSTRAINT_NOTNULL`. The transaction rolled back, `saveBlockAndTxs` propagated the error, and block ingestion stopped advancing past that height.

### Defect B — `upsertNewDataItem` clobbers back-filled values with NULLs

`bundles/import.sql:upsertNewDataItem` ON CONFLICT DO UPDATE unconditionally overwrote `parent_id`, `root_transaction_id`, and `data_offset` with the incoming params. The admin endpoint at `routes/ar-io.ts` hard-coded `parent_id: null, root_tx_id: null, data_offset: null` in its spread, so every re-POST after an unbundle reset correctly back-filled values to NULL — exactly the input that fed Defect A on the next flush.

### Repro

1. POST a data item to `/ar-io/admin/queue-data-item` (NULL parent_id).
2. Wait for the indexer to unbundle the containing bundle (parent_id back-filled to bundle id).
3. POST the same data item again (parent_id reset to NULL by Defect B).
4. When the data item's tag row's `root_transaction_id` becomes part of a stable block, the next flush throws (Defect A); ingestion halts.

## Fix

- **`flush.sql`**: skip rows where `parent_id` or `root_transaction_id` IS NULL in both `insertOrIgnoreStableDataItems` and `insertOrIgnoreStableDataItemTags`. Orphans stay queryable in `new_*` until back-filled.
- **`import.sql`**: use `COALESCE(@param, existing)` for `parent_id`, `root_transaction_id`, and `data_offset` in `upsertNewDataItem` so NULL re-POSTs don't overwrite populated values. A block comment documents the remaining INSERT-only root-atom fields and the structural follow-up.
- **`standalone-sqlite.test.ts`**: regression test exercising the failure path (optimistic POST → unbundle back-fill → optimistic re-POST → flush), asserting all three columns survive AND the row lands in `stable_data_items` without throwing.

The `routes/ar-io.ts` widening that originally landed in commit `704039bf` was reverted in commit `6986343b` — admin endpoint stays a pure optimistic path with hard-coded NULLs for the bundling fields. Fix 2 alone is load-bearing for the chain-stall.

## Risk analysis

| Axis | Verdict |
|---|---|
| Correctness | Behavior changes only in the `@param IS NULL` upsert case (the bug) and the NULL-`parent_id` flush case (the crash). No other code path relied on either behavior. |
| Reorgs | `height-reset.sql` only nulls `height`; never touches `parent_id` / `root_transaction_id`. COALESCE doesn't interact with reorg handling. |
| Performance | Fix 1 adds index-friendly `IS NOT NULL` predicates; Fix 2 adds three `COALESCE` calls per upsert. Both negligible. |
| Schema | None. Statement-level changes only, no migration. |
| Caller compatibility | Verified the only callers of `saveDataItem` (`data-item-indexer`, `tx-metadata-resolver`, the admin route). None rely on clobber-to-NULL semantics. |

## Recovery

- **Orphans whose bundles haven't been unbundled yet**: heal automatically the next time their containing bundle is unbundled.
- **Orphans whose bundles were already unbundled and then NULL-clobbered by a later optimistic POST** (the 320/320 case in the original analysis): no automatic re-trigger. The new flush filter excludes them (good), but they linger in `new_data_items` until the height-threshold stale cleanup eventually deletes them. A one-shot repair (repopulate `parent_id` / `root_transaction_id` / `data_offset` from the corresponding `bundle_data_items` row) is filed as a follow-up.

## Out of scope (separate tickets)

- **Two-statement split for tuple consistency** (per review): the {parent_id, root_transaction_id, root_parent_offset, data_offset, offset, size, signature_offset, signature_size, owner_offset, owner_size, signature_type} fields form a "root atom" that should move atomically. Per-column COALESCE prevents NULL-clobber but doesn't enforce group consistency, and the remaining INSERT-only fields (root_parent_offset, the offset/size pairs, signature_type) are silently shadowed when admin POST creates the row before unbundle. Structural fix is to split `upsertNewDataItem` into `insertOptimisticDataItem` (admin path; never touches the tuple) and `upsertNewDataItemWithRootAtom` (unbundle path; atomic root-atom write with non-NULL `parent_id` validated). Out of scope for the chain-stall hotfix.
- **One-shot repair for already-clobbered rows** (the 320/320 case described above).
- **Tag-row PK** in `new_data_item_tags`: the current PK includes `root_transaction_id` so NULL accumulates distinct rows under repeated optimistic POSTs. Drop `root_transaction_id` from the PK; long tail behind WAL bloat.
- **`bundles.db-wal` size on the affected gateway** — should checkpoint normally once flushes stop crashing; monitor on rollout, manual `PRAGMA wal_checkpoint(TRUNCATE)` if needed.
- **Bundle queue backlog** (102k+ queued ∧ never unbundled on the affected host).

## Test plan

- [x] `yarn build`, `yarn lint:check`, `yarn test:ci` — green in CI.
- [x] Regression test exercises both Defect B (clobber preserved) and the headline crash from Defect A (flush completes, row lands in `stable_data_items`).
- [ ] Reviewer confirms no other code paths rely on clobber-to-NULL semantics in `upsertNewDataItem`.
- [ ] Deploy on the affected gateway (turbo-gw-fsn1-2): observe `flushStableDataItems` no longer throws; chain head advances past 1,905,193; WAL checkpoint resumes.

Refs: PE-9073

🤖 Generated with [Claude Code](https://claude.com/claude-code)