### PR TITLE
fix(ar-io-data-source): release peerRequestLimiter on 'end', not just 'close'

### DIFF
--- a/src/data/ar-io-data-source.test.ts
+++ b/src/data/ar-io-data-source.test.ts
@@ -1285,6 +1285,119 @@ describe('ArIODataSource', () => {
           singlePeerManager.stopUpdatingPeers();
         }
       });
+
+      it("should release the slot on 'end' alone when 'close' never fires", async () => {
+        // Regression: HTTP IncomingMessage under a keepAlive http.Agent can
+        // fire 'end' (data fully received) without firing 'close' (socket
+        // returned to pool, response object never destroyed). The original
+        // code listened only on 'close', so each "successful" download leaked
+        // a limiter slot. After enough downloads, every peer hit
+        // maxConcurrent and tryAcquire returned false for all candidates,
+        // wedging the bundle pipeline. This test simulates that scenario by
+        // emitting 'end' without 'close'.
+        const limiter = new PeerRequestLimiter(2);
+
+        const singlePeerManager = new ArIOPeerManager({
+          log,
+          networkProcess: ARIO.init(),
+          nodeWallet: 'localNode',
+          initialPeers: { peer1: 'http://peer1.com' },
+          initialCategories: ['data'],
+        });
+
+        const singlePeerDataSource = new ArIODataSource({
+          log,
+          peerManager: singlePeerManager,
+          dataAttributesStore: mockDataAttributesStore,
+          peerRequestLimiter: limiter,
+        });
+
+        const stream = new PassThrough();
+        mock.method(axios, 'get', async () => ({
+          status: 200,
+          data: stream,
+          headers: {
+            'content-length': '10',
+            'content-type': 'application/octet-stream',
+            [headerNames.verified.toLowerCase()]: 'true',
+            [headerNames.trusted.toLowerCase()]: 'false',
+          },
+        }));
+
+        try {
+          await singlePeerDataSource.getData({ id: 'id1' });
+
+          // Slot is held while the stream is active
+          assert.equal(limiter.getActiveCount('http://peer1.com'), 1);
+
+          // Simulate the keepAlive scenario: only 'end' fires, not 'close'
+          stream.emit('end');
+
+          // With the fix, this releases the slot. Without the fix, the slot
+          // would leak indefinitely until 'close' eventually fired (or never).
+          assert.equal(limiter.getActiveCount('http://peer1.com'), 0);
+        } finally {
+          singlePeerManager.stopUpdatingPeers();
+          stream.destroy();
+        }
+      });
+
+      it('should not double-release when both end and close fire', async () => {
+        const limiter = new PeerRequestLimiter(2);
+
+        const singlePeerManager = new ArIOPeerManager({
+          log,
+          networkProcess: ARIO.init(),
+          nodeWallet: 'localNode',
+          initialPeers: { peer1: 'http://peer1.com' },
+          initialCategories: ['data'],
+        });
+
+        const singlePeerDataSource = new ArIODataSource({
+          log,
+          peerManager: singlePeerManager,
+          dataAttributesStore: mockDataAttributesStore,
+          peerRequestLimiter: limiter,
+        });
+
+        const stream = new PassThrough();
+        mock.method(axios, 'get', async () => ({
+          status: 200,
+          data: stream,
+          headers: {
+            'content-length': '10',
+            'content-type': 'application/octet-stream',
+            [headerNames.verified.toLowerCase()]: 'true',
+            [headerNames.trusted.toLowerCase()]: 'false',
+          },
+        }));
+
+        try {
+          await singlePeerDataSource.getData({ id: 'id1' });
+          assert.equal(limiter.getActiveCount('http://peer1.com'), 1);
+
+          // Both events fire — only one release should happen
+          stream.emit('end');
+          stream.emit('close');
+
+          // If the guard worked, active count is 0 (released exactly once).
+          // Without the guard, two releases on a count of 1 would still
+          // bottom out at 0 — but the second release would have been called
+          // against an absent key. Acquire a fresh slot to verify the
+          // limiter's internal accounting is still sane.
+          assert.equal(limiter.getActiveCount('http://peer1.com'), 0);
+          assert.equal(limiter.tryAcquire('http://peer1.com'), true);
+          assert.equal(limiter.tryAcquire('http://peer1.com'), true);
+          assert.equal(
+            limiter.tryAcquire('http://peer1.com'),
+            false,
+            'limiter still respects maxConcurrent after double event',
+          );
+        } finally {
+          singlePeerManager.stopUpdatingPeers();
+          stream.destroy();
+        }
+      });
     });
 
     it('should throw when skipRemoteForwarding is set', async () => {

--- a/src/data/ar-io-data-source.ts
+++ b/src/data/ar-io-data-source.ts
@@ -335,8 +335,26 @@ export class ArIODataSource implements ContiguousDataSource {
 
             // Defer limiter release until the stream is fully consumed so the
             // slot accurately reflects active outbound transfers.
+            //
+            // Listen on 'end', 'error', AND 'close' rather than 'close' alone:
+            // for HTTP IncomingMessage streams consumed via pipeline() under a
+            // keepAlive http.Agent, 'close' can fire late or not at all (the
+            // socket is returned to the pool without the response being
+            // destroyed). That left limiter slots leaked permanently — after
+            // ~30 min of activity every peer hit maxConcurrent, tryAcquire
+            // returned false for all candidates, and getData() stopped
+            // dispatching to any peer (download pipeline wedged with the
+            // bundleDataImporter queue pegged at its cap, no errors logged).
+            // 'end' is the canonical "data fully received" event and fires
+            // reliably for normal completion; 'error' covers explicit
+            // destroys (stall timeout, wall-clock cap, peer aborts).
+            // released guard makes the handler idempotent so multiple events
+            // do not double-release.
             streamPeerCounts.set(peer, (streamPeerCounts.get(peer) ?? 0) + 1);
-            contiguousData.stream.once('close', () => {
+            let released = false;
+            const releaseSlot = () => {
+              if (released) return;
+              released = true;
               const count = streamPeerCounts.get(peer) ?? 1;
               if (count <= 1) {
                 streamPeerCounts.delete(peer);
@@ -344,7 +362,10 @@ export class ArIODataSource implements ContiguousDataSource {
                 streamPeerCounts.set(peer, count - 1);
               }
               this.peerRequestLimiter?.release(peer);
-            });
+            };
+            contiguousData.stream.once('end', releaseSlot);
+            contiguousData.stream.once('error', releaseSlot);
+            contiguousData.stream.once('close', releaseSlot);
 
             return contiguousData;
           } catch (error: any) {


### PR DESCRIPTION
## Summary
`ar-io-data-source.ts` listened only on `contiguousData.stream.once('close', …)` to release the per-peer `peerRequestLimiter` slot. For HTTP `IncomingMessage` streams consumed via `pipeline()` under a keepAlive `http.Agent`, 'close' can fire late or not at all — the socket is returned to the pool without the response object being destroyed.

Every "successful" download could leak one limiter slot. After 15–30 minutes of activity in production, every peer hit `maxConcurrent` → `tryAcquire` returned false for all candidates → `executeHedgedRequest` could not dispatch to any peer → the 24 `bundleDataImporter` workers all blocked on data sources that never returned data. The pipeline wedged silently: `bundleDataImporter` queue stuck at 1000, no downloads completing, no errors logged.

## Repro
Set `BACKGROUND_RETRIEVAL_ORDER=ar-io-network,chunks,trusted-gateways,tx-data` and let the gateway run a bundle backfill against the AR.IO peer pool. Observed twice today (deploys at 06:01 UTC and 13:17 UTC) — wedge manifested ~15–30 min in, identical fingerprint each time, even after PR #734 (wall-clock cap on `attachStallTimeout`) because the workers never reached the code where that cap is attached.

## Fix
Listen on `'end'`, `'error'`, AND `'close'`. Idempotent `released` guard so the multi-event handler releases exactly once.

- `'end'` is the canonical "data fully received" event and fires reliably for normal HTTP responses regardless of agent/socket lifecycle
- `'error'` covers explicit destroys (stall timeout, wall-clock cap, peer aborts)
- `'close'` stays as a final fallback

The `streamPeerCounts` map and `onRelease` skip logic are unchanged.

## Test plan
- [x] New unit test: release on 'end' alone (no 'close') — the regression case
- [x] New unit test: 'end' + 'close' both fire → released exactly once → limiter accounting still respects `maxConcurrent`
- [x] Existing `peerRequestLimiter slot accounting` tests still pass unchanged (they use `stream.destroy()` which fires 'close')
- [ ] CI: `npm test` for `data/ar-io-data-source.test.ts`
- [ ] Local soak: deploy + sustain `BACKGROUND_RETRIEVAL_ORDER=ar-io-network,...` past 30 min without wedge. Today's two wedges manifested by 15 and 30 min respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)