### PR TITLE
feat(data-importer): instrument bundle download duration and queue-full skips

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -111,6 +111,47 @@ export const bundleDataItemCountHistogram = new promClient.Histogram({
   buckets: [1, 10, 100, 1000, 10_000, 100_000, 500_000, 1_000_000, 5_000_000],
 });
 
+// Wall-clock seconds spent in a single bundle download attempt
+// (from contiguousDataSource.getData → stream end / error). Labelled by
+// `outcome` so we can separately observe success vs error tails. Wide
+// buckets because turbo bundles can legitimately take many minutes.
+export const bundleDownloadDurationSeconds = new promClient.Histogram({
+  name: 'bundle_download_duration_seconds',
+  help: 'Wall-clock duration of a bundle download attempt',
+  labelNames: ['outcome'],
+  buckets: [0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600, 1200, 1800, 3600],
+});
+
+// Reported size (in bytes) of the contiguous data backing each bundle
+// download attempt. Useful for correlating size with download duration —
+// answers "are slow downloads big, or are big downloads also slow when
+// they finish?"
+export const bundleDownloadSizeBytes = new promClient.Histogram({
+  name: 'bundle_download_size_bytes',
+  help: 'Bundle download size in bytes (as reported by contiguousDataSource)',
+  labelNames: ['outcome'],
+  buckets: [
+    1_024,
+    10_240,
+    102_400,
+    1_048_576,
+    10_485_760,
+    104_857_600,
+    1_073_741_824,
+    10_737_418_240,
+  ],
+});
+
+// Count of items dropped by DataImporter because its queue was at
+// maxQueueSize. Critical for diagnosing retry-lane effectiveness: if this
+// is high while BundleRepairWorker.retryLargeBundles is running, retries
+// are being silently absorbed.
+export const dataImporterQueueFullSkipsCounter = new promClient.Counter({
+  name: 'data_importer_queue_full_skips_total',
+  help: 'Items dropped by DataImporter due to full queue',
+  labelNames: ['importer'],
+});
+
 export const dataItemsQueuedCounter = new promClient.Counter({
   name: 'data_items_queued_total',
   help: 'Count of data items queued for indexing',

--- a/src/system.ts
+++ b/src/system.ts
@@ -1211,6 +1211,7 @@ metrics.registerQueueLengthGauge('ans104Unbundler', {
 
 export const verificationDataImporter = new DataImporter({
   log,
+  name: 'verificationDataImporter',
   contiguousDataSource: txChunksDataSource,
   workerCount: config.ANS104_DOWNLOAD_WORKERS,
   maxQueueSize: config.VERIFICATION_DATA_IMPORTER_QUEUE_SIZE,
@@ -1220,6 +1221,7 @@ metrics.registerQueueLengthGauge('verificationDataImporter', {
 });
 export const bundleDataImporter = new DataImporter({
   log,
+  name: 'bundleDataImporter',
   contiguousDataSource: backgroundContiguousDataSource,
   ans104Unbundler,
   workerCount: config.ANS104_DOWNLOAD_WORKERS,

--- a/src/workers/data-importer.ts
+++ b/src/workers/data-importer.ts
@@ -15,6 +15,7 @@ import {
   PartialJsonTransaction,
 } from '../types.js';
 import * as config from '../config.js';
+import * as metrics from '../metrics.js';
 
 interface IndexProperty {
   index: number;
@@ -39,24 +40,28 @@ export class DataImporter {
   private ans104Unbundler: Ans104Unbundler | undefined;
 
   // Contiguous data queue
+  private name: string;
   private workerCount: number;
   private maxQueueSize: number;
   private queue: queueAsPromised<DataImporterQueueItem, void>;
 
   constructor({
     log,
+    name = 'default',
     contiguousDataSource,
     ans104Unbundler,
     workerCount,
     maxQueueSize = config.BUNDLE_DATA_IMPORTER_QUEUE_SIZE,
   }: {
     log: winston.Logger;
+    name?: string;
     contiguousDataSource: ContiguousDataSource;
     ans104Unbundler?: Ans104Unbundler;
     workerCount: number;
     maxQueueSize?: number;
   }) {
-    this.log = log.child({ class: this.constructor.name });
+    this.name = name;
+    this.log = log.child({ class: this.constructor.name, importer: name });
     this.contiguousDataSource = contiguousDataSource;
     if (ans104Unbundler) {
       this.ans104Unbundler = ans104Unbundler;
@@ -89,6 +94,7 @@ export class DataImporter {
       this.queue.push({ item, prioritized, bypassFilter });
       log.debug('Contiguous data download queued.');
     } else {
+      metrics.dataImporterQueueFullSkipsCounter.inc({ importer: this.name });
       log.debug('Skipping contiguous data download, queue is full.');
     }
   }
@@ -99,27 +105,48 @@ export class DataImporter {
     bypassFilter,
   }: DataImporterQueueItem): Promise<void> {
     const log = this.log.child({ method: 'download', id: item.id });
+    const startMs = Date.now();
 
     const data = await this.contiguousDataSource.getData({ id: item.id });
+    const size = data.size;
 
     return new Promise((resolve, reject) => {
       data.stream.on('end', () => {
+        const elapsedMs = Date.now() - startMs;
+        metrics.bundleDownloadDurationSeconds.observe(
+          { outcome: 'success' },
+          elapsedMs / 1000,
+        );
+        metrics.bundleDownloadSizeBytes.observe(
+          { outcome: 'success' },
+          size,
+        );
         const hasIndexProperty = this.hasIndexPropery(item);
+        log.info('Bundle download completed', {
+          elapsedMs,
+          size,
+          cached: data.cached,
+          willUnbundle: this.ans104Unbundler !== undefined && hasIndexProperty,
+        });
         if (this.ans104Unbundler && hasIndexProperty) {
-          log.debug('Data download completed. Queuing for unbundling...');
           this.ans104Unbundler.queueItem(item, prioritized, bypassFilter);
-        } else {
-          log.debug(
-            hasIndexProperty
-              ? 'Data download completed, skipping unbundling because unbundler is not available'
-              : 'Data download completed, skipping unbundling because no index was provided to the tx/data-item',
-          );
         }
         resolve();
       });
 
       data.stream.on('error', (error) => {
-        log.error('Error downloading data.', {
+        const elapsedMs = Date.now() - startMs;
+        metrics.bundleDownloadDurationSeconds.observe(
+          { outcome: 'error' },
+          elapsedMs / 1000,
+        );
+        metrics.bundleDownloadSizeBytes.observe(
+          { outcome: 'error' },
+          size,
+        );
+        log.error('Bundle download failed', {
+          elapsedMs,
+          size,
           message: error.message,
           stack: error.stack,
         });

--- a/src/workers/data-importer.ts
+++ b/src/workers/data-importer.ts
@@ -107,7 +107,22 @@ export class DataImporter {
     const log = this.log.child({ method: 'download', id: item.id });
     const startMs = Date.now();
 
-    const data = await this.contiguousDataSource.getData({ id: item.id });
+    // Instrument the source-chain rejection path (all sources exhausted,
+    // 404 from every tier, etc.) so failures before a stream is returned
+    // still show up in the duration / size histograms. Without this, the
+    // outcome="error" bucket only captures mid-stream failures.
+    let data;
+    try {
+      data = await this.contiguousDataSource.getData({ id: item.id });
+    } catch (error) {
+      const elapsedMs = Date.now() - startMs;
+      metrics.bundleDownloadDurationSeconds.observe(
+        { outcome: 'error' },
+        elapsedMs / 1000,
+      );
+      metrics.bundleDownloadSizeBytes.observe({ outcome: 'error' }, 0);
+      throw error;
+    }
     const size = data.size;
 
     return new Promise((resolve, reject) => {

--- a/src/workers/data-importer.ts
+++ b/src/workers/data-importer.ts
@@ -117,10 +117,7 @@ export class DataImporter {
           { outcome: 'success' },
           elapsedMs / 1000,
         );
-        metrics.bundleDownloadSizeBytes.observe(
-          { outcome: 'success' },
-          size,
-        );
+        metrics.bundleDownloadSizeBytes.observe({ outcome: 'success' }, size);
         const hasIndexProperty = this.hasIndexPropery(item);
         log.info('Bundle download completed', {
           elapsedMs,
@@ -140,10 +137,7 @@ export class DataImporter {
           { outcome: 'error' },
           elapsedMs / 1000,
         );
-        metrics.bundleDownloadSizeBytes.observe(
-          { outcome: 'error' },
-          size,
-        );
+        metrics.bundleDownloadSizeBytes.observe({ outcome: 'error' }, size);
         log.error('Bundle download failed', {
           elapsedMs,
           size,


### PR DESCRIPTION
## Summary
Adds three Prometheus signals to the bundle-download path so we can answer outstanding diagnostic questions about why turbo (large-DI) bundles aren't completing:

- `bundle_download_duration_seconds{outcome}` — wall-clock per download attempt. Wide buckets (0.5s → 1h) to surface multi-minute turbo downloads vs sub-second small-bundle hits.
- `bundle_download_size_bytes{outcome}` — `ContiguousData.size` per attempt. Correlate duration with payload size: distinguishes "slow because big" from "slow regardless of size."
- `data_importer_queue_full_skips_total{importer}` — increments every time `queueItem` drops an item because the queue is at `maxQueueSize`. Previously a silent `log.debug`; this is the diagnostic that tells us whether `BundleRepairWorker.retryLargeBundles` is having its retries silently absorbed before reaching a worker.

Promotes the on-success / on-error log lines from `debug` to `info` and attaches `elapsedMs` / `size` / `cached`, so operators can spot-check without a Prometheus scrape.

Adds an optional `name` parameter to `DataImporter` so the counter and log lines can distinguish `bundleDataImporter` from `verificationDataImporter`. Existing tests don't pass `name` and fall back to the default — no test changes required.

**No behavior changes.** Queue management, retry semantics, and stream plumbing are unchanged.

## Test plan
- [ ] CI: existing `data-importer.test.ts` should pass unchanged (the new `name` param is optional with a default)
- [ ] Local build + deploy, then verify:
  - `curl /ar-io/__gateway_metrics | grep bundle_download_duration_seconds` shows samples accruing
  - `data_importer_queue_full_skips_total{importer="bundleDataImporter"}` rises in step with `BundleRepairWorker.retryLargeBundles` cycles when the queue is at cap
  - JSON log entries `"Bundle download completed"` carry `elapsedMs`, `size`, `cached`
- [ ] Sanity: confirm no regression in `bundles_unbundled_total` rate over 30 min after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)