### PR TITLE
test(PE-9083): stub arweave network calls in ecdsa recovery test

### DIFF
--- a/src/lib/ecdsa-public-key-recover.test.ts
+++ b/src/lib/ecdsa-public-key-recover.test.ts
@@ -46,14 +46,18 @@ describe('secp256k1OwnerFromTx', () => {
   });
 
   it('should recover the correct owner from a signed transaction', async () => {
-    // Initialize an Arweave instance.
     const arweave = Arweave.init({
       host: 'turbo-gateway.com',
       port: 443,
       protocol: 'https',
     });
 
-    // Create a transaction with some dummy data.
+    // Stub the network calls that arweave.createTransaction would otherwise
+    // make to populate `reward` and `last_tx`. The values are irrelevant to
+    // signature recovery; we just need a signed tx.
+    arweave.transactions.getPrice = async () => '0';
+    arweave.transactions.getTransactionAnchor = async () => '';
+
     const tx = await arweave.createTransaction(
       { data: 'Test data for signature recovery' },
       testWallet1PrivateKey,


### PR DESCRIPTION
## Summary
- `src/lib/ecdsa-public-key-recover.test.ts` was calling `arweave.createTransaction` against a real gateway (`turbo-gateway.com`), which fetches `reward` via `getPrice` and `last_tx` via `getTransactionAnchor` over HTTPS. A 502 from the gateway intermittently fails CI on unrelated PRs (e.g. https://github.com/ar-io/ar-io-node/actions/runs/25386518041/job/74449061946?pr=703).
- Stub both methods on the arweave instance before `createTransaction`. Reward and last_tx are irrelevant to signature recovery; the test only needs a signed tx to feed into `secp256k1OwnerFromTx`.
- Test runs in ~14ms locally (down from ~1300ms in the failing CI run), confirming network is no longer in the loop.

## Test plan
- [x] `yarn test:file src/lib/ecdsa-public-key-recover.test.ts` passes locally
- [x] `yarn lint:check` clean
- [x] `prettier --check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)