### PR TITLE
fix(solana): plumb OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD through compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -595,6 +595,15 @@ services:
       # observer rejects with "Epoch duration too short for configured buffers").
       - OBSERVATION_STABILITY_BUFFER_MS=${OBSERVATION_STABILITY_BUFFER_MS:-}
       - OBSERVATION_SUBMISSION_BUFFER_MS=${OBSERVATION_SUBMISSION_BUFFER_MS:-}
+      # Maximum fraction of failed gateways before the report-sink circuit
+      # breaker refuses to submit. Default `0.8` is production-safe; on
+      # devnet (where most registered gateways are stubs that don't serve
+      # HTTP) `1.0` effectively disables the gate so the honest "all-
+      # failed" report can still ship — required for a freshly-joined
+      # devnet observer to ever increment its observerPerformanceRatio.
+      # See ar-io-observer src/config.ts OBSERVER_MAX_GATEWAY_FAILURE_
+      # THRESHOLD for context.
+      - OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD=${OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD:-}
       # Offset Observation Configuration
       - OFFSET_OBSERVATION_SAMPLE_RATE=${OFFSET_OBSERVATION_SAMPLE_RATE:-}
       - OFFSET_OBSERVATION_ENABLED=${OFFSET_OBSERVATION_ENABLED:-}


### PR DESCRIPTION
## Summary

Sibling fix to #733. The observer ships a safety circuit-breaker in `pipeline-report-sink.ts`: if more than the configured fraction of gateways were reported as failed (default 0.8 = 80%) the sink refuses to forward the report. Production-safe on mainnet, but **actively wrong on devnet** where the gateway registry is sparse and most registered entries are stubs that don't serve HTTP.

## Concrete impact, observed live

`arweave.nexus`'s first-ever prescription (epoch 81) was silently dropped:

```
> Finalizing and submitting report ...
> error: More than 80% of gateways failed - not reporting failures
> { failedGateways: 11, totalGateways: 12, failurePercentage: 91.67% }
```

The observer retried 30+ times within the submission window; every retry hit the same gate. On-chain result: `prescribedEpochCount: 1, observedEpochCount: 0`. `observerPerformanceRatio` halved to 0.5, `normalizedCompositeWeight` rounded to 0, and the gateway fell out of the prescription rotation.

The observer codebase's own [`config.ts`](https://github.com/ar-io/ar-io-observer/blob/solana/src/config.ts) comment already recommends `1.0` on devnet — but operators had no way to set it from `.env` because compose never plumbed the env var through.

## Fix

Two-line addition next to the existing `OBSERVATION_STABILITY_BUFFER_MS` / `OBSERVATION_SUBMISSION_BUFFER_MS` passthroughs (which #733 added for the same kind of gap).

## Test plan

- [x] Verified locally that setting `OBSERVER_MAX_GATEWAY_FAILURE_THRESHOLD=1.0` in `.env` now reaches the observer container (`docker compose config observer` shows the merged value).
- [x] No-op for mainnet operators: env defaults to empty, observer falls back to its 0.8 production default.
- [ ] Manual on-devnet verification: next prescription should now submit (won't know until our gateway is prescribed again — could take multiple epochs given current weight=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)