### PR TITLE
feat(data-importer): per-phase counters to locate pipeline wedge

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -158,6 +158,22 @@ export const dataItemsQueuedCounter = new promClient.Counter({
   labelNames: ['bundle_format'],
 });
 
+// Per-phase counters for DataImporter.download(). Exposes where a worker
+// is when the bundle pipeline wedges (queue pegged at cap, no completions).
+//   started:        function entry, before any await
+//   got_data:       contiguousDataSource.getData() returned successfully
+//   getData_errored: getData() rejected (peer exhaustion, network error, etc.)
+//   stream_ended:   response stream emitted 'end' (full read)
+//   stream_errored: response stream emitted 'error' (stall, abort, peer cut)
+// Read as deltas:
+//   (started - got_data - getData_errored)            = workers stuck in source chain
+//   (got_data - stream_ended - stream_errored)        = workers waiting on stream events
+export const dataImporterPhaseCounter = new promClient.Counter({
+  name: 'data_importer_worker_phase_total',
+  help: 'DataImporter worker progression through download() phases. Subtract pairs to find stuck workers.',
+  labelNames: ['phase'],
+});
+
 export const dataItemsIndexedCounter = new promClient.Counter({
   name: 'data_items_indexed_total',
   help: 'Count of data items indexed',

--- a/src/workers/data-importer.ts
+++ b/src/workers/data-importer.ts
@@ -109,13 +109,15 @@ export class DataImporter {
 
     // Phase counters: lets operators see *where* a worker is stuck when
     // the bundle pipeline wedges (queue pegged, no completions, no errors).
-    //   started - got_data       = workers currently inside getData()
-    //   got_data - stream_ended  - stream_errored = workers waiting on
-    //                                               stream end/error
-    // If (started - got_data) keeps climbing while completion counters
-    // flatline, the hang is in the source chain (cache lookup, sequential
-    // source dispatch, or one of the inner sources). If the gap is on the
-    // stream side, the hang is in the cache write or stream consumption.
+    //   started - got_data - getData_errored        = workers currently
+    //                                                 inside getData()
+    //   got_data - stream_ended - stream_errored    = workers waiting on
+    //                                                 stream end/error
+    // If (started - got_data - getData_errored) keeps climbing while
+    // completion counters flatline, the hang is in the source chain
+    // (cache lookup, sequential source dispatch, or one of the inner
+    // sources). If the gap is on the stream side, the hang is in the
+    // cache write or stream consumption.
     metrics.dataImporterPhaseCounter.inc({ phase: 'started' });
 
     // Instrument the source-chain rejection path (all sources exhausted,

--- a/src/workers/data-importer.ts
+++ b/src/workers/data-importer.ts
@@ -107,6 +107,17 @@ export class DataImporter {
     const log = this.log.child({ method: 'download', id: item.id });
     const startMs = Date.now();
 
+    // Phase counters: lets operators see *where* a worker is stuck when
+    // the bundle pipeline wedges (queue pegged, no completions, no errors).
+    //   started - got_data       = workers currently inside getData()
+    //   got_data - stream_ended  - stream_errored = workers waiting on
+    //                                               stream end/error
+    // If (started - got_data) keeps climbing while completion counters
+    // flatline, the hang is in the source chain (cache lookup, sequential
+    // source dispatch, or one of the inner sources). If the gap is on the
+    // stream side, the hang is in the cache write or stream consumption.
+    metrics.dataImporterPhaseCounter.inc({ phase: 'started' });
+
     // Instrument the source-chain rejection path (all sources exhausted,
     // 404 from every tier, etc.) so failures before a stream is returned
     // still show up in the duration / size histograms. Without this, the
@@ -121,12 +132,15 @@ export class DataImporter {
         elapsedMs / 1000,
       );
       metrics.bundleDownloadSizeBytes.observe({ outcome: 'error' }, 0);
+      metrics.dataImporterPhaseCounter.inc({ phase: 'getData_errored' });
       throw error;
     }
+    metrics.dataImporterPhaseCounter.inc({ phase: 'got_data' });
     const size = data.size;
 
     return new Promise((resolve, reject) => {
       data.stream.on('end', () => {
+        metrics.dataImporterPhaseCounter.inc({ phase: 'stream_ended' });
         const elapsedMs = Date.now() - startMs;
         metrics.bundleDownloadDurationSeconds.observe(
           { outcome: 'success' },
@@ -147,6 +161,7 @@ export class DataImporter {
       });
 
       data.stream.on('error', (error) => {
+        metrics.dataImporterPhaseCounter.inc({ phase: 'stream_errored' });
         const elapsedMs = Date.now() - startMs;
         metrics.bundleDownloadDurationSeconds.observe(
           { outcome: 'error' },


### PR DESCRIPTION
## Summary
The bundle backfill pipeline has wedged twice today with a fingerprint existing metrics can't pin down: `bundleDataImporter` queue stuck at its 1000 cap, `bundle_download_duration_seconds_count` flatlined, no errors logged, `ArIODataSource` shows zero activity. Workers are clearly blocked somewhere — but we can only see the gap between "queued" and "completed", not *where* in the `download()` flow they are.

Adds a labelled counter `data_importer_worker_phase_total{phase}` that increments at each phase of `DataImporter.download()`:

| phase | when it fires |
|---|---|
| `started` | function entry, before any `await` |
| `got_data` | `contiguousDataSource.getData()` returned |
| `getData_errored` | `getData()` rejected |
| `stream_ended` | response stream emitted `end` |
| `stream_errored` | response stream emitted `error` |

When the pipeline wedges, subtract pairs:
- `(started - got_data - getData_errored)` = workers blocked **inside the source chain** (cache lookup, SequentialDataSource dispatch, or an inner source returning `Promise<never>`)
- `(got_data - stream_ended - stream_errored)` = workers waiting on stream events that never fire

Both wedges so far showed 0 ArIODataSource activity, meaning the workers were stuck **before** the peer-call code. These counters will tell us at which prior boundary, so the next fix can target the right layer.

## Test plan
- [x] Existing tests untouched (instrumentation only, no behavior change)
- [ ] CI: existing `data-importer.test.ts` still passes
- [ ] Deploy locally + reproduce the wedge with `BACKGROUND_RETRIEVAL_ORDER=ar-io-network,...`. Read `data_importer_worker_phase_total` to identify the stuck phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)