### PR TITLE
fix(solana): plumb observer buffer envs through compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -590,6 +590,11 @@ services:
       - OBSERVATION_WINDOW_FRACTION=${OBSERVATION_WINDOW_FRACTION:-}
       - OBSERVATION_CYCLE_INTERVAL_MS=${OBSERVATION_CYCLE_INTERVAL_MS:-}
       - MAJORITY_VOTE_THRESHOLD=${MAJORITY_VOTE_THRESHOLD:-}
+      # Epoch-relative submission window (defaults tuned for mainnet's ~24h
+      # epochs; shorter-epoch networks like devnet must shrink these or the
+      # observer rejects with "Epoch duration too short for configured buffers").
+      - OBSERVATION_STABILITY_BUFFER_MS=${OBSERVATION_STABILITY_BUFFER_MS:-}
+      - OBSERVATION_SUBMISSION_BUFFER_MS=${OBSERVATION_SUBMISSION_BUFFER_MS:-}
       # Offset Observation Configuration
       - OFFSET_OBSERVATION_SAMPLE_RATE=${OFFSET_OBSERVATION_SAMPLE_RATE:-}
       - OFFSET_OBSERVATION_ENABLED=${OFFSET_OBSERVATION_ENABLED:-}


### PR DESCRIPTION
## Summary

The observer reads `OBSERVATION_STABILITY_BUFFER_MS` and `OBSERVATION_SUBMISSION_BUFFER_MS` from env at startup ([`ar-io-observer/src/system.ts:765-766`](https://github.com/ar-io/ar-io-observer/blob/solana/src/system.ts#L765-L766)), but the compose observer service env block did not pass them through. Operators had no way to override the defaults without editing `docker-compose.yaml`.

## Why this matters

The defaults (36m stability + 72m submission) total 108m, tuned for mainnet's ~24h epochs. On any shorter-epoch network — devnet has 1h epochs — they don't fit, and the observer rejects at startup:

```
error: Continuous observer start() rejected — attempting auto-restart
Epoch duration too short for configured buffers and window fraction.
epochDuration=3600000ms, windowLength=1800000ms,
stabilityBuffer=2160000ms, submissionBuffer=4320000ms
```

The observer then auto-restarts on a loop (up to 12 attempts) and never makes progress.

## Fix

Two lines next to the existing `OBSERVATION_WINDOW_FRACTION` plumbing, matching the established pattern for tunable observation knobs.

## Test plan

- [x] Verified on devnet: setting `OBSERVATION_STABILITY_BUFFER_MS=300000` + `OBSERVATION_SUBMISSION_BUFFER_MS=1200000` (5m + 20m, leaves 25m slack in a 1h epoch with `windowFraction=0.5`) brings the observer up cleanly:
  ```
  info: Epoch observation schedule initialized
    {windowLength: 1800000, windowStart: ..., windowEnd: ...,
     gatewayCount: 12, totalObservations: 36}
  info: Epoch initialized epochIndex=73
  ```
- [x] No-op for mainnet operators: env vars default to empty, observer falls back to its existing 36m + 72m defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)