### PR TITLE
perf(bundles): parallel retry lane for large Turbo bundles

### DIFF
--- a/migrations/2026.05.13T18.00.00.bundles.add-large-bundle-priority-index.sql
+++ b/migrations/2026.05.13T18.00.00.bundles.add-large-bundle-priority-index.sql
@@ -1,0 +1,22 @@
+-- up migration
+--
+-- Adds bundles_large_active_priority_idx — a partial index supporting the
+-- new `selectLargeFailedBundleIds` SQL statement (parallel retry lane for
+-- Turbo-class bundles).
+--
+-- Partial WHERE predicate keeps the index tiny: it only covers bundles that
+-- are (a) not yet fully indexed and (b) known to have data_item_count >= 50
+-- (Turbo bulk threshold; direct ArDrive bundles have 1-2 DIs). On a 9.8M-row
+-- bundles.db with ~1k known-large bundles in flight, the index is a few MB.
+--
+-- The 50 literal in the partial WHERE matches the default value of the
+-- BUNDLE_REPAIR_LARGE_BUNDLE_THRESHOLD env var. If operators lower that env,
+-- the partial index will still serve queries (just for the >= 50 subset);
+-- queries with threshold < 50 will fall back to a full scan. Operators who
+-- want to lower the threshold permanently should also adjust this index.
+
+CREATE INDEX IF NOT EXISTS bundles_large_active_priority_idx
+  ON bundles (data_item_count, retry_attempt_count, last_retried_at)
+  WHERE last_fully_indexed_at IS NULL AND data_item_count >= 50;
+
+ANALYZE bundles;

--- a/migrations/down/2026.05.13T18.00.00.bundles.add-large-bundle-priority-index.sql
+++ b/migrations/down/2026.05.13T18.00.00.bundles.add-large-bundle-priority-index.sql
@@ -1,0 +1,2 @@
+-- down migration
+DROP INDEX IF EXISTS bundles_large_active_priority_idx;

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,9 +5,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { canonicalize } from 'json-canonicalize';
-import { isMainThread } from 'node:worker_threads';
 import { existsSync, readFileSync } from 'node:fs';
+import { isMainThread } from 'node:worker_threads';
 
+import { verificationPriorities } from './constants.js';
 import { createFilter } from './filters.js';
 import * as env from './lib/env.js';
 import { initHttpSig, saveAttestationTxId } from './lib/httpsig.js';
@@ -15,9 +16,8 @@ import type {
   HttpSigObserverContext,
   HttpSigSignerContext,
 } from './lib/httpsig.js';
-import { release } from './version.js';
 import logger from './log.js';
-import { verificationPriorities } from './constants.js';
+import { release } from './version.js';
 
 //
 // HTTP server
@@ -1330,6 +1330,36 @@ export const BUNDLE_REPAIR_FILTER_REPROCESS_INTERVAL_SECONDS =
 export const BUNDLE_REPAIR_RETRY_BATCH_SIZE = +env.varOrDefault(
   'BUNDLE_REPAIR_RETRY_BATCH_SIZE',
   '5000',
+);
+
+// Parallel retry lane for large (Turbo-class) bundles. Runs alongside the
+// normal retry loop. Without this lane, the normal loop's ordering (by
+// retry_attempt_count) treats a 2-DI direct ArDrive bundle and a 500-DI Turbo
+// bundle equally, so the abundant small bundles starve the large ones. This
+// lane picks only bundles with known data_item_count >= threshold and orders
+// by size DESC, so workers chip away at the largest bundles first.
+//
+// All three knobs default to safe values:
+//   - interval = 300s (matches BUNDLE_REPAIR_RETRY_INTERVAL_SECONDS)
+//   - batch_size = 500 (small — each large bundle takes 30-60s to download)
+//   - threshold = 50 (above 1-2 DIs of direct ArDrive, captures Turbo bulk)
+//
+// Setting batch_size = 0 effectively disables this lane (the SELECT returns
+// an empty set with LIMIT 0; the for-loop in retryLargeBundles iterates over
+// nothing). Use this for a quick soft-disable without redeploying.
+export const BUNDLE_REPAIR_LARGE_RETRY_INTERVAL_SECONDS = +env.varOrDefault(
+  'BUNDLE_REPAIR_LARGE_RETRY_INTERVAL_SECONDS',
+  '300',
+);
+
+export const BUNDLE_REPAIR_LARGE_RETRY_BATCH_SIZE = +env.varOrDefault(
+  'BUNDLE_REPAIR_LARGE_RETRY_BATCH_SIZE',
+  '500',
+);
+
+export const BUNDLE_REPAIR_LARGE_BUNDLE_THRESHOLD = +env.varOrDefault(
+  'BUNDLE_REPAIR_LARGE_BUNDLE_THRESHOLD',
+  '50',
 );
 
 //

--- a/src/database/sql/bundles/repair.sql
+++ b/src/database/sql/bundles/repair.sql
@@ -24,6 +24,51 @@ FROM (
 )
 ORDER BY RANDOM()
 
+-- selectLargeFailedBundleIds
+-- Parallel retry lane for already-parsed bundles whose data_item_count is at
+-- or above @threshold (Turbo-class bundles with many DIs each). The original
+-- selectFailedBundleIds ordering (by retry_attempt_count) gives equal weight
+-- to a 2-DI direct ArDrive bundle and a 500-DI Turbo bundle, which means
+-- direct bundles dominate the worker pool and large bundles starve. This
+-- query targets only the subset where we already know data_item_count >=
+-- threshold and orders by size DESC so workers chip away at the largest
+-- bundles first. Bundles whose size is not yet known (data_item_count IS
+-- NULL) are intentionally excluded — they are handled by selectFailedBundleIds
+-- and get their size populated on first unbundle, after which they become
+-- eligible for this lane on subsequent retries.
+--
+-- Backed by bundles_large_active_priority_idx (partial index on
+-- (data_item_count, retry_attempt_count, last_retried_at) WHERE
+-- last_fully_indexed_at IS NULL AND data_item_count >= 50). The partial
+-- WHERE predicate uses the same threshold literal (50) as the default
+-- BUNDLE_REPAIR_LARGE_BUNDLE_THRESHOLD env var; lowering the env without
+-- recreating the index will still work but the index will only serve the
+-- subset >= 50.
+SELECT DISTINCT id
+FROM (
+  SELECT b.root_transaction_id AS id
+  FROM bundles b
+  WHERE (
+      (b.last_queued_at IS NULL AND b.last_skipped_at IS NULL)
+      OR (
+        b.last_queued_at IS NOT NULL
+        AND (
+          b.last_skipped_at IS NULL
+          OR b.last_skipped_at <= b.last_queued_at
+        )
+        AND b.last_queued_at < @reprocess_cutoff
+      )
+    )
+    AND b.last_fully_indexed_at IS NULL
+    AND b.matched_data_item_count IS NOT NULL
+    AND b.matched_data_item_count > 0
+    AND b.data_item_count IS NOT NULL
+    AND b.data_item_count >= @threshold
+  ORDER BY b.data_item_count DESC, b.retry_attempt_count, b.last_retried_at ASC
+  LIMIT @limit
+)
+ORDER BY RANDOM()
+
 -- updateFullyIndexedAt
 UPDATE bundles
 SET

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -905,6 +905,16 @@ export class StandaloneSqliteDatabaseWorker {
     return rows.map((row): string => toB64Url(row.id));
   }
 
+  getLargeFailedBundleIds(limit: number, threshold: number) {
+    const rows = this.stmts.bundles.selectLargeFailedBundleIds.all({
+      limit,
+      threshold,
+      reprocess_cutoff: currentUnixTimestamp() - BUNDLE_REPROCESS_WAIT_SECS,
+    });
+
+    return rows.map((row): string => toB64Url(row.id));
+  }
+
   backfillBundles() {
     this.stmts.bundles.insertMissingBundles.run();
   }
@@ -3309,6 +3319,16 @@ export class StandaloneSqliteDatabase
     return this.queueRead('bundles', 'getFailedBundleIds', [limit]);
   }
 
+  getLargeFailedBundleIds(
+    limit: number,
+    threshold: number,
+  ): Promise<string[]> {
+    return this.queueRead('bundles', 'getLargeFailedBundleIds', [
+      limit,
+      threshold,
+    ]);
+  }
+
   backfillBundles() {
     return this.queueRead('bundles', 'backfillBundles', undefined);
   }
@@ -3811,6 +3831,13 @@ if (!isMainThread) {
         case 'getFailedBundleIds':
           const failedBundleIds = worker.getFailedBundleIds(args[0]);
           parentPort?.postMessage(failedBundleIds);
+          break;
+        case 'getLargeFailedBundleIds':
+          const largeFailedBundleIds = worker.getLargeFailedBundleIds(
+            args[0],
+            args[1],
+          );
+          parentPort?.postMessage(largeFailedBundleIds);
           break;
         case 'backfillBundles':
           worker.backfillBundles();

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,9 +4,9 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { Readable, Writable } from 'node:stream';
 import { AoArNSNameDataWithName } from '@ar.io/sdk';
 import { Span } from '@opentelemetry/api';
+import { Readable, Writable } from 'node:stream';
 
 export interface B64uTag {
   name: string;
@@ -281,6 +281,7 @@ export interface BundleIndex {
   saveBundle(bundle: BundleRecord): Promise<BundleSaveResult>;
   saveBundleRetries(rootTransactionId: string): Promise<void>;
   getFailedBundleIds(limit: number): Promise<string[]>;
+  getLargeFailedBundleIds(limit: number, threshold: number): Promise<string[]>;
   updateBundlesFullyIndexedAt(): Promise<void>;
   updateBundlesForFilterChange(
     unbundleFilter: string,

--- a/src/workers/bundle-repair-worker.ts
+++ b/src/workers/bundle-repair-worker.ts
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import * as winston from 'winston';
-import * as config from '../config.js';
 
+import * as config from '../config.js';
 import { BundleIndex } from '../types.js';
 import { TransactionFetcher } from './transaction-fetcher.js';
 
@@ -54,6 +54,14 @@ export class BundleRepairWorker {
     );
     this.intervalIds.push(defaultInterval);
 
+    if (config.BUNDLE_REPAIR_LARGE_RETRY_BATCH_SIZE > 0) {
+      const largeRetryInterval = setInterval(
+        this.retryLargeBundles.bind(this),
+        config.BUNDLE_REPAIR_LARGE_RETRY_INTERVAL_SECONDS * 1000,
+      );
+      this.intervalIds.push(largeRetryInterval);
+    }
+
     const defaultUpdateInterval = setInterval(
       this.updateBundleTimestamps.bind(this),
       config.BUNDLE_REPAIR_UPDATE_TIMESTAMPS_INTERVAL_SECONDS * 1000,
@@ -98,6 +106,32 @@ export class BundleRepairWorker {
       }
     } catch (error: any) {
       this.log.error('Error retrying failed bundles:', error);
+    }
+  }
+
+  // Parallel retry lane for large (Turbo-class) bundles. Picks bundles whose
+  // data_item_count is known and >= BUNDLE_REPAIR_LARGE_BUNDLE_THRESHOLD,
+  // ordered by data_item_count DESC. txFetcher.queueTxId is idempotent within
+  // a single in-flight queue snapshot, so if a bundle is also picked by
+  // retryBundles in the same cycle the second queueTxId is a no-op; the only
+  // observable effect is retry_attempt_count incrementing twice instead of
+  // once, which is cosmetic.
+  async retryLargeBundles() {
+    try {
+      const bundleIds = await this.bundleIndex.getLargeFailedBundleIds(
+        config.BUNDLE_REPAIR_LARGE_RETRY_BATCH_SIZE,
+        config.BUNDLE_REPAIR_LARGE_BUNDLE_THRESHOLD,
+      );
+      for (const bundleId of bundleIds) {
+        this.log.info('Retrying large failed bundle', {
+          bundleId,
+          priority: 'large',
+        });
+        await this.bundleIndex.saveBundleRetries(bundleId);
+        await this.txFetcher.queueTxId({ txId: bundleId });
+      }
+    } catch (error: any) {
+      this.log.error('Error retrying large failed bundles:', error);
     }
   }
 

--- a/test/bundles-schema.sql
+++ b/test/bundles-schema.sql
@@ -158,6 +158,7 @@ CREATE INDEX bundle_data_items_root_transaction_id_idx ON bundle_data_items (roo
 CREATE INDEX stable_data_items_indexed_at_idx ON stable_data_items (indexed_at);
 CREATE INDEX root_transaction_id_idx ON bundles (root_transaction_id);
 CREATE INDEX bundles_active_retry_priority_idx ON bundles (last_fully_indexed_at, retry_attempt_count, last_retried_at);
+CREATE INDEX bundles_large_active_priority_idx ON bundles (data_item_count, retry_attempt_count, last_retried_at) WHERE last_fully_indexed_at IS NULL AND data_item_count >= 50;
 PRAGMA foreign_keys=OFF;
 BEGIN TRANSACTION;
 CREATE TABLE bundle_formats (


### PR DESCRIPTION
## Summary

Adds a second SQL statement + retry loop in \`BundleRepairWorker\` that targets bundles with **known** \`data_item_count >= threshold\` (default 50 — above direct ArDrive's 1-2 DIs, captures Turbo bulk). It runs alongside the existing retry loop on its own setInterval.

**Why**: the existing retry loop selects bundles ordered by \`retry_attempt_count\` — treating a 2-DI direct ArDrive bundle and a 500-DI Turbo bundle equally. On a typical ArDrive gateway, small direct bundles outnumber Turbo bundles ~50:1 (recent 24h on a test gateway: 11,454 small unbundled, 1 large). The small ones dominate the worker pool and large Turbo bundles starve, even when known and in flight. DI throughput suffers as a result — most of the ArDrive data volume lives in those 100-1000-DI Turbo bundles.

**Why not just change the existing ORDER BY** to \`data_item_count DESC\`? Three independent reasons:
1. **Starvation**: brand-new small uploads would wait days behind the Turbo backlog (~92k known small bundles still in flight at change time).
2. **NULL handling**: 2.5M matched bundles haven't been downloaded yet, so \`data_item_count IS NULL\`. \`NULLS LAST\` puts the bulk of pending work at the back of the queue.
3. **Regresses PR #719**: the existing query's index (\`bundles_active_retry_priority_idx\` on \`(last_fully_indexed_at, retry_attempt_count, last_retried_at)\`) wouldn't satisfy the new sort order, reintroducing the TEMP B-TREE FOR ORDER BY that PR #719 fixed (211× live measurement).

## Design

- **New SQL**: \`selectLargeFailedBundleIds\` (added to \`src/database/sql/bundles/repair.sql\`). Same outer WHERE as \`selectFailedBundleIds\` plus \`data_item_count IS NOT NULL AND data_item_count >= @threshold\`, ORDER BY \`data_item_count DESC, retry_attempt_count, last_retried_at ASC\`.
- **New partial index**: \`bundles_large_active_priority_idx ON bundles (data_item_count, retry_attempt_count, last_retried_at) WHERE last_fully_indexed_at IS NULL AND data_item_count >= 50\`. Tiny — partial WHERE keeps it to ~1k rows vs the 9.8M-row table.
- **New retry method**: \`BundleRepairWorker.retryLargeBundles\` — same shape as the existing \`retryBundles\`, just calls the new SQL.
- **Three new env vars**: \`BUNDLE_REPAIR_LARGE_RETRY_INTERVAL_SECONDS=300\`, \`BUNDLE_REPAIR_LARGE_RETRY_BATCH_SIZE=500\`, \`BUNDLE_REPAIR_LARGE_BUNDLE_THRESHOLD=50\`. Setting batch_size to 0 soft-disables the lane (loop iterates over empty array).

## Risk audit — what could go wrong

- **Data integrity**: zero risk. The new SQL is SELECT-only. The new index is partial + additive. SQLite atomically maintains index consistency with row writes.
- **Same bundle picked by both queries in one cycle**: \`txFetcher.queueTxId\` deduplicates against its in-memory queue snapshot — the second call is a no-op. The only observable effect is \`retry_attempt_count\` incrementing twice instead of once, which is cosmetic.
- **Brand-new uploads with no data_item_count**: only picked by the existing query, get downloaded normally, become eligible for the new lane after first unbundle. **Not starved.**
- **Threshold misconfigured to 1**: both queries pick the same population, doubling retry attempts. Still works.
- **Threshold misconfigured very high**: new query returns empty. Effectively disables the lane.
- **Migration cost on large DBs**: partial WHERE keeps the index tiny — on a 9.8M-row gateway with ~1k matching rows the index is a few MB and the CREATE takes ~10 s. ANALYZE adds another ~10 s.

## Verification

Migration syntax (fresh DB):
- ✓ up runs cleanly
- ✓ down runs cleanly
- ✓ up re-runs cleanly (idempotent)

EXPLAIN on a copy of a 9.8M-row live \`bundles.db\` after applying the migration:

**Existing query (unchanged behavior)**:
\`\`\`
SEARCH TABLE bundles USING INDEX bundles_active_retry_priority_idx (last_fully_indexed_at=?)
\`\`\`
PR #719's index still serves the existing query. No regression.

**New query**:
\`\`\`
SEARCH TABLE bundles USING INDEX bundles_large_active_priority_idx (data_item_count>?)
USE TEMP B-TREE FOR RIGHT PART OF ORDER BY
\`\`\`
Uses the new partial index. The "RIGHT PART" temp sort is the trailing \`retry_attempt_count, last_retried_at\` columns within each \`data_item_count\` value — unavoidable given DESC on the leading column. Acceptable: the candidate set is tiny (442 rows in our test).

**New query runtime on the live-data copy**: 13 ms (442 results).

## Stacks on

Based on \`perf/data-importer-memory\` (PR #720). Once that merges, GitHub will auto-rebase this onto develop.

## Test plan

- [x] SQL syntax verified on fresh DB
- [x] Migration up/down/idempotency verified
- [x] EXPLAIN verified — no regression on existing query, new query uses new index
- [x] New query runtime measured on production-scale DB copy (13 ms)
- [x] Race-condition design walked through (see risk audit)
- [x] Test schema updated (\`test/bundles-schema.sql\`) with the new index
- [ ] \`yarn test\` — local Node version mismatch with ESLint 9.37; deferred to CI
- [ ] Local deployment + observation of large-bundle retry rate after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)