### PR TITLE
fix(dns-resolver): preserve hostname for HTTPS URLs to keep SNI valid

### DIFF
--- a/src/lib/dns-resolver.test.ts
+++ b/src/lib/dns-resolver.test.ts
@@ -29,12 +29,12 @@ describe('DnsResolver', () => {
       mock.method(dns, 'resolve4', mockResolve4);
 
       const result = await dnsResolver.resolveUrl(
-        'https://example.com:8080/path',
+        'http://example.com:8080/path',
       );
 
       assert.equal(result.hostname, 'example.com');
-      assert.equal(result.originalUrl, 'https://example.com:8080/path');
-      assert.equal(result.resolvedUrl, 'https://192.168.1.1:8080/path');
+      assert.equal(result.originalUrl, 'http://example.com:8080/path');
+      assert.equal(result.resolvedUrl, 'http://192.168.1.1:8080/path');
       assert.deepEqual(result.ips, ['192.168.1.1', '192.168.1.2']);
       assert.equal(result.resolutionError, undefined);
       assert.equal(mockResolve4.mock.calls.length, 1);
@@ -49,10 +49,10 @@ describe('DnsResolver', () => {
       mock.method(dns, 'resolve4', mockResolve4);
       mock.method(dns, 'resolve6', mockResolve6);
 
-      const result = await dnsResolver.resolveUrl('https://example.com/path');
+      const result = await dnsResolver.resolveUrl('http://example.com/path');
 
       assert.equal(result.hostname, 'example.com');
-      assert.equal(result.resolvedUrl, 'https://[2001:db8::1]/path');
+      assert.equal(result.resolvedUrl, 'http://[2001:db8::1]/path');
       assert.deepEqual(result.ips, ['2001:db8::1']);
       assert.equal(mockResolve4.mock.calls.length, 1);
       assert.equal(mockResolve6.mock.calls.length, 1);
@@ -63,10 +63,10 @@ describe('DnsResolver', () => {
       mock.method(dns, 'resolve4', mockResolve4);
 
       const result = await dnsResolver.resolveUrl(
-        'https://data.example.com:8080/chunk',
+        'http://data.example.com:8080/chunk',
       );
 
-      assert.equal(result.resolvedUrl, 'https://10.0.0.1:8080/chunk');
+      assert.equal(result.resolvedUrl, 'http://10.0.0.1:8080/chunk');
     });
 
     it('should preserve path in resolved URL', async () => {
@@ -74,10 +74,45 @@ describe('DnsResolver', () => {
       mock.method(dns, 'resolve4', mockResolve4);
 
       const result = await dnsResolver.resolveUrl(
+        'http://example.com/chunk/12345',
+      );
+
+      assert.equal(result.resolvedUrl, 'http://10.0.0.1/chunk/12345');
+    });
+
+    it('should preserve hostname for HTTPS URLs (SNI/TLS cert validity)', async () => {
+      const mockResolve4 = mock.fn(async () => ['10.0.0.1', '10.0.0.2']);
+      mock.method(dns, 'resolve4', mockResolve4);
+
+      const result = await dnsResolver.resolveUrl(
         'https://example.com/chunk/12345',
       );
 
-      assert.equal(result.resolvedUrl, 'https://10.0.0.1/chunk/12345');
+      // Hostname must NOT be substituted with the IP for HTTPS, otherwise
+      // fetch() sends TLS SNI = IP and the server cert (issued for the
+      // hostname) trips ERR_TLS_CERT_ALTNAME_INVALID.
+      assert.equal(result.hostname, 'example.com');
+      assert.equal(result.originalUrl, 'https://example.com/chunk/12345');
+      assert.equal(result.resolvedUrl, 'https://example.com/chunk/12345');
+      // DNS resolution still runs so change-detection logging and the IP
+      // cache stay accurate.
+      assert.deepEqual(result.ips, ['10.0.0.1', '10.0.0.2']);
+      assert.equal(result.resolutionError, undefined);
+      assert.equal(mockResolve4.mock.calls.length, 1);
+    });
+
+    it('should preserve HTTPS hostname even when IPv4 falls back to IPv6', async () => {
+      const mockResolve4 = mock.fn(async () => {
+        throw new Error('IPv4 resolution failed');
+      });
+      const mockResolve6 = mock.fn(async () => ['2001:db8::1']);
+      mock.method(dns, 'resolve4', mockResolve4);
+      mock.method(dns, 'resolve6', mockResolve6);
+
+      const result = await dnsResolver.resolveUrl('https://example.com/path');
+
+      assert.equal(result.resolvedUrl, 'https://example.com/path');
+      assert.deepEqual(result.ips, ['2001:db8::1']);
     });
 
     it('should skip resolution for IP addresses', async () => {
@@ -141,13 +176,13 @@ describe('DnsResolver', () => {
       });
       mock.method(dns, 'resolve4', mockResolve4);
 
-      const urls = ['https://example1.com/path1', 'https://example2.com/path2'];
+      const urls = ['http://example1.com/path1', 'http://example2.com/path2'];
 
       const results = await dnsResolver.resolveUrls(urls);
 
       assert.equal(results.length, 2);
-      assert.equal(results[0].resolvedUrl, 'https://10.0.0.1/path1');
-      assert.equal(results[1].resolvedUrl, 'https://10.0.0.2/path2');
+      assert.equal(results[0].resolvedUrl, 'http://10.0.0.1/path1');
+      assert.equal(results[1].resolvedUrl, 'http://10.0.0.2/path2');
       assert.equal(mockResolve4.mock.calls.length, 2);
     });
 
@@ -162,14 +197,14 @@ describe('DnsResolver', () => {
       mock.method(dns, 'resolve4', mockResolve4);
       mock.method(dns, 'resolve6', mockResolve6);
 
-      const urls = ['https://success.com/path', 'https://failure.com/path'];
+      const urls = ['http://success.com/path', 'http://failure.com/path'];
 
       const results = await dnsResolver.resolveUrls(urls);
 
       assert.equal(results.length, 2);
-      assert.equal(results[0].resolvedUrl, 'https://10.0.0.1/path');
+      assert.equal(results[0].resolvedUrl, 'http://10.0.0.1/path');
       assert.equal(results[0].resolutionError, undefined);
-      assert.equal(results[1].resolvedUrl, 'https://failure.com/path');
+      assert.equal(results[1].resolvedUrl, 'http://failure.com/path');
       assert(results[1].resolutionError !== undefined);
     });
   });
@@ -179,12 +214,12 @@ describe('DnsResolver', () => {
       const mockResolve4 = mock.fn(async () => ['10.0.0.1']);
       mock.method(dns, 'resolve4', mockResolve4);
 
-      await dnsResolver.resolveUrl('https://example.com/path');
+      await dnsResolver.resolveUrl('http://example.com/path');
       const cached = dnsResolver.getResolvedUrl('example.com');
 
       assert(cached);
       assert.equal(cached.hostname, 'example.com');
-      assert.equal(cached.resolvedUrl, 'https://10.0.0.1/path');
+      assert.equal(cached.resolvedUrl, 'http://10.0.0.1/path');
     });
 
     it('should return undefined for unknown hostname', () => {
@@ -201,18 +236,18 @@ describe('DnsResolver', () => {
       });
       mock.method(dns, 'resolve4', mockResolve4);
 
-      await dnsResolver.resolveUrl('https://known.com/path');
+      await dnsResolver.resolveUrl('http://known.com/path');
 
       const urls = [
-        'https://known.com/different-path',
-        'https://unknown.com/path',
+        'http://known.com/different-path',
+        'http://unknown.com/path',
       ];
 
       const resolved = dnsResolver.getResolvedUrlStrings(urls);
 
       assert.equal(resolved.length, 2);
-      assert.equal(resolved[0], 'https://10.0.0.1/different-path');
-      assert.equal(resolved[1], 'https://unknown.com/path');
+      assert.equal(resolved[0], 'http://10.0.0.1/different-path');
+      assert.equal(resolved[1], 'http://unknown.com/path');
     });
 
     it('should handle invalid URLs gracefully', () => {
@@ -236,15 +271,15 @@ describe('DnsResolver', () => {
       mock.method(dns, 'resolve4', mockResolve4);
 
       // Initial resolution
-      await dnsResolver.resolveUrl('https://example.com/path');
+      await dnsResolver.resolveUrl('http://example.com/path');
       const initial = dnsResolver.getResolvedUrl('example.com');
-      assert.equal(initial?.resolvedUrl, 'https://10.0.0.1/path');
+      assert.equal(initial?.resolvedUrl, 'http://10.0.0.1/path');
 
       // Re-resolve URLs - should detect change
-      await dnsResolver.resolveUrls(['https://example.com/path']);
+      await dnsResolver.resolveUrls(['http://example.com/path']);
 
       const updated = dnsResolver.getResolvedUrl('example.com');
-      assert.equal(updated?.resolvedUrl, 'https://10.0.0.2/path');
+      assert.equal(updated?.resolvedUrl, 'http://10.0.0.2/path');
     });
   });
 });

--- a/src/lib/dns-resolver.ts
+++ b/src/lib/dns-resolver.ts
@@ -94,15 +94,31 @@ export class DnsResolver {
         throw new Error(`No IP addresses found for hostname: ${hostname}`);
       }
 
-      // Use the first IP address
-      const selectedIp = ips[0];
-      // IPv6 addresses need brackets when setting hostname
-      if (selectedIp.includes(':')) {
-        url.hostname = `[${selectedIp}]`;
+      // For HTTPS URLs, do NOT substitute the hostname with an IP. fetch()
+      // would otherwise set TLS SNI and Host to the IP, which mismatches the
+      // server certificate (cert is for the hostname, not the IP) and trips
+      // ERR_TLS_CERT_ALTNAME_INVALID. The DNS resolution still runs so
+      // change-detection logging and the IP cache stay accurate; we just
+      // return the original URL and let Node's native DNS resolve it at
+      // request time with the correct hostname for SNI.
+      let resolvedUrl: string;
+      if (url.protocol === 'https:') {
+        resolvedUrl = urlString;
+        log.debug('Preserving hostname for HTTPS URL to maintain SNI', {
+          hostname,
+          resolvedIps: ips.length,
+        });
       } else {
-        url.hostname = selectedIp;
+        // Use the first IP address
+        const selectedIp = ips[0];
+        // IPv6 addresses need brackets when setting hostname
+        if (selectedIp.includes(':')) {
+          url.hostname = `[${selectedIp}]`;
+        } else {
+          url.hostname = selectedIp;
+        }
+        resolvedUrl = url.toString();
       }
-      const resolvedUrl = url.toString();
 
       const result: ResolvedUrl = {
         hostname,

--- a/src/lib/dns-resolver.ts
+++ b/src/lib/dns-resolver.ts
@@ -27,7 +27,17 @@ export class DnsResolver {
   }
 
   /**
-   * Resolve a single URL to its IP addresses
+   * Resolve a URL's hostname to IP addresses.
+   *
+   * DNS lookup runs for both protocols, but the returned `resolvedUrl`
+   * differs by protocol:
+   * - HTTPS: `resolvedUrl === originalUrl`. The hostname is preserved so
+   *   TLS SNI/Host stay valid (otherwise `ERR_TLS_CERT_ALTNAME_INVALID`).
+   *   DNS is used only for the in-memory cache and change-detection logs.
+   * - HTTP: the first resolved IP is substituted into `resolvedUrl`, so
+   *   `resolvedUrl !== originalUrl`.
+   *
+   * Callers must not assume `resolvedUrl !== originalUrl`.
    */
   async resolveUrl(urlString: string): Promise<ResolvedUrl> {
     const log = this.log.child({ method: 'resolveUrl', url: urlString });
@@ -102,6 +112,7 @@ export class DnsResolver {
       // return the original URL and let Node's native DNS resolve it at
       // request time with the correct hostname for SNI.
       let resolvedUrl: string;
+      let selectedIp: string | undefined;
       if (url.protocol === 'https:') {
         resolvedUrl = urlString;
         log.debug('Preserving hostname for HTTPS URL to maintain SNI', {
@@ -110,7 +121,7 @@ export class DnsResolver {
         });
       } else {
         // Use the first IP address
-        const selectedIp = ips[0];
+        selectedIp = ips[0];
         // IPv6 addresses need brackets when setting hostname
         if (selectedIp.includes(':')) {
           url.hostname = `[${selectedIp}]`;
@@ -131,7 +142,7 @@ export class DnsResolver {
       this.resolvedUrls.set(hostname, result);
       log.debug('Successfully resolved URL', {
         hostname,
-        selectedIp: ips[0],
+        ...(selectedIp !== undefined ? { selectedIp } : {}),
         totalIps: ips.length,
       });
 

--- a/src/lib/dns-resolver.ts
+++ b/src/lib/dns-resolver.ts
@@ -131,7 +131,7 @@ export class DnsResolver {
       this.resolvedUrls.set(hostname, result);
       log.debug('Successfully resolved URL', {
         hostname,
-        selectedIp,
+        selectedIp: ips[0],
         totalIps: ips.length,
       });
 


### PR DESCRIPTION
## Summary
When `PREFERRED_CHUNK_GET_NODE_URLS` includes HTTPS endpoints (e.g. `https://arweave.net`), the `DnsResolver` overwrites the URL hostname with the resolved IP. `fetch()` then sends TLS SNI = IP and Host = IP, which mismatches the server certificate (issued for the hostname, not the IP) and trips `ERR_TLS_CERT_ALTNAME_INVALID`. From the caller's perspective those peers look 100% dead, even though the upstream service is perfectly healthy.

## Repro
With Node 20.20.2 (same as the gateway runtime):
```
INPUT: https://arweave.net/
  dns.resolve4 → [ '109.61.91.195', ... ]
  url.hostname = ip → https://109.61.91.195/
  fetch() → ERR_TLS_CERT_ALTNAME_INVALID
```

## Field evidence
Production gateway with four HTTPS chunk endpoints added to `PREFERRED_CHUNK_GET_NODE_URLS`:
- `get_chunk_total{class="ArIOChunkSource"}` — **115 success vs 4292 errors (97% failure)**
- `get_chunk_total{class="ArweaveCompositeClient"}` — 849 success vs 33 errors (96% success on overlapping peers; this path does not use DnsResolver substitution)

## Scope
Only the HTTPS branch behavior changes. HTTP URLs continue to get the IP substitution they always had — the 22 default `data-*.arweave.xyz:1984` preferred chunk peers still pin to resolved IPs, exactly as before.

DNS resolution still runs for HTTPS URLs so:
- The IP cache (`getResolvedUrl`) stays populated
- Change-detection logging (line 158 area) still fires when the IP set changes

The HTTPS URL just gets returned unchanged so `fetch()` resolves the hostname natively at request time with the correct SNI.

## Test plan
- [x] Existing tests that asserted HTTPS substitution moved to HTTP (substitution's actual valid use case)
- [x] Two new test cases verify HTTPS preservation, including the IPv4→IPv6 fallback path
- [ ] CI: `npm test` for the `lib/dns-resolver.test.ts` suite
- [ ] Local deploy: add `https://arweave.net` to `PREFERRED_CHUNK_GET_NODE_URLS` and confirm `get_chunk_total{class="ArIOChunkSource",status="success"}` rises while `status="error"` rate drops well below 97%

🤖 Generated with [Claude Code](https://claude.com/claude-code)