### PR TITLE
chore(deps): bump lodash and diff per dependabot (PE-9090)

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,9 @@
     "hono": "4.12.12",
     "defu": "6.1.7",
     "bn.js": "5.2.3",
-    "yaml": "2.8.3"
+    "yaml": "2.8.3",
+    "lodash": "4.18.1",
+    "diff": "4.0.4"
   },
   "devDependencies": {
     "@aws-lite/s3-types": "^0.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9462,10 +9462,10 @@ dezalgo@^1.0.4:
     asap "^2.0.0"
     wrappy "1"
 
-diff@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+diff@4.0.4, diff@^4.0.1:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.4.tgz#7a6dbfda325f25f07517e9b518f897c08332e07d"
+  integrity sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==
 
 dijkstrajs@^1.0.1:
   version "1.0.3"
@@ -11608,10 +11608,10 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
 
-lodash@^4.17.15, lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@4.18.1, lodash@^4.17.15, lodash@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
## Summary

Address the 6 hanging dependabot PRs by bringing remaining transitive
deps in line with their suggested versions.

| Dependabot PR | Dep | Suggested | Installed before | After |
|---|---|---|---|---|
| #670 | hono | 4.12.12 | 4.12.12 (resolution) | unchanged |
| #664 | lodash | 4.18.1 | 4.17.21 | **4.18.1** |
| #663 | defu | 6.1.6 | 6.1.7 (resolution) | unchanged |
| #660 | yaml | 2.8.3 | 2.8.3 (resolution) | unchanged |
| #599 | @isaacs/brace-expansion | 5.0.1 | 5.0.1 (resolution) | unchanged |
| #588 | diff | 4.0.4 | 4.0.2 | **4.0.4** |

Only `lodash` and `diff` actually needed bumping. Both are transitive
devDeps (lodash via testcontainers, prettier-plugin-sort-imports,
x402; diff via ts-node) so they're pinned via the existing
`resolutions` block — same pattern already used for hono, defu, yaml,
and brace-expansion.

The lodash bump carries security fixes (prototype pollution in
`_.unset`/`_.omit`, code injection in `_.template`).

Once this lands, the 6 dependabot PRs above can be closed.

## Test plan

- [x] yarn install resolves without conflicts
- [x] yarn lint:check
- [x] yarn build
- [x] yarn test (1775 pass, 4 skipped, 0 fail)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)