### PR TITLE
PE-9099: caller-supplied content-type predicate + lazy poisoned-cache eviction

### DIFF
--- a/src/data/attribute-fetchers.ts
+++ b/src/data/attribute-fetchers.ts
@@ -22,6 +22,7 @@ import { toB64Url } from '../lib/encoding.js';
 import { isEmptyString } from '../lib/string.js';
 import * as metrics from '../metrics.js';
 import { startChildSpan } from '../tracing.js';
+import { isAcceptableBundleContentType } from '../lib/ans-104.js';
 
 type AttributeKind = 'owner' | 'signature';
 type AttributeSubject = 'data_item' | 'transaction';
@@ -155,6 +156,15 @@ export abstract class AttributeFetchers {
         },
         parentSpan: span,
         signal,
+        // PE-9099: refuse parent-bundle responses whose content-type
+        // can't plausibly be a raw ANS-104 bundle. Defends against the
+        // in-range silent-corruption case for small bundles where the
+        // requested signature/owner offset would otherwise fall within
+        // a poisoned cache's 1134-byte parking-page payload — we'd
+        // silently store HTML bytes as cryptographic material in the
+        // attribute store. With the predicate the cache/gateway layer
+        // throws and the source chain falls through to chunks.
+        acceptContentType: isAcceptableBundleContentType,
       });
       const { stream } = data;
       span.setAttributes({

--- a/src/data/filtered-contiguous-data-source.ts
+++ b/src/data/filtered-contiguous-data-source.ts
@@ -111,12 +111,14 @@ export class FilteredContiguousDataSource implements ContiguousDataSource {
     region,
     parentSpan,
     signal,
+    acceptContentType,
   }: {
     id: string;
     requestAttributes?: RequestAttributes;
     region?: Region;
     parentSpan?: Span;
     signal?: AbortSignal;
+    acceptContentType?: (contentType: string | undefined) => boolean;
   }): Promise<ContiguousData> {
     // Check if request should be blocked
     if (requestAttributes) {
@@ -154,6 +156,7 @@ export class FilteredContiguousDataSource implements ContiguousDataSource {
       region,
       parentSpan,
       signal,
+      acceptContentType,
     });
   }
 }

--- a/src/data/gateways-data-source.test.ts
+++ b/src/data/gateways-data-source.test.ts
@@ -804,6 +804,95 @@ describe('GatewayDataSource', () => {
       });
     });
 
+    describe('acceptContentType predicate (PE-9099)', () => {
+      it('throws when caller predicate rejects upstream content-type', async () => {
+        // Simulates the production poison: upstream returns 200/1134-byte
+        // text/html (bundlr.network parking page) for a request that the
+        // caller intends to parse as an ANS-104 bundle.
+        mockedAxiosInstance.request = async () => ({
+          status: 200,
+          data: Readable.from([Buffer.alloc(1134, 0x3c)]),
+          headers: {
+            'content-length': '1134',
+            'content-type': 'text/html; charset=utf-8',
+          },
+        });
+
+        await assert.rejects(
+          dataSource.getData({
+            id: 'poisoned-id',
+            requestAttributes,
+            acceptContentType: (ct) =>
+              ct === undefined || ct.startsWith('application/octet-stream'),
+          }),
+          /content-type "text\/html; charset=utf-8" rejected by caller predicate/,
+        );
+      });
+
+      it('accepts when caller predicate accepts upstream content-type', async () => {
+        mockedAxiosInstance.request = async () => ({
+          status: 200,
+          data: Readable.from([Buffer.alloc(128)]),
+          headers: {
+            'content-length': '128',
+            'content-type': 'application/octet-stream',
+          },
+        });
+
+        const result = await dataSource.getData({
+          id: 'binary-id',
+          requestAttributes,
+          acceptContentType: (ct) =>
+            ct === undefined || ct.startsWith('application/octet-stream'),
+        });
+
+        assert.equal(result.size, 128);
+        assert.equal(result.sourceContentType, 'application/octet-stream');
+      });
+
+      it('accepts when caller predicate allows undefined content-type', async () => {
+        // Some upstreams omit content-type for raw bundle responses; the
+        // predicate must be able to allow this.
+        mockedAxiosInstance.request = async () => ({
+          status: 200,
+          data: Readable.from([Buffer.alloc(128)]),
+          headers: {
+            'content-length': '128',
+            // no content-type at all
+          },
+        });
+
+        const result = await dataSource.getData({
+          id: 'untyped-id',
+          requestAttributes,
+          acceptContentType: (ct) => ct === undefined,
+        });
+
+        assert.equal(result.size, 128);
+      });
+
+      it('passes the response through unchanged when no predicate is supplied', async () => {
+        // Backward-compat: callers without a predicate must not see any
+        // new validation — text/html should be returned just like before.
+        mockedAxiosInstance.request = async () => ({
+          status: 200,
+          data: Readable.from([Buffer.alloc(1134, 0x3c)]),
+          headers: {
+            'content-length': '1134',
+            'content-type': 'text/html; charset=utf-8',
+          },
+        });
+
+        const result = await dataSource.getData({
+          id: 'html-id-no-predicate',
+          requestAttributes,
+        });
+
+        assert.equal(result.size, 1134);
+        assert.equal(result.sourceContentType, 'text/html; charset=utf-8');
+      });
+    });
+
     it('should throw when skipRemoteForwarding is set', async () => {
       await assert.rejects(
         dataSource.getData({

--- a/src/data/gateways-data-source.ts
+++ b/src/data/gateways-data-source.ts
@@ -124,12 +124,14 @@ export class GatewaysDataSource implements ContiguousDataSource {
     region,
     parentSpan,
     signal,
+    acceptContentType,
   }: {
     id: string;
     requestAttributes?: RequestAttributes;
     region?: Region;
     parentSpan?: Span;
     signal?: AbortSignal;
+    acceptContentType?: (contentType: string | undefined) => boolean;
   }): Promise<ContiguousData> {
     const span = startChildSpan(
       'GatewaysDataSource.getData',
@@ -361,6 +363,42 @@ export class GatewaysDataSource implements ContiguousDataSource {
                       isRangedRequest ? '200 or 206' : '200'
                     }.`,
                   );
+                }
+
+                // PE-9099: caller-supplied content-type predicate. Used by
+                // callers that intend to parse the bytes as a specific
+                // format (e.g., ANS-104 bundles) to refuse responses that
+                // are obviously not that format — most notably the
+                // `text/html` parking pages a legacy gateway's S3 cache
+                // can hold from a 2024 outage of `gateway.bundlr.network`.
+                // Reject + throw so the data-source chain falls through
+                // to the next priority tier (and ultimately to chunks).
+                if (acceptContentType !== undefined) {
+                  const upstreamContentType = response.headers[
+                    'content-type'
+                  ] as string | undefined;
+                  if (!acceptContentType(upstreamContentType)) {
+                    response.data.destroy();
+                    metrics.gatewayContentTypeRejectedTotal.inc({
+                      gateway_url: gatewayUrl,
+                      priority: String(priority),
+                      content_type: upstreamContentType ?? 'unknown',
+                    });
+                    span.addEvent(
+                      'Gateway response content-type rejected by caller',
+                      {
+                        'gateways.url': gatewayUrl,
+                        'gateways.tier.priority': priority,
+                        'gateways.request.path': path,
+                        'http.content_type': upstreamContentType,
+                      },
+                    );
+                    throw new Error(
+                      `Gateway content-type "${upstreamContentType ?? '(none)'}" ` +
+                        `rejected by caller predicate for ${id} ` +
+                        `(likely poisoned upstream cache)`,
+                    );
+                  }
                 }
 
                 if (upstreamIgnoredRange) {

--- a/src/data/gateways-data-source.ts
+++ b/src/data/gateways-data-source.ts
@@ -379,10 +379,22 @@ export class GatewaysDataSource implements ContiguousDataSource {
                   ] as string | undefined;
                   if (!acceptContentType(upstreamContentType)) {
                     response.data.destroy();
+                    // Strip params (`; charset=utf-8`), trim, lowercase
+                    // before using as a metric label so Prometheus doesn't
+                    // explode into one series per minor variant.
+                    const normalizedContentType = upstreamContentType
+                      ?.split(';', 1)[0]
+                      ?.trim()
+                      .toLowerCase();
+                    const contentTypeLabel =
+                      normalizedContentType !== undefined &&
+                      normalizedContentType !== ''
+                        ? normalizedContentType
+                        : 'unknown';
                     metrics.gatewayContentTypeRejectedTotal.inc({
                       gateway_url: gatewayUrl,
                       priority: String(priority),
-                      content_type: upstreamContentType ?? 'unknown',
+                      content_type: contentTypeLabel,
                     });
                     span.addEvent(
                       'Gateway response content-type rejected by caller',

--- a/src/data/read-through-data-cache.test.ts
+++ b/src/data/read-through-data-cache.test.ts
@@ -79,6 +79,7 @@ describe('ReadThroughDataCache', function () {
       },
       cleanup: async (_) => Promise.resolve(),
       finalize: async (_, __) => Promise.resolve(),
+      delete: async (_) => Promise.resolve(),
     };
 
     mockContiguousDataIndex = {
@@ -2063,6 +2064,232 @@ describe('ReadThroughDataCache', function () {
           }),
         /backgroundCacheRangeConcurrency must be a positive finite number/,
       );
+    });
+  });
+
+  describe('acceptContentType lazy poison eviction (PE-9099)', () => {
+    it('evicts the on-disk blob and falls through when stored content-type fails the predicate', async () => {
+      // Cache holds a poisoned text/html entry (the production scenario:
+      // 1134-byte bundlr.network parking page cached as bundle bytes).
+      // Caller asks for bundle bytes via acceptContentType predicate.
+      // Expect: blob is deleted, request falls through to upstream.
+      mock.method(mockDataAttributesStore, 'getDataAttributes', () =>
+        Promise.resolve({
+          hash: 'poisoned-hash',
+          size: 1134,
+          contentType: 'text/html; charset=utf-8',
+          isManifest: false,
+          stable: false,
+          verified: false,
+          signature: null,
+        }),
+      );
+
+      let deletedHash: string | undefined;
+      mock.method(mockContiguousDataStore, 'delete', (hash: string) => {
+        deletedHash = hash;
+        return Promise.resolve();
+      });
+
+      let upstreamCalled = false;
+      mock.method(mockContiguousDataSource, 'getData', () => {
+        upstreamCalled = true;
+        return Promise.resolve({
+          stream: Readable.from([Buffer.alloc(64, 'A')]),
+          size: 64,
+          verified: false,
+          trusted: true,
+          cached: false,
+          sourceContentType: 'application/octet-stream',
+        });
+      });
+      mock.method(mockContiguousDataStore, 'createWriteStream', () =>
+        Promise.resolve(
+          new Writable({
+            write(_chunk, _enc, cb) {
+              cb();
+            },
+          }),
+        ),
+      );
+
+      const result = await readThroughDataCache.getData({
+        id: 'poisoned-id',
+        requestAttributes,
+        acceptContentType: (ct) =>
+          ct === undefined || ct.startsWith('application/octet-stream'),
+      });
+
+      assert.equal(
+        deletedHash,
+        'poisoned-hash',
+        'poisoned blob should have been deleted by hash',
+      );
+      assert.equal(
+        upstreamCalled,
+        true,
+        'upstream should have been called after eviction (treat as cache miss)',
+      );
+      assert.equal(
+        result.cached,
+        false,
+        'returned data should not be from cache',
+      );
+
+      // Drain
+      for await (const _ of result.stream) {
+        // discard
+      }
+    });
+
+    it('does NOT evict when no predicate is supplied (back-compat)', async () => {
+      mock.method(mockDataAttributesStore, 'getDataAttributes', () =>
+        Promise.resolve({
+          hash: 'html-hash',
+          size: 1134,
+          contentType: 'text/html; charset=utf-8',
+          isManifest: false,
+          stable: false,
+          verified: false,
+          signature: null,
+        }),
+      );
+
+      let deleteCalled = false;
+      mock.method(mockContiguousDataStore, 'delete', () => {
+        deleteCalled = true;
+        return Promise.resolve();
+      });
+      mock.method(mockContiguousDataStore, 'get', () =>
+        Promise.resolve(
+          new Readable({
+            read() {
+              this.push(Buffer.alloc(1134, 0x3c));
+              this.push(null);
+            },
+          }),
+        ),
+      );
+
+      const result = await readThroughDataCache.getData({
+        id: 'html-id',
+        requestAttributes,
+        // no acceptContentType
+      });
+
+      assert.equal(
+        deleteCalled,
+        false,
+        'no predicate → no eviction (back-compat)',
+      );
+      assert.equal(result.cached, true);
+      assert.equal(result.sourceContentType, 'text/html; charset=utf-8');
+
+      // Drain
+      for await (const _ of result.stream) {
+        // discard
+      }
+    });
+
+    it('does NOT evict when stored content-type passes the predicate', async () => {
+      mock.method(mockDataAttributesStore, 'getDataAttributes', () =>
+        Promise.resolve({
+          hash: 'clean-hash',
+          size: 64,
+          contentType: 'application/octet-stream',
+          isManifest: false,
+          stable: false,
+          verified: false,
+          signature: null,
+        }),
+      );
+
+      let deleteCalled = false;
+      mock.method(mockContiguousDataStore, 'delete', () => {
+        deleteCalled = true;
+        return Promise.resolve();
+      });
+      mock.method(mockContiguousDataStore, 'get', () =>
+        Promise.resolve(
+          new Readable({
+            read() {
+              this.push(Buffer.alloc(64));
+              this.push(null);
+            },
+          }),
+        ),
+      );
+
+      const result = await readThroughDataCache.getData({
+        id: 'clean-id',
+        requestAttributes,
+        acceptContentType: (ct) =>
+          ct === undefined || ct.startsWith('application/octet-stream'),
+      });
+
+      assert.equal(
+        deleteCalled,
+        false,
+        'acceptable content-type → no eviction',
+      );
+      assert.equal(result.cached, true);
+
+      // Drain
+      for await (const _ of result.stream) {
+        // discard
+      }
+    });
+
+    it('forwards acceptContentType to the upstream data source on cache miss', async () => {
+      mock.method(mockDataAttributesStore, 'getDataAttributes', () =>
+        Promise.resolve(undefined),
+      );
+      mock.method(mockContiguousDataIndex, 'getDataParent', () =>
+        Promise.resolve(undefined),
+      );
+
+      let upstreamReceivedPredicate:
+        | ((ct: string | undefined) => boolean)
+        | undefined;
+      mock.method(mockContiguousDataSource, 'getData', (args: any) => {
+        upstreamReceivedPredicate = args.acceptContentType;
+        return Promise.resolve({
+          stream: Readable.from([Buffer.alloc(64, 'A')]),
+          size: 64,
+          verified: false,
+          trusted: true,
+          cached: false,
+        });
+      });
+      mock.method(mockContiguousDataStore, 'createWriteStream', () =>
+        Promise.resolve(
+          new Writable({
+            write(_chunk, _enc, cb) {
+              cb();
+            },
+          }),
+        ),
+      );
+
+      const myPredicate = (ct: string | undefined) =>
+        ct === undefined || ct.startsWith('application/octet-stream');
+
+      const result = await readThroughDataCache.getData({
+        id: 'uncached-id',
+        requestAttributes,
+        acceptContentType: myPredicate,
+      });
+
+      assert.strictEqual(
+        upstreamReceivedPredicate,
+        myPredicate,
+        'predicate must flow through to upstream getData() so the upstream source can reject too',
+      );
+
+      // Drain
+      for await (const _ of result.stream) {
+        // discard
+      }
     });
   });
 });

--- a/src/data/read-through-data-cache.ts
+++ b/src/data/read-through-data-cache.ts
@@ -441,6 +441,7 @@ export class ReadThroughDataCache implements ContiguousDataSource {
     region,
     parentSpan,
     signal,
+    acceptContentType,
   }: {
     id: string;
     requestAttributes?: RequestAttributes;
@@ -450,6 +451,7 @@ export class ReadThroughDataCache implements ContiguousDataSource {
     };
     parentSpan?: Span;
     signal?: AbortSignal;
+    acceptContentType?: (contentType: string | undefined) => boolean;
   }): Promise<ContiguousData> {
     const span = startChildSpan(
       'ReadThroughDataCache.getData',
@@ -474,7 +476,7 @@ export class ReadThroughDataCache implements ContiguousDataSource {
       // Check for abort before starting
       signal?.throwIfAborted();
       // Get data attributes
-      const attributes = await this.dataAttributesStore.getDataAttributes(id);
+      let attributes = await this.dataAttributesStore.getDataAttributes(id);
 
       if (attributes) {
         span.setAttributes({
@@ -484,6 +486,50 @@ export class ReadThroughDataCache implements ContiguousDataSource {
           'data.verified': attributes.verified,
           'data.content_type': attributes.contentType,
         });
+      }
+
+      // PE-9099: lazy poison eviction. If the caller supplied a
+      // content-type predicate and the cached attributes record a
+      // content-type the caller refuses (e.g., text/html for a
+      // request that expects an ANS-104 bundle, a known footprint of
+      // legacy gateway S3 caches poisoned with `gateway.bundlr.network`
+      // parking pages), drop the on-disk blob and treat this request
+      // as a cache miss. The next successful cache write (after a
+      // fall-through to a clean source) will overwrite the stale
+      // attributes with the correct content-type, healing the entry
+      // for future requests.
+      if (
+        acceptContentType !== undefined &&
+        attributes !== undefined &&
+        !acceptContentType(attributes.contentType)
+      ) {
+        span.addEvent('Evicting poisoned cache entry', {
+          'cache.evicted.id': id,
+          'cache.evicted.hash': attributes.hash,
+          'cache.evicted.content_type': attributes.contentType,
+        });
+        this.log.warn('Evicting poisoned cache entry', {
+          id,
+          hash: attributes.hash,
+          contentType: attributes.contentType,
+        });
+        metrics.poisonedCacheEvictionsTotal.inc({
+          content_type: attributes.contentType ?? 'unknown',
+        });
+        if (attributes.hash !== undefined) {
+          try {
+            await this.dataStore.delete(attributes.hash);
+          } catch (err: any) {
+            this.log.warn('Failed to delete poisoned cache blob', {
+              id,
+              hash: attributes.hash,
+              message: err?.message,
+            });
+          }
+        }
+        // Clear attributes so the rest of getData() falls through
+        // as if this were a cold cache miss.
+        attributes = undefined;
       }
 
       if (attributes?.hash !== undefined) {
@@ -613,6 +659,7 @@ export class ReadThroughDataCache implements ContiguousDataSource {
         region,
         parentSpan: span,
         signal,
+        acceptContentType,
       });
       const upstreamDuration = Date.now() - upstreamStart;
 

--- a/src/data/root-parent-data-source.ts
+++ b/src/data/root-parent-data-source.ts
@@ -291,12 +291,14 @@ export class RootParentDataSource implements ContiguousDataSource {
     region,
     parentSpan,
     signal,
+    acceptContentType,
   }: {
     id: string;
     requestAttributes?: RequestAttributes;
     region?: Region;
     parentSpan?: Span;
     signal?: AbortSignal;
+    acceptContentType?: (contentType: string | undefined) => boolean;
   }): Promise<ContiguousData> {
     const span = startChildSpan(
       'RootParentDataSource.getData',
@@ -393,6 +395,7 @@ export class RootParentDataSource implements ContiguousDataSource {
                 region: finalRegion,
                 parentSpan: span,
                 signal,
+                acceptContentType,
               });
 
               // Cache only after successful fetch to avoid poisoning from bad hints
@@ -495,6 +498,7 @@ export class RootParentDataSource implements ContiguousDataSource {
             region: finalRegion,
             parentSpan: span,
             signal,
+            acceptContentType,
           });
 
           // Cache only after successful fetch to avoid poisoning from bad hints
@@ -594,6 +598,7 @@ export class RootParentDataSource implements ContiguousDataSource {
             region: finalRegion,
             parentSpan: fetchSpan,
             signal,
+            acceptContentType,
           });
 
           span.setAttributes({
@@ -734,6 +739,7 @@ export class RootParentDataSource implements ContiguousDataSource {
             region,
             parentSpan: span,
             signal,
+            acceptContentType,
           });
         } catch (error: any) {
           span.recordException(error);
@@ -921,6 +927,7 @@ export class RootParentDataSource implements ContiguousDataSource {
           region: finalRegion,
           parentSpan: fetchSpan,
           signal,
+          acceptContentType,
         });
 
         span.setAttributes({

--- a/src/data/sampling-contiguous-data-source.ts
+++ b/src/data/sampling-contiguous-data-source.ts
@@ -108,12 +108,14 @@ export class SamplingContiguousDataSource implements ContiguousDataSource {
     region,
     parentSpan,
     signal,
+    acceptContentType,
   }: {
     id: string;
     requestAttributes?: RequestAttributes;
     region?: Region;
     parentSpan?: Span;
     signal?: AbortSignal;
+    acceptContentType?: (contentType: string | undefined) => boolean;
   }): Promise<ContiguousData> {
     // Check for abort before starting
     signal?.throwIfAborted();
@@ -167,6 +169,7 @@ export class SamplingContiguousDataSource implements ContiguousDataSource {
         region,
         parentSpan: span,
         signal,
+        acceptContentType,
       });
 
       const latencyMs = Date.now() - startTime;

--- a/src/data/sequential-data-source.ts
+++ b/src/data/sequential-data-source.ts
@@ -36,12 +36,14 @@ export class SequentialDataSource implements ContiguousDataSource {
     region,
     parentSpan,
     signal,
+    acceptContentType,
   }: {
     id: string;
     requestAttributes?: RequestAttributes;
     region?: Region;
     parentSpan?: Span;
     signal?: AbortSignal;
+    acceptContentType?: (contentType: string | undefined) => boolean;
   }): Promise<ContiguousData> {
     const span = startChildSpan(
       'SequentialDataSource.getData',
@@ -103,6 +105,7 @@ export class SequentialDataSource implements ContiguousDataSource {
             region,
             parentSpan: sourceSpan,
             signal,
+            acceptContentType,
           });
 
           const sourceDuration = Date.now() - sourceStart;

--- a/src/lib/ans-104.test.ts
+++ b/src/lib/ans-104.test.ts
@@ -14,6 +14,13 @@ describe('isAcceptableBundleContentType (PE-9099)', () => {
     assert.equal(isAcceptableBundleContentType(undefined), true);
   });
 
+  it('accepts null (SQLite-stored attributes surface as JS null)', () => {
+    // Regression guard: prior version crashed with
+    // "Cannot read properties of null (reading 'trim')" when called
+    // from ReadThroughDataCache with a NULL stored content_type.
+    assert.equal(isAcceptableBundleContentType(null), true);
+  });
+
   it('accepts application/octet-stream', () => {
     assert.equal(
       isAcceptableBundleContentType('application/octet-stream'),

--- a/src/lib/ans-104.test.ts
+++ b/src/lib/ans-104.test.ts
@@ -1,0 +1,55 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { isAcceptableBundleContentType } from './ans-104.js';
+
+describe('isAcceptableBundleContentType (PE-9099)', () => {
+  it('accepts undefined (legitimate upstreams may omit Content-Type)', () => {
+    assert.equal(isAcceptableBundleContentType(undefined), true);
+  });
+
+  it('accepts application/octet-stream', () => {
+    assert.equal(
+      isAcceptableBundleContentType('application/octet-stream'),
+      true,
+    );
+  });
+
+  it('accepts application/octet-stream with parameters', () => {
+    assert.equal(
+      isAcceptableBundleContentType('application/octet-stream; charset=binary'),
+      true,
+    );
+  });
+
+  it('accepts application/x-arweave-data', () => {
+    assert.equal(
+      isAcceptableBundleContentType('application/x-arweave-data'),
+      true,
+    );
+  });
+
+  it('rejects text/html (the bundlr.network parking-page poison)', () => {
+    assert.equal(
+      isAcceptableBundleContentType('text/html; charset=utf-8'),
+      false,
+    );
+    assert.equal(isAcceptableBundleContentType('text/html'), false);
+  });
+
+  it('rejects application/json', () => {
+    assert.equal(isAcceptableBundleContentType('application/json'), false);
+  });
+
+  it('rejects unrelated content-types', () => {
+    assert.equal(isAcceptableBundleContentType('image/png'), false);
+    assert.equal(isAcceptableBundleContentType('video/mp4'), false);
+    assert.equal(isAcceptableBundleContentType('text/plain'), false);
+  });
+});

--- a/src/lib/ans-104.test.ts
+++ b/src/lib/ans-104.test.ts
@@ -35,6 +35,10 @@ describe('isAcceptableBundleContentType (PE-9099)', () => {
     );
   });
 
+  it('accepts binary/octet-stream (legacy synonym for application/octet-stream)', () => {
+    assert.equal(isAcceptableBundleContentType('binary/octet-stream'), true);
+  });
+
   it('rejects text/html (the bundlr.network parking-page poison)', () => {
     assert.equal(
       isAcceptableBundleContentType('text/html; charset=utf-8'),

--- a/src/lib/ans-104.test.ts
+++ b/src/lib/ans-104.test.ts
@@ -39,6 +39,21 @@ describe('isAcceptableBundleContentType (PE-9099)', () => {
     assert.equal(isAcceptableBundleContentType('binary/octet-stream'), true);
   });
 
+  it('accepts variant casings and surrounding whitespace', () => {
+    assert.equal(
+      isAcceptableBundleContentType('Application/Octet-Stream'),
+      true,
+    );
+    assert.equal(
+      isAcceptableBundleContentType('  application/octet-stream  '),
+      true,
+    );
+    assert.equal(
+      isAcceptableBundleContentType('APPLICATION/X-ARWEAVE-DATA'),
+      true,
+    );
+  });
+
   it('rejects text/html (the bundlr.network parking-page poison)', () => {
     assert.equal(
       isAcceptableBundleContentType('text/html; charset=utf-8'),

--- a/src/lib/ans-104.ts
+++ b/src/lib/ans-104.ts
@@ -54,6 +54,9 @@ const DEFAULT_STREAM_TIMEOUT = 1000 * 30; // 30 seconds
  *     bundle responses.
  *   - `application/octet-stream` — the canonical bundle content-type.
  *   - `application/x-arweave-data` — used by some Arweave-stack tools.
+ *   - `binary/octet-stream` — legacy MIME synonym for application/octet-stream;
+ *     ~350 such rows exist in production gateway `data.db.contiguous_data`
+ *     from older upstreams (PE-9099 investigation, 2026-05-18).
  */
 export const isAcceptableBundleContentType = (
   contentType: string | undefined,
@@ -61,7 +64,8 @@ export const isAcceptableBundleContentType = (
   if (contentType === undefined) return true;
   return (
     contentType.startsWith('application/octet-stream') ||
-    contentType.startsWith('application/x-arweave-data')
+    contentType.startsWith('application/x-arweave-data') ||
+    contentType.startsWith('binary/octet-stream')
   );
 };
 

--- a/src/lib/ans-104.ts
+++ b/src/lib/ans-104.ts
@@ -59,9 +59,15 @@ const DEFAULT_STREAM_TIMEOUT = 1000 * 30; // 30 seconds
  *     from older upstreams (PE-9099 investigation, 2026-05-18).
  */
 export const isAcceptableBundleContentType = (
-  contentType: string | undefined,
+  contentType: string | null | undefined,
 ): boolean => {
-  if (contentType === undefined) return true;
+  // Stored attributes in SQLite surface NULL as JS `null`, not
+  // `undefined`. Treat both as "no content-type known" and accept.
+  // (A previous version handled only `undefined` and crashed on `null`
+  // when called from ReadThroughDataCache's eviction check — every
+  // bundle whose stored contentType was NULL would throw "Cannot read
+  // properties of null (reading 'trim')" and the unbundle would fail.)
+  if (contentType === undefined || contentType === null) return true;
   // Real upstreams have been observed to send variant casings and
   // whitespace (`Application/Octet-Stream`, ` application/octet-stream `).
   // Normalize before prefix-matching so we don't reject valid responses

--- a/src/lib/ans-104.ts
+++ b/src/lib/ans-104.ts
@@ -41,6 +41,30 @@ const UNBUNDLE_ERROR: ParseEventName = 'unbundle-error';
 
 const DEFAULT_STREAM_TIMEOUT = 1000 * 30; // 30 seconds
 
+/**
+ * Predicate used by ANS-104 bundle fetches to reject upstream responses
+ * whose content-type can't plausibly be a raw bundle. The known footprint
+ * is `text/html` parking pages cached in the legacy gateway's S3 layer
+ * from a Sept-2024 outage of `gateway.bundlr.network`; rejecting them
+ * here forces the data-source chain to fall through to the next priority
+ * tier (and ultimately to `TxChunksDataSource` for fresh Arweave chunks).
+ *
+ * Accepts:
+ *   - `undefined` — many legitimate upstreams omit Content-Type for raw
+ *     bundle responses.
+ *   - `application/octet-stream` — the canonical bundle content-type.
+ *   - `application/x-arweave-data` — used by some Arweave-stack tools.
+ */
+export const isAcceptableBundleContentType = (
+  contentType: string | undefined,
+): boolean => {
+  if (contentType === undefined) return true;
+  return (
+    contentType.startsWith('application/octet-stream') ||
+    contentType.startsWith('application/x-arweave-data')
+  );
+};
+
 interface ParserMessage {
   eventName: ParseEventName;
   dataItem?: NormalizedDataItem;
@@ -284,8 +308,15 @@ export class Ans104Parser {
       try {
         const log = this.log.child({ parentId });
 
-        // Get data stream
-        data = await this.contiguousDataSource.getData({ id: parentId });
+        // Get data stream. PE-9099: refuse responses whose content-type
+        // can't be a raw ANS-104 bundle (most notably text/html parking
+        // pages held in poisoned upstream caches). The data source chain
+        // will fall through to the next priority tier and ultimately to
+        // chunks, which fetches real bytes from Arweave network nodes.
+        data = await this.contiguousDataSource.getData({
+          id: parentId,
+          acceptContentType: isAcceptableBundleContentType,
+        });
 
         // Construct temp path for passing data to worker
         await fsPromises.mkdir(path.join(process.cwd(), 'data/tmp/ans-104'), {

--- a/src/lib/ans-104.ts
+++ b/src/lib/ans-104.ts
@@ -62,10 +62,15 @@ export const isAcceptableBundleContentType = (
   contentType: string | undefined,
 ): boolean => {
   if (contentType === undefined) return true;
+  // Real upstreams have been observed to send variant casings and
+  // whitespace (`Application/Octet-Stream`, ` application/octet-stream `).
+  // Normalize before prefix-matching so we don't reject valid responses
+  // on a cosmetic difference.
+  const normalized = contentType.trim().toLowerCase();
   return (
-    contentType.startsWith('application/octet-stream') ||
-    contentType.startsWith('application/x-arweave-data') ||
-    contentType.startsWith('binary/octet-stream')
+    normalized.startsWith('application/octet-stream') ||
+    normalized.startsWith('application/x-arweave-data') ||
+    normalized.startsWith('binary/octet-stream')
   );
 };
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -573,6 +573,29 @@ export const gatewayRangeIgnoredTotal = new promClient.Counter({
   labelNames: ['gateway_url', 'priority', 'outcome'] as const,
 });
 
+// PE-9099: count of upstream responses rejected because the caller-supplied
+// `acceptContentType` predicate refused the response's content-type. The
+// known case is `text/html` parking pages cached in the legacy gateway's
+// S3 layer from a Sept-2024 outage of `gateway.bundlr.network`. Operators
+// can correlate the per-gateway rate to know which upstream caches are
+// still serving poison.
+export const gatewayContentTypeRejectedTotal = new promClient.Counter({
+  name: 'gateway_content_type_rejected_total',
+  help: 'Count of upstream responses rejected by the caller-supplied content-type predicate (e.g., text/html when expecting bundle bytes).',
+  labelNames: ['gateway_url', 'priority', 'content_type'] as const,
+});
+
+// PE-9099: count of local on-disk cache entries evicted by the lazy
+// poison-detection in ReadThroughDataCache when a caller's
+// `acceptContentType` predicate refuses the stored content-type. The
+// blob is deleted and the request falls through to upstream; the next
+// successful cache write replaces the entry with clean bytes.
+export const poisonedCacheEvictionsTotal = new promClient.Counter({
+  name: 'poisoned_cache_evictions_total',
+  help: 'Count of on-disk cache blobs evicted because their stored content-type was rejected by the caller predicate (lazy heal of poisoned cache entries).',
+  labelNames: ['content_type'] as const,
+});
+
 export const dataRequestChunksHistogram = new promClient.Histogram({
   name: 'data_request_chunks',
   help: 'Number of chunks fetched per data request',

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1053,12 +1053,29 @@ export interface ContiguousDataSource {
     region,
     parentSpan,
     signal,
+    acceptContentType,
   }: {
     id: string;
     requestAttributes?: RequestAttributes;
     region?: Region;
     parentSpan?: Span;
     signal?: AbortSignal;
+    /**
+     * Optional predicate the caller supplies to validate the upstream's
+     * response content-type. When provided, sources MUST reject the
+     * response if `acceptContentType(contentType)` returns false. The
+     * argument is the raw value of the upstream's `Content-Type` header
+     * (case as received) or `undefined` if absent.
+     *
+     * Use case: callers that intend to parse the bytes as a specific
+     * format (e.g., raw ANS-104 bundle) can refuse responses that are
+     * obviously not that format (e.g., `text/html` from a poisoned
+     * upstream cache returning a domain-parking page). The predicate
+     * runs before any bytes are handed back, so the caller is shielded
+     * from poison and the data-source chain can fall through to the
+     * next priority tier. PE-9099.
+     */
+    acceptContentType?: (contentType: string | undefined) => boolean;
   }): Promise<ContiguousData>;
 }
 


### PR DESCRIPTION
## Summary

Adds an optional `acceptContentType?: (ct: string | undefined) => boolean` predicate to `ContiguousDataSource.getData()`. Callers that intend to parse the bytes as a specific format (ANS-104 bundles, for now) can refuse responses whose `Content-Type` indicates the wrong shape — most notably `text/html` parking pages cached upstream from a 2024-09 outage of `gateway.bundlr.network`. When the predicate rejects:

- `GatewaysDataSource` refuses the upstream response, throws, and the source chain falls through to the next priority tier (and ultimately to `TxChunksDataSource` for fresh Arweave chunks).
- `ReadThroughDataCache` performs **lazy eviction** of poisoned cache entries: deletes the on-disk blob, treats the request as a cache miss, and lets the next successful fetch repopulate with clean bytes + correct content-type.

Callers that don't pass the predicate see zero behavioral change.

## Wired callers

- `Ans104Parser.parseBundle` — refuses non-bundle response shapes before handing bytes to the unbundler worker.
- `AttributeFetcher.fetchDataFromParent` — defends the in-range silent-corruption case (small bundles where a signature/owner Range read would otherwise silently store HTML bytes as cryptographic material).

## Predicate

`isAcceptableBundleContentType` (in `src/lib/ans-104.ts`) accepts:
- `undefined` (many legitimate upstreams omit Content-Type for raw bundle bodies)
- `application/octet-stream*`
- `application/x-arweave-data*`
- `binary/octet-stream*` (legacy MIME synonym for octet-stream — ~350 such rows exist in production gateway `data.db.contiguous_data`)

Plumbed through `ReadThroughDataCache`, `SequentialDataSource`, `FilteredContiguousDataSource`, `SamplingContiguousDataSource`, and `RootParentDataSource`.

## Metrics

- `gateway_content_type_rejected_total{gateway_url, priority, content_type}` — count of upstream responses refused by a caller predicate.
- `poisoned_cache_evictions_total{content_type}` — count of on-disk cache blobs evicted by the lazy heal.

## Production validation

Deployed to canary ~2026-05-18. Within an hour of deploy:
- predicate firing on real poison: `application/json`, `text/html; charset=utf-8`, `image/*`, etc.
- lazy evictions repairing the on-disk cache for affected ids on subsequent retries
- end-to-end response for previously-poisoned ids switched from `application/json` → `application/octet-stream` after a one-time DB cleanup of `data.db.contiguous_data.original_source_content_type` (operational, separate from this PR)

## Out of scope (follow-ups)

- Write-time validation in `ReadThroughDataCache` to prevent recurrence of the wrong-content-type cache write (notes in `docs/drafts/2026-05-18-PE-9099-content-type-corruption-cleanup.md`).
- Cleanup of the legacy ALB / AWS S3 cache (operational, not code).

## Test plan

- [x] `yarn lint:check` clean
- [x] `npx tsc --noEmit --project tsconfig.prod.json` clean
- [x] Full test suite (`yarn test`) — 1852 / 1856 pass (4 pre-existing skips); no new failures
- [x] New unit tests:
  - `isAcceptableBundleContentType`: 8 cases (undefined, octet-stream + variant, x-arweave-data, **binary/octet-stream**, rejected: text/html, application/json, image/png, video/mp4, text/plain)
  - `GatewaysDataSource`: 4 cases for `acceptContentType` (reject, accept, accept-undefined, no-predicate back-compat)
  - `ReadThroughDataCache`: 4 cases for lazy poison eviction (evict on poison, no-evict without predicate, no-evict on clean content-type, predicate-flows-to-upstream)
- [x] Production deploy on gw2 — metrics confirm predicate + eviction firing on real poison; downstream `bundles_unbundled` rate recovered for affected ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)