### PR TITLE
refactor(solana): rename ArNS processId -> antId and expose X-ArNS-Ant-Id

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -421,9 +421,14 @@ components:
         ttlSeconds:
           type: integer
           description: Time-to-live in seconds for this resolution
-        processId:
+        antId:
           type: string
-          description: AO process ID
+          description: |
+            Per-ANT identifier for the ANT that resolved this name. In
+            Solana mode this is the ANT mint's PDA (base58 pubkey); in AO
+            mode this was the ANT's AO process ID. Omitted when resolution
+            came via a trusted-gateway peer that has not yet shipped the
+            X-ArNS-Ant-Id header.
         resolvedAt:
           type: integer
           description: Unix timestamp when the name was resolved
@@ -436,7 +441,6 @@ components:
       required:
         - txId
         - ttlSeconds
-        - processId
         - resolvedAt
         - index
         - limit
@@ -531,9 +535,6 @@ paths:
                       wallet:
                         $ref: '#/components/schemas/Base64Url43'
                         description: Gateway wallet address
-                      processId:
-                        $ref: '#/components/schemas/Base64Url43'
-                        description: Gateway process ID
                       ans104UnbundleFilter:
                         type: object
                         description: Configuration for ANS-104 unbundling filter
@@ -550,7 +551,6 @@ paths:
                         type: string
                         description: Gateway software release version
                     required:
-                      - processId
                       - supportedManifestVersions
                       - release
             application/octet-stream:
@@ -617,8 +617,6 @@ paths:
                   wallet:
                     $ref: '#/components/schemas/Base64Url43'
                     description: Gateway wallet address
-                  processId:
-                    $ref: '#/components/schemas/Base64Url43'
                   ans104UnbundleFilter:
                     type: object
                     description: Configuration for ANS-104 unbundling filter
@@ -870,7 +868,6 @@ paths:
                       - publicKey
                       - keyId
                 required:
-                  - processId
                   - supportedManifestVersions
                   - release
                   - bundlers
@@ -2591,10 +2588,23 @@ paths:
               schema:
                 type: string
               description: Time-to-live in seconds for this resolution
-            x-arns-process-id:
+            x-arns-ant-program-id:
               schema:
                 type: string
-              description: AO process ID
+              description: |
+                Solana program ID of the AR.IO ANT program that owns the
+                ANT mint that resolved this name. Single value across all
+                ArNS names served by this gateway. Set from
+                ARIO_ANT_PROGRAM_ID.
+            x-arns-ant-id:
+              schema:
+                type: string
+              description: |
+                Per-ANT identifier for the ANT that resolved this request
+                (Solana ANT mint PDA in Solana mode, AO process ID in AO
+                mode). Replaces the AO-era X-ArNS-Process-Id header.
+                Omitted when resolution came via a trusted-gateway peer
+                that has not yet shipped this header.
             x-arns-resolved-at:
               schema:
                 type: string

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -69,6 +69,13 @@ export const headerNames = {
    * metadata.
    */
   arnsAntProgramId: 'X-ArNS-Ant-Program-Id',
+  /**
+   * Identifier of the specific ANT (the per-name account, not the program)
+   * that resolved this request. In Solana mode this is the ANT mint's PDA;
+   * in AO mode this was the ANT's AO process ID. Replaces the AO-era
+   * `X-ArNS-Process-Id` header — same purpose, generalized name.
+   */
+  arnsAntId: 'X-ArNS-Ant-Id',
   arnsResolvedAt: 'X-ArNS-Resolved-At',
   arnsLimit: 'X-ArNS-Undername-Limit',
   arnsIndex: 'X-ArNS-Record-Index',

--- a/src/lib/httpsig.ts
+++ b/src/lib/httpsig.ts
@@ -39,6 +39,7 @@ export const TRIGGER_HEADERS = new Set([
   'x-arns-resolved-id',
   'x-arns-ttl-seconds',
   'x-arns-ant-program-id',
+  'x-arns-ant-id',
   'x-arweave-chunk-data-root',
   'x-arweave-chunk-tx-id',
   'x-ar-io-chunk-source-type',

--- a/src/middleware/arns.ts
+++ b/src/middleware/arns.ts
@@ -161,8 +161,7 @@ export const createArnsMiddleware = ({
         const resolution = await nameResolver.resolve({
           name: arnsSubdomain,
         });
-        const { resolvedId, ttl, processId, resolvedAt, limit, index } =
-          resolution;
+        const { resolvedId, ttl, antId, resolvedAt, limit, index } = resolution;
         end();
         const resolutionDuration = Date.now() - resolutionStart;
         span.setAttribute('arns.resolution_duration_ms', resolutionDuration);
@@ -198,7 +197,7 @@ export const createArnsMiddleware = ({
             basename,
             record,
             ttl,
-            processId,
+            antId,
             resolvedAt,
             limit,
             index,
@@ -219,6 +218,9 @@ export const createArnsMiddleware = ({
               headerNames.arnsAntProgramId,
               config.ARIO_ANT_PROGRAM_ID,
             );
+          }
+          if (antId !== undefined) {
+            res.header(headerNames.arnsAntId, antId);
           }
           if (resolvedAt !== undefined) {
             res.header(headerNames.arnsResolvedAt, resolvedAt.toString());

--- a/src/resolution/composite-arns-resolver.test.ts
+++ b/src/resolution/composite-arns-resolver.test.ts
@@ -19,7 +19,7 @@ const mockResolution: NameResolution = {
   resolvedId: 'tx1',
   resolvedAt: Date.now(),
   ttl: 300,
-  processId: 'process1',
+  antId: 'process1',
   limit: 1,
   index: 1,
 };
@@ -101,7 +101,7 @@ describe('CompositeArNSResolver', () => {
       resolvedId: 'tx1',
       resolvedAt: now - 100000,
       ttl: 300,
-      processId: 'process1',
+      antId: 'process1',
       limit: 1,
       index: 1,
     };
@@ -188,7 +188,7 @@ describe('CompositeArNSResolver', () => {
       resolvedId: undefined,
       resolvedAt: undefined,
       ttl: undefined,
-      processId: undefined,
+      antId: undefined,
       limit: undefined,
       index: undefined,
     });
@@ -201,7 +201,7 @@ describe('CompositeArNSResolver', () => {
       resolvedId: 'cached-tx',
       resolvedAt: now - 1_000_000, // expired (resolvedAt + ttl*1000 < now)
       ttl: 300,
-      processId: 'process1',
+      antId: 'process1',
       limit: 1,
       index: 1,
     };
@@ -242,7 +242,7 @@ describe('CompositeArNSResolver', () => {
       resolvedId: 'cached-tx',
       resolvedAt: now - 1_000_000,
       ttl: 300,
-      processId: 'process1',
+      antId: 'process1',
       limit: 1,
       index: 1,
     };
@@ -262,7 +262,7 @@ describe('CompositeArNSResolver', () => {
                   resolvedId: 'fresh-tx',
                   resolvedAt: Date.now(),
                   ttl: 300,
-                  processId: 'process1',
+                  antId: 'process1',
                   limit: 1,
                   index: 1,
                 }),
@@ -316,7 +316,7 @@ describe('CompositeArNSResolver', () => {
       resolvedId: undefined,
       resolvedAt: undefined,
       ttl: undefined,
-      processId: undefined,
+      antId: undefined,
       limit: undefined,
       index: undefined,
     });
@@ -345,7 +345,7 @@ describe('CompositeArNSResolver', () => {
           resolvedId: undefined,
           resolvedAt: undefined,
           ttl: undefined,
-          processId: undefined,
+          antId: undefined,
           limit: undefined,
           index: undefined,
         };

--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -268,7 +268,7 @@ export class CompositeArNSResolver implements NameResolver {
         resolvedId: undefined,
         resolvedAt: undefined,
         ttl: undefined,
-        processId: undefined,
+        antId: undefined,
         limit: undefined,
         index: undefined,
       };
@@ -424,7 +424,7 @@ export class CompositeArNSResolver implements NameResolver {
       resolvedId: undefined,
       resolvedAt: undefined,
       ttl: undefined,
-      processId: undefined,
+      antId: undefined,
       limit: undefined,
       index: undefined,
     };

--- a/src/resolution/on-demand-arns-resolver.ts
+++ b/src/resolution/on-demand-arns-resolver.ts
@@ -53,7 +53,7 @@ export class OnDemandArNSResolver implements NameResolver {
           resolvedId: undefined,
           resolvedAt: undefined,
           ttl: undefined,
-          processId: undefined,
+          antId: undefined,
           limit: undefined,
           index: undefined,
         };
@@ -75,19 +75,22 @@ export class OnDemandArNSResolver implements NameResolver {
           resolvedId: undefined,
           resolvedAt: Date.now(),
           ttl: 300,
-          processId: undefined,
+          antId: undefined,
           limit: undefined,
           index: undefined,
         };
       }
 
-      const processId = baseArNSRecord.processId;
+      // SDK boundary: `baseArNSRecord.processId` is the SDK's field name for
+      // the per-ANT identifier (a Solana PDA in Solana mode). We expose it
+      // internally and on the wire as `antId` / `X-ArNS-Ant-Id`.
+      const antId = baseArNSRecord.processId;
 
       const ant = new SolanaANTReadable({
         // See note in system.ts re: nested @solana/rpc-spec drift
         // between @ar.io/sdk and the top-level kit copy.
         rpc: this.solanaRpc as any,
-        processId: processId,
+        processId: antId,
         // Pin the ANT program to the gateway-configured ID so devnet/
         // testnet deployments don't silently fall back to the SDK's
         // bundled mainnet placeholder (which has no accounts off
@@ -122,7 +125,7 @@ export class OnDemandArNSResolver implements NameResolver {
         name,
         resolvedId,
         resolvedAt: Date.now(),
-        processId: processId,
+        antId,
         ttl,
         limit: baseArNSRecord.undernameLimit,
         index,
@@ -140,7 +143,7 @@ export class OnDemandArNSResolver implements NameResolver {
       resolvedId: undefined,
       resolvedAt: undefined,
       ttl: undefined,
-      processId: undefined,
+      antId: undefined,
       limit: undefined,
       index: undefined,
     };

--- a/src/resolution/trusted-gateway-arns-resolver.test.ts
+++ b/src/resolution/trusted-gateway-arns-resolver.test.ts
@@ -127,5 +127,65 @@ describe('TrustedGatewayArNSResolver', () => {
       assert.equal(resolution.ttl, DEFAULT_ARNS_TTL_SECONDS);
       assert.ok(resolution.resolvedAt !== undefined);
     });
+
+    it('should propagate antId from upstream X-ArNS-Ant-Id header', async () => {
+      const upstreamAntId = 'AntPda1111111111111111111111111111111111111';
+      interceptorId = axios.interceptors.request.use((config) => {
+        config.adapter = () =>
+          Promise.resolve({
+            status: 200,
+            statusText: 'OK',
+            headers: {
+              [headerNames.arnsResolvedId.toLowerCase()]: resolvedId,
+              [headerNames.arnsTtlSeconds.toLowerCase()]: '300',
+              [headerNames.arnsLimit.toLowerCase()]: '10',
+              [headerNames.arnsIndex.toLowerCase()]: '0',
+              [headerNames.arnsAntId.toLowerCase()]: upstreamAntId,
+            },
+            config,
+            data: null,
+          });
+        return config;
+      });
+
+      const resolver = new TrustedGatewayArNSResolver({
+        log,
+        trustedGatewayUrl: 'https://__NAME__.turbo-gateway.com',
+      });
+
+      const resolution = await resolver.resolve({ name: 'test' });
+
+      assert.equal(resolution.antId, upstreamAntId);
+      assert.equal(resolution.resolvedId, resolvedId);
+    });
+
+    it('should leave antId undefined when upstream omits X-ArNS-Ant-Id', async () => {
+      interceptorId = axios.interceptors.request.use((config) => {
+        config.adapter = () =>
+          Promise.resolve({
+            status: 200,
+            statusText: 'OK',
+            headers: {
+              [headerNames.arnsResolvedId.toLowerCase()]: resolvedId,
+              [headerNames.arnsTtlSeconds.toLowerCase()]: '300',
+              [headerNames.arnsLimit.toLowerCase()]: '10',
+              [headerNames.arnsIndex.toLowerCase()]: '0',
+            },
+            config,
+            data: null,
+          });
+        return config;
+      });
+
+      const resolver = new TrustedGatewayArNSResolver({
+        log,
+        trustedGatewayUrl: 'https://__NAME__.turbo-gateway.com',
+      });
+
+      const resolution = await resolver.resolve({ name: 'test' });
+
+      assert.equal(resolution.antId, undefined);
+      assert.equal(resolution.resolvedId, resolvedId);
+    });
   });
 });

--- a/src/resolution/trusted-gateway-arns-resolver.ts
+++ b/src/resolution/trusted-gateway-arns-resolver.ts
@@ -58,7 +58,7 @@ export class TrustedGatewayArNSResolver implements NameResolver {
           resolvedId: undefined,
           resolvedAt: Date.now(),
           ttl: DEFAULT_ARNS_TTL_SECONDS,
-          processId: undefined,
+          antId: undefined,
           limit: undefined,
           index: undefined,
         };
@@ -66,11 +66,15 @@ export class TrustedGatewayArNSResolver implements NameResolver {
 
       const resolvedId =
         response.headers[headerNames.arnsResolvedId.toLowerCase()];
-      // ANT identity is no longer surfaced on the HTTP response — peers
-      // expose only `X-ArNS-Ant-Program-Id` (the AR.IO ANT program). The
-      // per-name ANT mint is not propagated across the trusted-gateway
-      // hop; downstream callers that need it must re-resolve via the SDK.
-      const processId: string | undefined = undefined;
+      // Per-ANT identifier from the upstream peer. Peers that have not
+      // shipped the X-ArNS-Ant-Id header yet will return `undefined` here;
+      // downstream callers that need the ANT id must re-resolve via the
+      // SDK in that case.
+      const antIdHeader = response.headers[headerNames.arnsAntId.toLowerCase()];
+      const antId: string | undefined =
+        typeof antIdHeader === 'string' && antIdHeader.length > 0
+          ? antIdHeader
+          : undefined;
       const ttl =
         parseInt(response.headers[headerNames.arnsTtlSeconds.toLowerCase()]) ||
         DEFAULT_ARNS_TTL_SECONDS;
@@ -87,7 +91,7 @@ export class TrustedGatewayArNSResolver implements NameResolver {
           statusCode: response.status,
           resolvedId,
           resolvedAt: Date.now(),
-          processId,
+          antId,
           ttl,
           limit,
           index,
@@ -115,7 +119,7 @@ export class TrustedGatewayArNSResolver implements NameResolver {
       resolvedId: undefined,
       resolvedAt: undefined,
       ttl: undefined,
-      processId: undefined,
+      antId: undefined,
       limit: undefined,
       index: undefined,
     };

--- a/src/routes/ar-io-info-builder.ts
+++ b/src/routes/ar-io-info-builder.ts
@@ -171,7 +171,6 @@ export interface ArIoInfoConfig {
  * ```typescript
  * const info = buildArIoInfo({
  *   wallet: 'wallet-address',
- *   processId: 'process-id',
  *   ans104UnbundleFilter: {},
  *   ans104IndexFilter: {},
  *   release: 'r123',

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -150,7 +150,6 @@ arIoRouter.get('/ar-io/healthcheck', async (_req, res) => {
  * Response (both features enabled):
  * {
  *   "wallet": "...",
- *   "processId": "...",
  *   "bundlers": [
  *     { "url": "https://turbo.ardrive.io/" }
  *   ],

--- a/src/routes/arns.ts
+++ b/src/routes/arns.ts
@@ -43,7 +43,7 @@ arnsRouter.get('/ar-io/resolver/:name', async (req, res) => {
     return;
   }
 
-  const { statusCode, resolvedId, ttl, processId, resolvedAt, index, limit } =
+  const { statusCode, resolvedId, ttl, antId, resolvedAt, index, limit } =
     resolved;
 
   if (resolvedId === undefined || statusCode === 404) {
@@ -59,6 +59,9 @@ arnsRouter.get('/ar-io/resolver/:name', async (req, res) => {
   if (config.ARIO_ANT_PROGRAM_ID !== undefined) {
     res.header(headerNames.arnsAntProgramId, config.ARIO_ANT_PROGRAM_ID);
   }
+  if (antId !== undefined) {
+    res.header(headerNames.arnsAntId, antId);
+  }
   if (resolvedAt !== undefined) {
     res.header(headerNames.arnsResolvedAt, resolvedAt.toString());
   }
@@ -69,7 +72,7 @@ arnsRouter.get('/ar-io/resolver/:name', async (req, res) => {
   res.json({
     txId: resolvedId,
     ttlSeconds: ttl,
-    processId,
+    antId,
     resolvedAt,
     index,
     limit,

--- a/src/store/kv-arns-name-resolution-store.ts
+++ b/src/store/kv-arns-name-resolution-store.ts
@@ -16,7 +16,7 @@ import { KVBufferStore } from '../types.js';
  *   key: 'ardrive',
  *   value: Buffer.from({
  *      txId: <ARWEAVE-TX-ID>,
- *      processId: <AO-PROCESS-ID>,
+ *      antId: <PER-ANT-IDENTIFIER>, // Solana ANT PDA or AO process ID
  *      owner: <OWNING_ANT_ADDRESS>,
  *      ttl: <TTL_SECONDS>
  *   })

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1110,12 +1110,14 @@ export interface ValidNameResolution {
   resolvedAt: number;
   ttl: number;
   /**
-   * ANT mint pubkey that resolved this name. Set when the resolution
-   * came from a direct SDK call (`OnDemandArNSResolver` /
-   * `ArNSNamesCache`); `undefined` on trusted-gateway hops since the
-   * ANT identity is no longer propagated over HTTP.
+   * Per-ANT identifier for the ANT that resolved this name. In Solana mode
+   * this is the ANT mint's PDA; in AO mode this was the ANT's AO process
+   * ID. Set when the resolution came from a direct SDK call
+   * (`OnDemandArNSResolver` / `ArNSNamesCache`); read off the
+   * `X-ArNS-Ant-Id` header on trusted-gateway hops when the peer emits it,
+   * `undefined` otherwise.
    */
-  processId: string | undefined;
+  antId: string | undefined;
   limit: number;
   index: number;
 }
@@ -1127,7 +1129,7 @@ export interface MissingNameResolution {
   resolvedId: undefined;
   resolvedAt: number;
   ttl: number;
-  processId: undefined;
+  antId: undefined;
   limit: undefined;
   index: undefined;
 }
@@ -1139,7 +1141,7 @@ export interface FailedNameResolution {
   resolvedId: undefined;
   resolvedAt: undefined;
   ttl: undefined;
-  processId: undefined;
+  antId: undefined;
   limit: undefined;
   index: undefined;
 }

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -17,7 +17,7 @@ declare global {
         basename: string;
         record: string;
         ttl?: number;
-        processId?: string;
+        antId?: string;
         resolvedAt?: number;
         limit?: number;
         index?: number;


### PR DESCRIPTION
## Summary

Per-ANT identifier was being plumbed through the resolver stack as the AO-era `processId` field and silently dropped on the wire — clients had no way to identify *which specific ANT* resolved a name (only the AR.IO ANT program via `X-ArNS-Ant-Program-Id`, which is the same value for every ArNS name).

This PR:

- Renames the internal `processId` field to `antId` across `NameResolution` variants (`types.d.ts`), the `Request.arns` context (`express.d.ts`), and the three resolvers that produce it (on-demand, trusted-gateway, composite)
- Adds `X-ArNS-Ant-Id` header constant in `constants.ts` and emits it from both the subdomain middleware (`middleware/arns.ts`) and the `/ar-io/resolver/:name` route (`routes/arns.ts`)
- Adds the header to the HTTPSIG trigger-headers set so response signing covers it
- Adds `antId` to the JSON body of `/ar-io/resolver/:name` (was emitting an unused `processId: undefined`)
- Updates the trusted-gateway resolver to parse `X-ArNS-Ant-Id` from upstream peer responses (was hardcoding `undefined`)
- SDK boundary preserved: `on-demand-arns-resolver` still reads `baseArNSRecord.processId` from `@ar.io/sdk`'s `AoArNSNameDataWithName.processId`. Rename happens only at the value's exit from SDK code into ar-io-node internals.
- Cleans up two stale JSDoc references in `ar-io-info-builder.ts` and `ar-io.ts` (documented a non-existent `processId` field on `/ar-io/info`)
- Updates `kv-arns-name-resolution-store` JSDoc to reflect new field name
- Adds two `trusted-gateway-arns-resolver` tests covering header parse when present and `undefined` propagation when absent
- Updates `docs/openapi.yaml` to rename schema field + header, add long-missing `x-arns-ant-program-id` documentation, and drop stale `processId` refs in `/ar-io/info` schemas

## Transition notes for operators

- Existing entries in the resolution cache (`KvArNSResolutionStore`, Redis-backed by default) are written with the old `processId` field and will return `antId: undefined` until their TTL expires (default 1 hour). Operators upgrading can `redis-cli FLUSHALL` to force re-resolution if they want `X-ArNS-Ant-Id` immediately on every name.
- Resolutions served via the trusted-gateway path will continue to return `antId: undefined` until the upstream peer also ships this rename. Direct on-demand resolution (Solana RPC lookups) populates `antId` immediately. Operators acting as primary gateways may want `ARNS_RESOLVER_PRIORITY_ORDER=on-demand,gateway` instead of the default `gateway,on-demand`.

## Verified end-to-end on devnet

```
$ curl -I https://<gateway>/ardrive
x-arns-ant-program-id: 8ZMuXhiK7DorjPUg8RB1rzu7CvsABMk38WDJRbM62y2C
x-arns-ant-id: 3atfp97N7DpQRrV3fyBHiWFZM75rKSiuYB9uGP3weJpc

$ curl https://<gateway>/ar-io/resolver/ardrive | jq .antId
"3atfp97N7DpQRrV3fyBHiWFZM75rKSiuYB9uGP3weJpc"
```

## Test plan

- [x] `yarn lint:check` passes
- [x] `yarn deps:check` passes
- [x] `tsc --project tsconfig.prod.json` passes
- [x] `yarn test` passes: **1751 / 0 fail / 4 skipped** (was 1749 — +2 new trusted-gateway tests)
- [x] End-to-end smoke: `X-ArNS-Ant-Id` header present on subdomain + resolver endpoint JSON includes `antId`
- [x] OpenAPI YAML parses + matches actual emit behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)