### PR TITLE
fix(metrics): normalize export-parquet job-status path (PE-9078)

### DIFF
--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -67,7 +67,12 @@ arIoRouter.use(
           return '/ar-io/resolver/:name';
         if (path.match(/^\/ar-io\/admin\/bundle-status\/[a-zA-Z0-9_-]{43}$/))
           return '/ar-io/admin/bundle-status/:id';
-        if (path.startsWith('/ar-io/admin/')) return path; // Keep other admin routes as-is
+        if (path.match(/^\/ar-io\/admin\/export-parquet\/status\/[^/]+$/))
+          return '/ar-io/admin/export-parquet/status/:jobId';
+        // Any new admin route with a path parameter MUST be normalized
+        // above this line, or each unique parameter value will permanently
+        // accumulate as a distinct prom-client label set.
+        if (path.startsWith('/ar-io/admin/')) return path;
         if (path.startsWith('/ar-io/')) return path; // Keep other ar-io routes as-is
       }
 


### PR DESCRIPTION
The /ar-io/admin/export-parquet/status/:jobId route fell through the admin catch-all in normalizePath and was passed verbatim to express-prom-bundle, so every randomUUID()-generated jobId became a permanent label set on http_request_duration_seconds. The clickhouse-auto-import sidecar triggers ~24 exports/day at default intervals, so this slowly bloated metric cardinality and inflated scrape latency on indexer deployments.

Add the normalize case alongside bundle-status, and reword the catch-all comment to flag the regression mode for future routes.

Gateway/core deployments don't run the parquet exporter, so this is in practice an indexer-only cardinality leak — but the fix is in shared route registration code that protects both.