### PR TITLE
fix(solana): restore core wallets mount required by HTTPSIG observer keypair

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,6 +60,7 @@ services:
       - ${ETL_STAGING_PATH:-./data/etl/staging}:/app/data/etl/staging
       - ${CDB64_ROOT_TX_INDEX_DATA_PATH:-./data/cdb64-root-tx-index}:/app/data/cdb64-root-tx-index
       - ${KEYS_DATA_PATH:-./data/keys}:/app/data/keys
+      - ${WALLETS_PATH:-./wallets}:/app/wallets:ro
       - ${SECRETS_PATH:-./secrets}:/app/secrets:ro
       - envoy-eds-data:/app/data/envoy-eds
     environment:


### PR DESCRIPTION
## Summary

`2708c23f` dropped the `WALLETS_PATH` bind mount on the assumption that no code under `src/` read `/app/wallets` after `c15831dc` — verified by grep. The grep produced a false negative: `c15831dc`'s `OBSERVER_KEYPAIR_PATH` is a generic env var whose value (an absolute path conventionally under `/app/wallets/`) is supplied at deploy time, so the path string never appears as a literal in `src/`.

With the mount removed, core's HTTPSIG init fails on startup:

```
error: HTTPSIG initialization failed; signing disabled
{"error":"Solana keypair file not found: /app/wallets/<file>"}
```

`config.ts:initializeHttpSig` then leaves `HTTPSIG_SIGNER` undefined, so `/ar-io/info` silently drops the `httpsig` section. Verifiers can no longer look up the gateway's signing key in the GAR — defeating the whole point of the `c15831dc` refactor.

This PR restores the read-only bind mount in the same position `c15831dc` left it.

## Test plan

- [x] Set `OBSERVER_KEYPAIR_PATH=/app/wallets/<keypair>.json` in `.env`
- [x] `docker compose up -d --force-recreate core`
- [x] Confirm `/ar-io/info` returns `httpsig` with the operator pubkey
- [x] Confirm core logs show `HTTPSIG response signing enabled` with `keySource` pointing at the keypair (not auto-generated PEM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)