### PR TITLE
fix(arns): fall back to cached resolution on undefined fresh result (PE-9075)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `X-AR-IO-Data-Id` (or for the resolved id of `unregistered_arns` on
   default-config gateways) and remove matches.
 
+- **ArNS cached fallback on fast-fail (PE-9075)**:
+  `CompositeArNSResolver` previously fell back to a cached resolution
+  only when fresh resolution exceeded
+  `ARNS_CACHED_RESOLUTION_FALLBACK_TIMEOUT_MS`. When fresh resolution
+  returned `undefined` faster than the timeout (names cache miss,
+  AO/CU dry-run error swallowed to undefined), the fallback didn't
+  fire and the gateway dropped through to `ARNS_NOT_FOUND_ARNS_NAME`
+  — serving the "unregistered" placeholder for names with valid
+  cached resolutions during AO/CU flaps. Now falls back to the
+  cached resolution whenever fresh has no resolved id, matching the
+  comment-documented intent. New metric
+  `arns_cached_resolution_fallback_on_empty_total` counts how often
+  this fires.
+
 ## [Release 77] - 2026-04-24
 
 This is a **recommended release** focused on **cross-gateway GraphQL

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -253,6 +253,12 @@ export const arnsCacheMissCounter = new promClient.Counter({
   help: 'Number of misses in the arns cache',
 });
 
+export const arnsCachedResolutionFallbackOnEmptyCounter =
+  new promClient.Counter({
+    name: 'arns_cached_resolution_fallback_on_empty_total',
+    help: 'Count of times CompositeArNSResolver returned a cached resolution because fresh resolution had no resolved id (no error/timeout)',
+  });
+
 export const arnsNameCacheDurationSummary = new promClient.Summary({
   name: 'arns_name_cache_duration_ms',
   help: 'Time in ms it takes to fetch and cache arns base names',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -253,6 +253,13 @@ export const arnsCacheMissCounter = new promClient.Counter({
   help: 'Number of misses in the arns cache',
 });
 
+/**
+ * Incremented when {@link CompositeArNSResolver} returns a cached resolution
+ * because a fresh resolution attempt resolved with no resolved id — distinct
+ * from the timeout-triggered cached fallback. Tracks how often the gateway
+ * is serving stale data due to upstream (names cache / AO / CU) returning
+ * `undefined` faster than the cached-resolution fallback timeout.
+ */
 export const arnsCachedResolutionFallbackOnEmptyCounter =
   new promClient.Counter({
     name: 'arns_cached_resolution_fallback_on_empty_total',

--- a/src/resolution/composite-arns-resolver.test.ts
+++ b/src/resolution/composite-arns-resolver.test.ts
@@ -194,6 +194,134 @@ describe('CompositeArNSResolver', () => {
     });
   });
 
+  it('falls back to cached resolution when fresh resolver returns undefined fast (PE-9075)', async () => {
+    const now = Date.now();
+    const expiredCachedResolution: NameResolution = {
+      name: 'test.ar',
+      resolvedId: 'cached-tx',
+      resolvedAt: now - 1_000_000, // expired (resolvedAt + ttl*1000 < now)
+      ttl: 300,
+      processId: 'process1',
+      limit: 1,
+      index: 1,
+    };
+
+    mock.method(mockResolutionCache, 'get', async () =>
+      Buffer.from(JSON.stringify(expiredCachedResolution)),
+    );
+
+    const resolver1: NameResolver = {
+      resolve: mock.fn(async () => {
+        // Fast-fail: throws synchronously, resolveParallel returns undefined
+        // well within arnsCachedResolutionFallbackTimeoutMs.
+        throw new Error('AO/CU dry-run failed');
+      }),
+    };
+
+    const compositeResolver = new CompositeArNSResolver({
+      log,
+      resolvers: [resolver1],
+      resolutionCache: mockResolutionCache,
+      registryCache: mockRegistryCache,
+      arnsNamesCache: {} as ArNSNamesCache, // unused, avoids unawaited promises
+      maxConcurrentResolutions: 1,
+      resolverTimeoutMs: 1000,
+      arnsCachedResolutionFallbackTimeoutMs: 1000,
+    });
+
+    const result = await compositeResolver.resolve({ name: 'test.ar' });
+
+    assert.strictEqual((resolver1.resolve as any).mock.calls.length, 1);
+    assert.deepEqual(result, expiredCachedResolution);
+  });
+
+  it('falls back to cached resolution when fresh resolver exceeds the cached-resolution fallback timeout', async () => {
+    const now = Date.now();
+    const expiredCachedResolution: NameResolution = {
+      name: 'test.ar',
+      resolvedId: 'cached-tx',
+      resolvedAt: now - 1_000_000,
+      ttl: 300,
+      processId: 'process1',
+      limit: 1,
+      index: 1,
+    };
+
+    mock.method(mockResolutionCache, 'get', async () =>
+      Buffer.from(JSON.stringify(expiredCachedResolution)),
+    );
+
+    const resolver1: NameResolver = {
+      resolve: mock.fn(
+        async () =>
+          new Promise<NameResolution>((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  name: 'test.ar',
+                  resolvedId: 'fresh-tx',
+                  resolvedAt: Date.now(),
+                  ttl: 300,
+                  processId: 'process1',
+                  limit: 1,
+                  index: 1,
+                }),
+              500,
+            ),
+          ),
+      ),
+    };
+
+    const compositeResolver = new CompositeArNSResolver({
+      log,
+      resolvers: [resolver1],
+      resolutionCache: mockResolutionCache,
+      registryCache: mockRegistryCache,
+      arnsNamesCache: {} as ArNSNamesCache, // unused, avoids unawaited promises
+      maxConcurrentResolutions: 1,
+      resolverTimeoutMs: 1000,
+      lastResolverTimeoutMs: 1000,
+      arnsCachedResolutionFallbackTimeoutMs: 50,
+    });
+
+    const result = await compositeResolver.resolve({ name: 'test.ar' });
+
+    assert.deepEqual(result, expiredCachedResolution);
+  });
+
+  it('returns undefined resolution when fresh resolver fast-fails AND no cached resolution exists (PE-9075)', async () => {
+    mock.method(mockResolutionCache, 'get', async () => undefined);
+
+    const resolver1: NameResolver = {
+      resolve: mock.fn(async () => {
+        throw new Error('AO/CU dry-run failed');
+      }),
+    };
+
+    const compositeResolver = new CompositeArNSResolver({
+      log,
+      resolvers: [resolver1],
+      resolutionCache: mockResolutionCache,
+      registryCache: mockRegistryCache,
+      arnsNamesCache: {} as ArNSNamesCache, // unused, avoids unawaited promises
+      maxConcurrentResolutions: 1,
+      resolverTimeoutMs: 1000,
+      arnsCachedResolutionFallbackTimeoutMs: 1000,
+    });
+
+    const result = await compositeResolver.resolve({ name: 'test.ar' });
+
+    assert.deepEqual(result, {
+      name: 'test.ar',
+      resolvedId: undefined,
+      resolvedAt: undefined,
+      ttl: undefined,
+      processId: undefined,
+      limit: undefined,
+      index: undefined,
+    });
+  });
+
   it('should respect maxConcurrentResolutions limit', async () => {
     let activeResolutions = 0;
     let maxActiveResolutions = 0;

--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -348,8 +348,8 @@ export class CompositeArNSResolver implements NameResolver {
       // resolution returns no resolved id or we exceed the cached resolution
       // fallback timeout.
       let usedCachedFallback = false;
-      const fresh = await (cachedResolution
-        ? // Cached resultion exists
+      const resolution = await (cachedResolution
+        ? // Cached resolution exists
           pTimeout(
             this.resolveParallel({
               name,
@@ -379,20 +379,22 @@ export class CompositeArNSResolver implements NameResolver {
             parentSpan: span,
           }));
 
-      // pTimeout's `fallback` only fires on timeout — when it fires, `fresh`
-      // is the cached resolution returned by the fallback. Surface that path
-      // first so the on-empty metric below is never confused with a timeout.
-      if (usedCachedFallback) {
+      // pTimeout's `fallback` only fires on timeout — when it fires,
+      // `resolution` is the cached value returned by the fallback. Surface
+      // that path first so the on-empty metric below is never confused with
+      // a timeout. The `&& cachedResolution` guard narrows the type and is
+      // defensive against future drift around the ternary above.
+      if (usedCachedFallback && cachedResolution) {
         span.addEvent('Resolved by cache fallback');
-        return fresh as NameResolution;
+        return cachedResolution;
       }
       // If fresh resolution resolved fast with no resolved id (e.g.,
       // names-cache miss, AO/CU dry-run error swallowed to undefined), still
       // prefer the cached resolution if one exists. Matches the
       // comment-documented intent of "fall back if error occurs OR timeout".
-      if (fresh?.resolvedId !== undefined) {
+      if (resolution?.resolvedId !== undefined) {
         span.addEvent('Resolved by fresh resolution');
-        return fresh;
+        return resolution;
       }
       if (cachedResolution) {
         span.addEvent(

--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -344,10 +344,11 @@ export class CompositeArNSResolver implements NameResolver {
       metrics.arnsCacheMissCounter.inc();
       this.log.verbose('Resolution cache miss for ArNS name', { name });
 
-      // If there is a cached resolution, fall back to it if either an error
-      // occurs or we exceed the cached resolution fallback timeout
+      // If there is a cached resolution, fall back to it if either fresh
+      // resolution returns no resolved id or we exceed the cached resolution
+      // fallback timeout.
       let usedCachedFallback = false;
-      const resolution = await (cachedResolution
+      const fresh = await (cachedResolution
         ? // Cached resultion exists
           pTimeout(
             this.resolveParallel({
@@ -378,13 +379,25 @@ export class CompositeArNSResolver implements NameResolver {
             parentSpan: span,
           }));
 
-      if (resolution) {
-        if (usedCachedFallback) {
-          span.addEvent('Resolved by cache fallback');
-        } else {
-          span.addEvent('Resolved by fresh resolution');
-        }
-        return resolution;
+      // pTimeout's `fallback` only fires on timeout. If fresh resolution
+      // resolved fast with no resolved id (e.g., names-cache miss, AO/CU
+      // dry-run error swallowed to undefined), still prefer the cached
+      // resolution if one exists. Matches the comment-documented intent of
+      // "fall back if error occurs OR timeout".
+      if (fresh?.resolvedId !== undefined) {
+        span.addEvent(
+          usedCachedFallback
+            ? 'Resolved by cache fallback'
+            : 'Resolved by fresh resolution',
+        );
+        return fresh;
+      }
+      if (cachedResolution) {
+        span.addEvent(
+          'Using cached resolution due to fresh-resolution returning no id',
+        );
+        metrics.arnsCachedResolutionFallbackOnEmptyCounter.inc();
+        return cachedResolution;
       }
 
       span.addEvent('Unable to resolve name');

--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -379,17 +379,19 @@ export class CompositeArNSResolver implements NameResolver {
             parentSpan: span,
           }));
 
-      // pTimeout's `fallback` only fires on timeout. If fresh resolution
-      // resolved fast with no resolved id (e.g., names-cache miss, AO/CU
-      // dry-run error swallowed to undefined), still prefer the cached
-      // resolution if one exists. Matches the comment-documented intent of
-      // "fall back if error occurs OR timeout".
+      // pTimeout's `fallback` only fires on timeout — when it fires, `fresh`
+      // is the cached resolution returned by the fallback. Surface that path
+      // first so the on-empty metric below is never confused with a timeout.
+      if (usedCachedFallback) {
+        span.addEvent('Resolved by cache fallback');
+        return fresh as NameResolution;
+      }
+      // If fresh resolution resolved fast with no resolved id (e.g.,
+      // names-cache miss, AO/CU dry-run error swallowed to undefined), still
+      // prefer the cached resolution if one exists. Matches the
+      // comment-documented intent of "fall back if error occurs OR timeout".
       if (fresh?.resolvedId !== undefined) {
-        span.addEvent(
-          usedCachedFallback
-            ? 'Resolved by cache fallback'
-            : 'Resolved by fresh resolution',
-        );
+        span.addEvent('Resolved by fresh resolution');
         return fresh;
       }
       if (cachedResolution) {


### PR DESCRIPTION
## Summary

- Fixes `CompositeArNSResolver` to fall back to a cached resolution when the fresh resolver returns `undefined` quickly, not only on `pTimeout` timeout.
- Matches the comment-documented intent ("fall back if error occurs OR timeout") that the previous implementation only partially honored.
- Adds `arns_cached_resolution_fallback_on_empty_total` counter for observability.

## Why

When AO/CU dry-runs fail fast (or the ArNS names cache fast-misses recently-registered names), `resolveParallel` resolves with `undefined` inside the timeout window. `pTimeout`'s `fallback` fires only on actual timeouts, so the gateway dropped through to `ARNS_NOT_FOUND_ARNS_NAME` and served the "Make this domain space yours" placeholder for names that had perfectly good (recently expired) cached resolutions.

Confirmed live on production: `sol.ar.io` and other names showing the placeholder during AO/CU flaps despite having usable cached resolutions in `KvArNSResolutionStore`.

## Test plan

- [x] `yarn test src/resolution/composite-arns-resolver.test.ts` — three new tests pass (9/9 in file)
- [x] `yarn test` (full suite) — 1703/1703 pass, 4 skipped, 0 fail
- [x] `yarn lint:check` — clean
- [x] `yarn build` — clean
- [ ] Manual smoke against staging gateway: trigger AO unreachability, observe cached fallback in span events (`Using cached resolution due to fresh-resolution returning no id`) and metric increments

## Risk / rollback

| Risk | Mitigation |
|---|---|
| Cached fallback returns very stale data when AO is down for hours | Bounded by `ARNS_CACHE_TTL_SECONDS` (default 30d). Operators can lower it for tighter freshness. |
| Cached fallback hides AO outages from monitoring | New `arns_cached_resolution_fallback_on_empty_total` counter makes it visible. Alert on rate-of-change. |
| Logs go quieter during AO flaps (old code emitted "Unable to resolve name" warning; new code only logs that when both fresh and cache are empty) | Use the new counter for alerting instead. |
| Test mocks don't catch a real edge case | Manual smoke against staging before merge. |

**Rollback:** revert the commit. The change is localized to one function in one file; revert is clean. No DB/state migration.

## Out of scope (deferred to separate PRs)

- **Bound max-staleness for cached fallback** (e.g., refuse cached if `resolvedAt + ttl * N < now`). Worth doing but adds a knob; address separately based on observed metric rates after merge.
- **Document `ARNS_CACHED_RESOLUTION_FALLBACK_TIMEOUT_MS` in `docs/envs.md`**. Should land but doesn't gate this fix.
- **Add a sibling counter for the existing timeout-fallback path** (currently bumps `usedCachedFallback` flag + span event but no Prometheus counter — observability is asymmetric across the two fallback triggers). 2-line follow-up.
- **Make `pTimeout` also handle errors as fallback triggers** (currently `resolveParallel` swallows errors to undefined; if it ever rethrows, the fallback would still need explicit handling). Left for now since the swallow-to-undefined behavior is consistent.

## Architectural notes for reviewers

- During sustained AO outages, the background-refresh path (`composite-arns-resolver.ts:319-337`) also returns `undefined` and never writes to the cache, so cached `resolvedAt` ages forever and every request hits the fallback. Pre-existing — not introduced here — but the new counter will make it visible: `arns_cached_resolution_fallback_on_empty_total` rising without corresponding cache-write activity is the signature.
- This fix also corrects a previously-broken case where `lastResolverTimeoutMs` (configurable, often >250ms) fires faster than `arnsCachedResolutionFallbackTimeoutMs`. Old code dropped to placeholder in that window; new code falls back to cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)