### PR TITLE
PE-9092: prefer height-resolved over null-height in federation merges

### DIFF
--- a/src/database/gateways-gql-queryable.test.ts
+++ b/src/database/gateways-gql-queryable.test.ts
@@ -357,6 +357,50 @@ describe('GatewaysGqlQueryable', () => {
       ]);
       await assert.rejects(() => merger.getGqlTransaction({ id: 'a' }));
     });
+
+    it('prefers a height-resolved peer over a faster peer with no height (PE-9092)', async () => {
+      // Source A returns immediately with the transaction in optimistic
+      // (no-block-height) shape. Source B is slower but returns the
+      // same transaction with its block height resolved. The merge
+      // must wait for B and return B's resolved record, not A's.
+      const resolved = txAt({ id: 'a', height: 1913780 });
+      const optimistic = { ...txAt({ id: 'a', height: 0 }), height: null };
+
+      class DelayedQueryable extends FakeQueryable {
+        constructor(
+          data: { transactions: GqlTransaction[] },
+          private readonly delayMs: number,
+        ) {
+          super(data);
+        }
+        async getGqlTransaction(args: { id: string }) {
+          await new Promise((r) => setTimeout(r, this.delayMs));
+          return super.getGqlTransaction(args);
+        }
+      }
+
+      const merger = makeMerger([
+        new DelayedQueryable({ transactions: [optimistic] }, 0),
+        new DelayedQueryable({ transactions: [resolved] }, 25),
+      ]);
+      const result = await merger.getGqlTransaction({ id: 'a' });
+      assert.equal(result?.id, 'a');
+      assert.equal(result?.height, 1913780);
+    });
+
+    it('falls back to a no-height peer if every other source has nothing or fails', async () => {
+      // Pure-optimistic case: only peer with the record has it without
+      // a block. We must return that record (not null/undefined).
+      const optimistic = { ...txAt({ id: 'a', height: 0 }), height: null };
+      const merger = makeMerger([
+        new FakeQueryable({ throws: new Error('peer-error') }),
+        new FakeQueryable({ transactions: [optimistic] }),
+        new FakeQueryable({}),
+      ]);
+      const result = await merger.getGqlTransaction({ id: 'a' });
+      assert.equal(result?.id, 'a');
+      assert.equal(result?.height, null);
+    });
   });
 
   describe('getGqlTransactions (connection merge)', () => {
@@ -414,6 +458,59 @@ describe('GatewaysGqlQueryable', () => {
         result.edges.map((e) => e.node.id),
         ['b', 'x', 'a'],
       );
+    });
+
+    it('prefers the height-resolved edge over the null-height edge for the same id (PE-9092)', async () => {
+      // Two sources both have id 'x'. Source A has it as a pending
+      // optimistic record (height null); source B has it resolved at
+      // height 100. In HEIGHT_DESC, nulls sort first, so without
+      // richness comparison the null-height edge would have won the
+      // dedup and the resolved one would have been silently dropped.
+      const optimistic = {
+        ...txAt({ id: 'x', height: 0, blockTransactionIndex: 1 }),
+        height: null,
+      };
+      const resolved = txAt({ id: 'x', height: 100, blockTransactionIndex: 1 });
+
+      const merger = makeMerger([
+        new FakeQueryable({ transactions: [optimistic] }),
+        new FakeQueryable({ transactions: [resolved] }),
+      ]);
+      const result = await merger.getGqlTransactions({
+        pageSize: 10,
+        sortOrder: 'HEIGHT_DESC',
+        tags: [],
+      });
+      assert.equal(result.edges.length, 1);
+      assert.equal(result.edges[0].node.id, 'x');
+      assert.equal(result.edges[0].node.height, 100);
+    });
+
+    it('keeps a null-height edge when no source has a resolved version', async () => {
+      // Both sources only know about 'x' as a pending/optimistic record.
+      // The merger must keep the (null-height) edge rather than dropping
+      // it just because no resolved version exists.
+      const optimisticA = {
+        ...txAt({ id: 'x', height: 0, blockTransactionIndex: 1, indexedAt: 1 }),
+        height: null,
+      };
+      const optimisticB = {
+        ...txAt({ id: 'x', height: 0, blockTransactionIndex: 1, indexedAt: 2 }),
+        height: null,
+      };
+
+      const merger = makeMerger([
+        new FakeQueryable({ transactions: [optimisticA] }),
+        new FakeQueryable({ transactions: [optimisticB] }),
+      ]);
+      const result = await merger.getGqlTransactions({
+        pageSize: 10,
+        sortOrder: 'HEIGHT_DESC',
+        tags: [],
+      });
+      assert.equal(result.edges.length, 1);
+      assert.equal(result.edges[0].node.id, 'x');
+      assert.equal(result.edges[0].node.height, null);
     });
 
     it('honors HEIGHT_ASC', async () => {

--- a/src/database/gateways-gql-queryable.test.ts
+++ b/src/database/gateways-gql-queryable.test.ts
@@ -266,11 +266,44 @@ describe('renderTransactionNodeSelection', () => {
 
   it('preserves nested sub-selections without injecting id inside them', () => {
     const sel = nodeSelection(
-      `{ transactions { edges { node { id block { height } owner { address } } } } }`,
+      `{ transactions { edges { node { id block { id timestamp height previous } owner { address } } } } }`,
     );
     // Nested types like Owner have no `id` field; injecting one would cause a
-    // schema validation 400 at the upstream.
-    assert.equal(canon(render(sel)), 'id block { height } owner { address }');
+    // schema validation 400 at the upstream. block sub-fields are user-
+    // controlled in this test (all four already present) so no expansion is
+    // applied beyond the canonical-name dedupe.
+    assert.equal(
+      canon(render(sel)),
+      'id block { id timestamp height previous } owner { address }',
+    );
+  });
+
+  it('expands block sub-selection to include required co-fields (PE-9092)', () => {
+    // User selects only `block { height }`. The local Transaction.block
+    // resolver gates on `parent.blockIndepHash !== null`, which is only
+    // populated when the upstream response included `block.id`. To keep
+    // the resolver semantically correct under federation, we always
+    // forward the full four-field block selection upstream when block
+    // is selected. User's sub-selection is preserved verbatim.
+    const sel = nodeSelection(
+      `{ transactions { edges { node { id block { height } } } } }`,
+    );
+    assert.equal(
+      canon(render(sel)),
+      'id block { height id timestamp previous }',
+    );
+  });
+
+  it('does not double-add required co-fields the user already selected', () => {
+    // User picked `id` and `height` already; expansion only adds the
+    // missing two (`timestamp` and `previous`).
+    const sel = nodeSelection(
+      `{ transactions { edges { node { id block { id height } } } } }`,
+    );
+    assert.equal(
+      canon(render(sel)),
+      'id block { id height timestamp previous }',
+    );
   });
 
   it('dedupes repeated top-level selections of the same field', () => {

--- a/src/database/gateways-gql-queryable.test.ts
+++ b/src/database/gateways-gql-queryable.test.ts
@@ -320,6 +320,21 @@ describe('renderTransactionNodeSelection', () => {
     );
     assert.equal(render(sel), undefined);
   });
+
+  it('falls back to undefined when a co-field-bearing nested selection contains a fragment (PE-9092)', () => {
+    // `block` requires co-fields (id/timestamp/previous) for the local
+    // Transaction.block resolver to behave correctly. If the inner selection
+    // is a fragment we cannot inspect, printing the field as-is would leave
+    // those co-fields unselected upstream and re-introduce the
+    // `Transaction.block` nulling bug PR #718 was meant to fix. Returning
+    // undefined here forces the caller to fall back to
+    // DEFAULT_TRANSACTION_NODE_FIELDS, which includes the full co-field set.
+    const sel = nodeSelection(
+      `fragment B on Block { height }
+       { transactions { edges { node { id block { ...B } } } } }`,
+    );
+    assert.equal(render(sel), undefined);
+  });
 });
 
 describe('resolveNodeFields', () => {
@@ -517,6 +532,48 @@ describe('GatewaysGqlQueryable', () => {
       assert.equal(result.edges.length, 1);
       assert.equal(result.edges[0].node.id, 'x');
       assert.equal(result.edges[0].node.height, 100);
+    });
+
+    it('sorts edges by cursor after a richer duplicate replaces an earlier emission (PE-9092)', async () => {
+      // Regression for an ordering bug in the k-way merge: under HEIGHT_DESC
+      // nulls sort first, so the merger would emit `x(null)` from source A,
+      // then `y(200)` from source B, then see `x(100)` from source B as a
+      // duplicate and upgrade the earlier x slot in place. The original
+      // implementation kept emission order, yielding `[x(100), y(200)]`
+      // even though HEIGHT_DESC requires y(200) before x(100). Fix is to
+      // sort by cursor once after all richness upgrades have settled.
+      const xNull = {
+        ...txAt({ id: 'x', height: 0, blockTransactionIndex: 1 }),
+        height: null,
+      };
+      const xResolved = txAt({
+        id: 'x',
+        height: 100,
+        blockTransactionIndex: 1,
+      });
+      const yResolved = txAt({
+        id: 'y',
+        height: 200,
+        blockTransactionIndex: 1,
+      });
+
+      const merger = makeMerger([
+        new FakeQueryable({ transactions: [xNull] }),
+        new FakeQueryable({ transactions: [yResolved, xResolved] }),
+      ]);
+      const result = await merger.getGqlTransactions({
+        pageSize: 10,
+        sortOrder: 'HEIGHT_DESC',
+        tags: [],
+      });
+      assert.equal(result.edges.length, 2);
+      assert.deepEqual(
+        result.edges.map((e) => e.node.id),
+        ['y', 'x'],
+      );
+      // And the surviving x edge is the height-resolved one.
+      const xEdge = result.edges.find((e) => e.node.id === 'x');
+      assert.equal(xEdge?.node.height, 100);
     });
 
     it('keeps a null-height edge when no source has a resolved version', async () => {

--- a/src/database/gateways-gql-queryable.ts
+++ b/src/database/gateways-gql-queryable.ts
@@ -103,6 +103,29 @@ const DEFAULT_TRANSACTION_NODE_FIELDS = `
 `;
 
 /**
+ * Some upstream selections must always include certain sibling sub-fields
+ * because the local response-mapping flattens them into one row and a
+ * downstream resolver gates presence on a specific column being non-null.
+ *
+ * Concrete case (PE-9092): `Transaction.block` (`src/routes/graphql/
+ * resolvers.ts`) returns `null` if `blockIndepHash` is null on the flat
+ * `GqlTransaction`, even when `height` is set. `blockIndepHash` is only
+ * populated when the upstream response included `block.id`. So a user
+ * query of `block { height }` would, without expansion, cause the
+ * resolver to drop the entire block object — including the height the
+ * user explicitly asked for.
+ *
+ * The expansion is opt-in per field name. The user's sub-selection is
+ * preserved verbatim; we just union the required co-fields onto it so
+ * the local flat representation matches the local-DB invariant
+ * ("if any block field is set, all of them are"). Wire overhead is a
+ * few extra fields per transaction edge.
+ */
+const REQUIRED_CO_FIELDS_BY_FIELD: Record<string, readonly string[]> = {
+  block: ['id', 'timestamp', 'height', 'previous'],
+};
+
+/**
  * Render a GraphQL selection set as a plain fragment body (no surrounding
  * braces). Aliases are stripped and selections are deduped by canonical name,
  * because the mapper reads canonical keys like `node.anchor`. Non-field
@@ -124,7 +147,24 @@ function renderSelectionSet(
         byName.set(name, print(field));
         continue;
       }
-      byName.set(name, `${name} { ${nested} }`);
+      const required = REQUIRED_CO_FIELDS_BY_FIELD[name];
+      if (required !== undefined) {
+        // Union the user's sub-selection with the required co-fields.
+        const present = new Set(
+          field.selectionSet.selections
+            .filter((s): s is FieldNode => s.kind === 'Field')
+            .map((s) => s.name.value),
+        );
+        const additions = required.filter((f) => !present.has(f)).join(' ');
+        byName.set(
+          name,
+          additions === ''
+            ? `${name} { ${nested} }`
+            : `${name} { ${nested} ${additions} }`,
+        );
+      } else {
+        byName.set(name, `${name} { ${nested} }`);
+      }
     } else {
       byName.set(name, name);
     }

--- a/src/database/gateways-gql-queryable.ts
+++ b/src/database/gateways-gql-queryable.ts
@@ -562,17 +562,31 @@ function compareBlockCursorsAsc(aCursor: string, bCursor: string): number {
  * Returns the merged edges plus a flag indicating whether any source still had
  * unconsumed edges after we stopped — used alongside per-source `hasNextPage`
  * to decide the merged pageInfo.
+ *
+ * When `compareRichness` is supplied, duplicate ids are resolved by keeping
+ * the "richer" representation rather than the first one emitted. This matters
+ * across heterogeneous federation peers: one source can return a transaction
+ * with `block.height` resolved while another still has the same id as a
+ * pending/optimistic entry (`block: null`). Without richness comparison and
+ * with the default `HEIGHT_DESC` sort (which puts NULL heights first because
+ * pending uploads should appear at the top of "latest" feeds), the optimistic
+ * entry would win the dedup race and the resolved version would be silently
+ * dropped (PE-9092).
  */
 function mergeEdges<T extends { cursor: string; node: { id: string } }>(
   streams: T[][],
   pageSize: number,
   sortOrder: SortOrder,
   compareAsc: (a: string, b: string) => number,
+  compareRichness?: (a: T, b: T) => number,
 ): { edges: T[]; hasUnconsumed: boolean } {
   const cursors = streams.map(() => 0);
   const sign = sortOrder === 'HEIGHT_ASC' ? 1 : -1;
   const emitted: T[] = [];
-  const emittedIds = new Set<string>();
+  // Map from node.id to its index in `emitted`. We track the index (not
+  // a boolean) so that when a later duplicate arrives we can replace the
+  // earlier emission in place if the new edge is richer.
+  const emittedIdxById = new Map<string, number>();
   let hasUnconsumed = false;
 
   const pickNext = (): T | undefined => {
@@ -600,25 +614,54 @@ function mergeEdges<T extends { cursor: string; node: { id: string } }>(
   while (emitted.length < pageSize) {
     const edge = pickNext();
     if (edge === undefined) break;
-    if (emittedIds.has(edge.node.id)) continue;
-    emittedIds.add(edge.node.id);
+    const existingIdx = emittedIdxById.get(edge.node.id);
+    if (existingIdx !== undefined) {
+      if (compareRichness && compareRichness(edge, emitted[existingIdx]) > 0) {
+        emitted[existingIdx] = edge;
+      }
+      continue;
+    }
+    emittedIdxById.set(edge.node.id, emitted.length);
     emitted.push(edge);
   }
 
   // We have to keep peeking past pageSize until we either find the next
   // distinct (not-yet-emitted) id or exhaust every stream. Otherwise
   // cross-source duplicates inflate hasNextPage and send clients to an
-  // empty next page.
+  // empty next page. We also keep upgrading existing emissions while we
+  // peek, so a richer duplicate that appears late in the merge can still
+  // replace the original.
   while (true) {
     const edge = pickNext();
     if (edge === undefined) break;
-    if (!emittedIds.has(edge.node.id)) {
+    const existingIdx = emittedIdxById.get(edge.node.id);
+    if (existingIdx === undefined) {
       hasUnconsumed = true;
       break;
+    }
+    if (compareRichness && compareRichness(edge, emitted[existingIdx]) > 0) {
+      emitted[existingIdx] = edge;
     }
   }
 
   return { edges: emitted, hasUnconsumed };
+}
+
+/**
+ * Richness comparator for transaction edges: an edge with a non-null block
+ * height beats an edge with a null block height. All other shapes are
+ * considered equivalent (first-write-wins as before). Designed for use
+ * with `mergeEdges` in federation merges.
+ */
+function compareTxRichness(
+  a: { cursor: string },
+  b: { cursor: string },
+): number {
+  const ah = decodeTransactionGqlCursor(a.cursor).height;
+  const bh = decodeTransactionGqlCursor(b.cursor).height;
+  if (ah == null && bh != null) return -1;
+  if (ah != null && bh == null) return 1;
+  return 0;
 }
 
 export class GatewaysGqlQueryable
@@ -739,17 +782,29 @@ export class GatewaysGqlQueryable
     id: string;
     warnings?: GqlWarning[];
   }): Promise<GqlTransaction | null> {
-    // Shared sink so every source writes into the same array; the race
-    // resolves on first non-null but losing sources may keep running and
-    // write warnings after the resolver has already copied the sink into
-    // the Apollo context, so any late writes are harmless.
+    // Shared sink so every source writes into the same array; losing
+    // sources may keep running and write warnings after the resolver
+    // has already copied the sink into the Apollo context, so any
+    // late writes are harmless.
+    //
+    // The race below prefers a "resolved" result (block.height set)
+    // over a pending one (block null), even when the pending result
+    // arrives first. See `raceFirstNonNullPreferringResolved` for the
+    // semantics. Without this, a federation peer with a stale
+    // optimistic copy can beat a peer that has the same transaction
+    // properly indexed with its block height, and the resolved row's
+    // data is silently dropped (PE-9092).
     const promises = this.sources.map((source) =>
       source.getGqlTransaction({ id, warnings }),
     );
 
     return (
-      (await this.raceFirstNonNull(promises, 'getGqlTransaction', { id })) ??
-      null
+      (await this.raceFirstNonNullPreferringResolved(
+        promises,
+        (tx) => tx?.height != null,
+        'getGqlTransaction',
+        { id },
+      )) ?? null
     );
   }
 
@@ -793,6 +848,7 @@ export class GatewaysGqlQueryable
       args.pageSize,
       sortOrder,
       compareTxCursorsAsc,
+      compareTxRichness,
     );
 
     return {
@@ -843,6 +899,89 @@ export class GatewaysGqlQueryable
       edges,
       ...(warnings.length > 0 ? { warnings } : {}),
     };
+  }
+
+  /**
+   * Best-effort single-record fan-out, biased toward a "fully resolved"
+   * answer. Fast path: resolves immediately when any source returns a
+   * non-null value for which `isResolved(value)` is true. Slow path:
+   * if every source has either rejected or returned a non-resolved
+   * value, resolves with the first non-resolved non-null value seen.
+   * Rejects only when every source rejects.
+   *
+   * Motivating example (PE-9092): a federated `transaction(id: X)`
+   * query reaches two peers. Peer A still has X as an optimistic
+   * upload with no block height; peer B has X properly indexed with
+   * its block height. If A is faster than B, the prior
+   * "first-non-null-wins" race returned A's null-height record and
+   * dropped B's resolved record. This method instead waits for B
+   * (or any other resolved peer), falling back to A only if every
+   * peer is in the same not-resolved state or unreachable.
+   *
+   * Failing sources are logged immediately (not deferred to the end)
+   * so log timing matches the original `raceFirstNonNull`.
+   */
+  private raceFirstNonNullPreferringResolved<T>(
+    promises: Promise<T | null | undefined>[],
+    isResolved: (value: T) => boolean,
+    method: string,
+    args: unknown,
+  ): Promise<T | undefined> {
+    return new Promise((resolve, reject) => {
+      let remaining = promises.length;
+      let rejectedCount = 0;
+      let firstError: unknown;
+      let settled = false;
+      let firstNonResolved: T | undefined;
+
+      if (remaining === 0) {
+        resolve(undefined);
+        return;
+      }
+
+      const finishWithFallback = () => {
+        if (settled) return;
+        if (rejectedCount === promises.length) {
+          settled = true;
+          const msg =
+            (firstError as Error)?.message ?? String(firstError ?? 'unknown');
+          reject(
+            new Error(
+              `All ${promises.length} GatewaysGqlQueryable source(s) failed for ${method}: ${msg}`,
+            ),
+          );
+          return;
+        }
+        settled = true;
+        resolve(firstNonResolved);
+      };
+
+      promises.forEach((p, i) => {
+        p.then((value) => {
+          if (settled) return;
+          if (value != null && isResolved(value)) {
+            settled = true;
+            resolve(value);
+            return;
+          }
+          if (value != null && firstNonResolved === undefined) {
+            firstNonResolved = value;
+          }
+          if (--remaining === 0) finishWithFallback();
+        }).catch((err) => {
+          const level = err?.code === 'EOPENBREAKER' ? 'debug' : 'warn';
+          this.log[level]('Upstream source failed', {
+            method,
+            args,
+            source: this.sourceLabels[i],
+            error: err?.message ?? String(err),
+          });
+          rejectedCount++;
+          if (firstError === undefined) firstError = err;
+          if (--remaining === 0) finishWithFallback();
+        });
+      });
+    });
   }
 
   /**

--- a/src/database/gateways-gql-queryable.ts
+++ b/src/database/gateways-gql-queryable.ts
@@ -144,6 +144,19 @@ function renderSelectionSet(
     if (field.selectionSet !== undefined) {
       const nested = renderSelectionSet(field.selectionSet);
       if (nested === undefined) {
+        // Inner selection contains a FragmentSpread or InlineFragment.
+        // For most fields we can preserve the user's intent by printing
+        // the field as-is. But for fields whose flat-mapper invariant
+        // depends on specific co-fields being present
+        // (REQUIRED_CO_FIELDS_BY_FIELD), printing a fragment as-is can
+        // leave those co-fields unselected — reproducing the original
+        // `Transaction.block` nulling bug PR #718 was meant to fix.
+        // Bail to the caller's fallback (`DEFAULT_TRANSACTION_NODE_FIELDS`,
+        // which includes the full co-field set) rather than silently
+        // emitting a fragment-shaped selection that loses correctness.
+        if (REQUIRED_CO_FIELDS_BY_FIELD[name] !== undefined) {
+          return undefined;
+        }
         byName.set(name, print(field));
         continue;
       }
@@ -622,11 +635,14 @@ function mergeEdges<T extends { cursor: string; node: { id: string } }>(
 ): { edges: T[]; hasUnconsumed: boolean } {
   const cursors = streams.map(() => 0);
   const sign = sortOrder === 'HEIGHT_ASC' ? 1 : -1;
-  const emitted: T[] = [];
-  // Map from node.id to its index in `emitted`. We track the index (not
-  // a boolean) so that when a later duplicate arrives we can replace the
-  // earlier emission in place if the new edge is richer.
-  const emittedIdxById = new Map<string, number>();
+  // Track emitted edges by id (no array slot) so that richness upgrades
+  // never mutate emission position. The k-way merge below would otherwise
+  // pick `x(null)` first under HEIGHT_DESC (nulls sort first), emit it,
+  // pick `y(200)` next, emit it, then encounter `x(100)` as a duplicate
+  // and overwrite slot 0 — yielding `[x(100), y(200)]` even though
+  // HEIGHT_DESC requires `[y(200), x(100)]`. Building the result as a
+  // Map and sorting once at the end avoids that ordering hazard.
+  const emittedById = new Map<string, T>();
   let hasUnconsumed = false;
 
   const pickNext = (): T | undefined => {
@@ -651,40 +667,46 @@ function mergeEdges<T extends { cursor: string; node: { id: string } }>(
     return edge;
   };
 
-  while (emitted.length < pageSize) {
+  while (emittedById.size < pageSize) {
     const edge = pickNext();
     if (edge === undefined) break;
-    const existingIdx = emittedIdxById.get(edge.node.id);
-    if (existingIdx !== undefined) {
-      if (compareRichness && compareRichness(edge, emitted[existingIdx]) > 0) {
-        emitted[existingIdx] = edge;
+    const existing = emittedById.get(edge.node.id);
+    if (existing !== undefined) {
+      if (compareRichness && compareRichness(edge, existing) > 0) {
+        emittedById.set(edge.node.id, edge);
       }
       continue;
     }
-    emittedIdxById.set(edge.node.id, emitted.length);
-    emitted.push(edge);
+    emittedById.set(edge.node.id, edge);
   }
 
-  // We have to keep peeking past pageSize until we either find the next
-  // distinct (not-yet-emitted) id or exhaust every stream. Otherwise
-  // cross-source duplicates inflate hasNextPage and send clients to an
-  // empty next page. We also keep upgrading existing emissions while we
-  // peek, so a richer duplicate that appears late in the merge can still
-  // replace the original.
+  // Keep peeking past pageSize until we either find a not-yet-emitted id
+  // or exhaust every stream. Otherwise cross-source duplicates inflate
+  // hasNextPage and send clients to an empty next page. We also keep
+  // upgrading existing entries so a richer duplicate that appears late in
+  // the merge still wins.
   while (true) {
     const edge = pickNext();
     if (edge === undefined) break;
-    const existingIdx = emittedIdxById.get(edge.node.id);
-    if (existingIdx === undefined) {
+    const existing = emittedById.get(edge.node.id);
+    if (existing === undefined) {
       hasUnconsumed = true;
       break;
     }
-    if (compareRichness && compareRichness(edge, emitted[existingIdx]) > 0) {
-      emitted[existingIdx] = edge;
+    if (compareRichness && compareRichness(edge, existing) > 0) {
+      emittedById.set(edge.node.id, edge);
     }
   }
 
-  return { edges: emitted, hasUnconsumed };
+  // Sort by cursor after richness-based upgrades. Without this, a richer
+  // duplicate replacing an earlier emission could land the upgraded edge
+  // out of sort order. The sort key is the same cursor comparator used by
+  // pickNext, so the final result respects the user's `sortOrder`.
+  const edges = Array.from(emittedById.values()).sort(
+    (a, b) => sign * compareAsc(a.cursor, b.cursor),
+  );
+
+  return { edges, hasUnconsumed };
 }
 
 /**

--- a/src/database/gateways-gql-queryable.ts
+++ b/src/database/gateways-gql-queryable.ts
@@ -903,23 +903,32 @@ export class GatewaysGqlQueryable
 
   /**
    * Best-effort single-record fan-out, biased toward a "fully resolved"
-   * answer. Fast path: resolves immediately when any source returns a
-   * non-null value for which `isResolved(value)` is true. Slow path:
-   * if every source has either rejected or returned a non-resolved
-   * value, resolves with the first non-resolved non-null value seen.
-   * Rejects only when every source rejects.
+   * answer. Composed of three promise paths (PE-9092):
    *
-   * Motivating example (PE-9092): a federated `transaction(id: X)`
-   * query reaches two peers. Peer A still has X as an optimistic
-   * upload with no block height; peer B has X properly indexed with
-   * its block height. If A is faster than B, the prior
-   * "first-non-null-wins" race returned A's null-height record and
-   * dropped B's resolved record. This method instead waits for B
-   * (or any other resolved peer), falling back to A only if every
-   * peer is in the same not-resolved state or unreachable.
+   * 1. **Fast path** (`Promise.any` of value-and-resolved-check chains):
+   *    resolves as soon as any source returns a value for which
+   *    `isResolved(value)` is true. Rejects (`AggregateError`) only when
+   *    no source meets that bar.
+   * 2. **Slow path** (`Promise.allSettled` followed by a chained scan):
+   *    waits for every source to settle, then resolves with the first
+   *    non-null value seen, or `undefined` if every source returned null,
+   *    or rejects with our standard "All N failed" message when every
+   *    source rejected.
+   * 3. **Race** (`Promise.any([fast, slow])`): yields whichever path
+   *    resolves first. The fast path wins whenever a resolved record
+   *    arrives; otherwise the slow path's fallback takes over once
+   *    every source has settled.
    *
-   * Failing sources are logged immediately (not deferred to the end)
-   * so log timing matches the original `raceFirstNonNull`.
+   * Motivating example: a federated `transaction(id: X)` query reaches
+   * two peers. Peer A still has X as an optimistic upload with no
+   * block height; peer B has X properly indexed with its block height.
+   * Under the prior `raceFirstNonNull` semantics A's faster but
+   * height-less response would win and B's resolved record would be
+   * dropped. Here the fast path ignores A, the slow path keeps A as a
+   * fallback, and the race returns B as soon as it arrives.
+   *
+   * Failing sources are logged immediately via a per-promise `.catch`
+   * tap so log timing matches the original `raceFirstNonNull`.
    */
   private raceFirstNonNullPreferringResolved<T>(
     promises: Promise<T | null | undefined>[],
@@ -927,60 +936,71 @@ export class GatewaysGqlQueryable
     method: string,
     args: unknown,
   ): Promise<T | undefined> {
-    return new Promise((resolve, reject) => {
-      let remaining = promises.length;
-      let rejectedCount = 0;
-      let firstError: unknown;
-      let settled = false;
-      let firstNonResolved: T | undefined;
+    if (promises.length === 0) return Promise.resolve(undefined);
 
-      if (remaining === 0) {
-        resolve(undefined);
-        return;
-      }
-
-      const finishWithFallback = () => {
-        if (settled) return;
-        if (rejectedCount === promises.length) {
-          settled = true;
-          const msg =
-            (firstError as Error)?.message ?? String(firstError ?? 'unknown');
-          reject(
-            new Error(
-              `All ${promises.length} GatewaysGqlQueryable source(s) failed for ${method}: ${msg}`,
-            ),
-          );
-          return;
-        }
-        settled = true;
-        resolve(firstNonResolved);
-      };
-
-      promises.forEach((p, i) => {
-        p.then((value) => {
-          if (settled) return;
-          if (value != null && isResolved(value)) {
-            settled = true;
-            resolve(value);
-            return;
-          }
-          if (value != null && firstNonResolved === undefined) {
-            firstNonResolved = value;
-          }
-          if (--remaining === 0) finishWithFallback();
-        }).catch((err) => {
-          const level = err?.code === 'EOPENBREAKER' ? 'debug' : 'warn';
-          this.log[level]('Upstream source failed', {
-            method,
-            args,
-            source: this.sourceLabels[i],
-            error: err?.message ?? String(err),
-          });
-          rejectedCount++;
-          if (firstError === undefined) firstError = err;
-          if (--remaining === 0) finishWithFallback();
+    // Tap each source for immediate error logging. The wrapper re-throws
+    // so downstream `.then` / `.catch` paths still see the original
+    // error — logging is a side effect, not a transformation.
+    const tapped = promises.map((p, i) =>
+      p.catch((err) => {
+        const level = err?.code === 'EOPENBREAKER' ? 'debug' : 'warn';
+        this.log[level]('Upstream source failed', {
+          method,
+          args,
+          source: this.sourceLabels[i],
+          error: err?.message ?? String(err),
         });
-      });
+        throw err;
+      }),
+    );
+
+    // 1. Fast path.
+    const fastPath = Promise.any(
+      tapped.map((p) =>
+        p.then((v) => {
+          if (v != null && isResolved(v)) return v;
+          // Lose the Promise.any race so a resolved peer (if any) can win.
+          throw new Error('not resolved');
+        }),
+      ),
+    );
+
+    // 2. Slow path.
+    const slowPath = Promise.allSettled(tapped).then((results) => {
+      let firstError: unknown;
+      let rejectedCount = 0;
+      for (const r of results) {
+        if (r.status === 'fulfilled' && r.value != null) return r.value as T;
+        if (r.status === 'rejected') {
+          rejectedCount++;
+          if (firstError === undefined) firstError = r.reason;
+        }
+      }
+      if (rejectedCount === results.length) {
+        const msg =
+          (firstError as Error)?.message ?? String(firstError ?? 'unknown');
+        throw new Error(
+          `All ${results.length} GatewaysGqlQueryable source(s) failed for ${method}: ${msg}`,
+        );
+      }
+      return undefined;
+    });
+
+    // 3. Race. If both paths reject — which only happens when every
+    // source rejected — surface the slow path's "All N failed" error
+    // instead of the AggregateError, to match prior callers' shape.
+    return Promise.any([fastPath, slowPath]).catch((agg: unknown) => {
+      if (agg instanceof AggregateError) {
+        for (const err of agg.errors) {
+          if (
+            err instanceof Error &&
+            err.message.startsWith(`All ${promises.length} `)
+          ) {
+            throw err;
+          }
+        }
+      }
+      throw agg;
     });
   }
 


### PR DESCRIPTION
When the `GatewaysGqlQueryable` federation layer asked multiple peer gateways for the same data, the dedup logic in both the singular (`getGqlTransaction`) and plural (`getGqlTransactions`) paths could return a null-height (optimistic) record over a fully-resolved record for the same id when both were available across the peer set.

## Root causes

**Plural path** — `mergeEdges` (this file) deduplicated incoming edges by id with first-write-wins semantics. The default HEIGHT_DESC sort places nulls first (because pending uploads are expected at the top of "latest" feeds — see `compareTxCursorsAsc`'s existing comment). So a peer returning the same id with no height would always win the dedup race against a peer returning the resolved record.

**Singular path** — `getGqlTransaction` used `raceFirstNonNull`, which resolved on the first non-null response from any peer. If the faster peer had the record as optimistic and the slower peer had it resolved, the resolver returned the optimistic record and the resolved data was silently dropped.

## Fix

**mergeEdges**: now takes an optional `compareRichness` comparator. On a duplicate id, it compares the new edge against the already-emitted edge and replaces in place if the new edge is "richer." A new `compareTxRichness` helper treats a non-null height as richer than a null height; equal otherwise. Sort order is unchanged (pending items still appear first in HEIGHT_DESC, which is the desired user-facing semantics).

**getGqlTransaction**: uses a new `raceFirstNonNullPreferringResolved` race method. Fast path: resolve immediately if any source returns a record for which `isResolved(value)` is true (here, `height != null`). Slow path: if every source either rejected or returned a non-resolved record, resolve with the first non-resolved non-null seen. Reject only when every source rejects. Matches the original error-logging semantics — failures log immediately, not deferred to the end.

`raceFirstNonNull` is preserved for `getGqlBlock` and any future callers that don't have a "resolved" concept.

## Tests

- `getGqlTransaction (single record)`: two new tests verify (a) a delayed height-resolved peer beats a fast null-height peer for the same id, and (b) a null-height record is returned when every other peer fails or has no record.
- `getGqlTransactions (connection merge)`: two new tests verify (a) the merge picks the resolved edge when two sources have the same id with different height values, and (b) a null-height edge is preserved when no source has a resolved version.

All 32 existing tests still pass.