### PR TITLE
chore(deps): bump @ar.io/sdk to ^4.0.0-solana.14 + @solana/kit to ^6.8.0, sweep AO refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "url": "https://github.com/ar-io/ar-io-node"
   },
   "dependencies": {
-    "@ar.io/sdk": "4.0.0-solana.8",
+    "@ar.io/sdk": "^4.0.0-solana.14",
     "@ardrive/ardrive-promise-cache": "^1.4.0",
     "@ardrive/turbo-sdk": "^1.40.2",
-    "@solana/kit": "^2.1.0",
+    "@solana/kit": "^6.8.0",
     "@aws-lite/client": "^0.23.2",
     "@aws-lite/s3": "^0.2.6",
     "@aws-sdk/client-dynamodb": "^3.968.0",

--- a/src/data/ar-io-data-source.test.ts
+++ b/src/data/ar-io-data-source.test.ts
@@ -8,7 +8,7 @@ import { strict as assert } from 'node:assert';
 import { afterEach, before, beforeEach, describe, it, mock } from 'node:test';
 import { PassThrough } from 'node:stream';
 import axios from 'axios';
-import { AoARIORead, ARIO } from '@ar.io/sdk';
+import { ARIORead, ARIO } from '@ar.io/sdk';
 import { Readable } from 'node:stream';
 import { RequestAttributes, ContiguousDataAttributesStore } from '../types.js';
 import { ArIODataSource } from './ar-io-data-source.js';
@@ -25,7 +25,7 @@ let dataSource: ArIODataSource;
 let peerManager: ArIOPeerManager;
 const nodeUrl = 'localNode.com';
 let requestAttributes: RequestAttributes;
-let mockedArIOInstance: AoARIORead;
+let mockedArIOInstance: ARIORead;
 let mockedAxiosGet: any;
 let mockDataAttributesStore: ContiguousDataAttributesStore;
 

--- a/src/init/resolvers.ts
+++ b/src/init/resolvers.ts
@@ -8,7 +8,7 @@ import { Logger } from 'winston';
 import { OnDemandArNSResolver } from '../resolution/on-demand-arns-resolver.js';
 import { TrustedGatewayArNSResolver } from '../resolution/trusted-gateway-arns-resolver.js';
 import { KVBufferStore, NameResolver } from '../types.js';
-import { AoARIORead } from '@ar.io/sdk';
+import { ARIORead } from '@ar.io/sdk';
 import { CompositeArNSResolver } from '../resolution/composite-arns-resolver.js';
 import { RedisKvStore } from '../store/redis-kv-store.js';
 import { NodeKvStore } from '../store/node-kv-store.js';
@@ -76,7 +76,7 @@ export const createArNSResolver = ({
   registryCache: KvArNSRegistryStore;
   trustedGatewayUrl?: string;
   trustedArnsResolverHostHeader?: string;
-  networkProcess: AoARIORead;
+  networkProcess: ARIORead;
   overrides?: {
     ttlSeconds?: number;
   };

--- a/src/peers/ar-io-peer-manager.test.ts
+++ b/src/peers/ar-io-peer-manager.test.ts
@@ -6,13 +6,13 @@
  */
 import { strict as assert } from 'node:assert';
 import { afterEach, before, beforeEach, describe, it, mock } from 'node:test';
-import { AoARIORead } from '@ar.io/sdk';
+import { ARIORead } from '@ar.io/sdk';
 import { ArIOPeerManager } from './ar-io-peer-manager.js';
 import { createTestLogger } from '../../test/test-logger.js';
 
 let log: ReturnType<typeof createTestLogger>;
 let peerManager: ArIOPeerManager;
-let mockedArIOInstance: AoARIORead;
+let mockedArIOInstance: ARIORead;
 
 const INITIAL_PEERS = {
   peer1: 'http://peer1.com',
@@ -47,7 +47,7 @@ beforeEach(async () => {
       hasMore: false,
       nextCursor: undefined,
     }),
-  } as AoARIORead;
+  } as ARIORead;
 
   // Create peer manager with initial peers to avoid network calls
   peerManager = new ArIOPeerManager({

--- a/src/peers/ar-io-peer-manager.ts
+++ b/src/peers/ar-io-peer-manager.ts
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import winston from 'winston';
-import { AoARIORead } from '@ar.io/sdk';
+import { ARIORead } from '@ar.io/sdk';
 import CircuitBreaker from 'opossum';
 import memoize from 'memoizee';
 import * as config from '../config.js';
@@ -52,7 +52,7 @@ export class ArIOPeerManager implements WithFormattedPeers {
   private log: winston.Logger;
   private nodeWallet: string | undefined;
   private updatePeersRefreshIntervalMs: number;
-  private networkProcess: AoARIORead;
+  private networkProcess: ARIORead;
   private peers: Record<string, string> = {};
   private intervalId?: NodeJS.Timeout;
 
@@ -80,8 +80,8 @@ export class ArIOPeerManager implements WithFormattedPeers {
 
   // circuit breaker for getGateways
   private arioGatewaysCircuitBreaker: CircuitBreaker<
-    Parameters<AoARIORead['getGateways']>,
-    Awaited<ReturnType<AoARIORead['getGateways']>>
+    Parameters<ARIORead['getGateways']>,
+    Awaited<ReturnType<ARIORead['getGateways']>>
   >;
 
   constructor({
@@ -104,7 +104,7 @@ export class ArIOPeerManager implements WithFormattedPeers {
     },
   }: {
     log: winston.Logger;
-    networkProcess: AoARIORead;
+    networkProcess: ARIORead;
     nodeWallet?: string;
     initialPeers?: Record<string, string>;
     initialCategories?: WeightCategory[];

--- a/src/resolution/arns-names-cache.test.ts
+++ b/src/resolution/arns-names-cache.test.ts
@@ -8,7 +8,7 @@ import { strict as assert } from 'node:assert';
 import { after, beforeEach, describe, it } from 'node:test';
 import winston from 'winston';
 import { ArNSNamesCache } from './arns-names-cache.js';
-import { AoARIORead, Logger as ARIOLogger } from '@ar.io/sdk';
+import { ARIORead, Logger as ARIOLogger } from '@ar.io/sdk';
 import { NodeKvStore } from '../store/node-kv-store.js';
 
 // disable sdk logging to reduce noise
@@ -57,7 +57,7 @@ describe('ArNSNamesCache', () => {
             nextCursor: undefined,
           };
         },
-      } as unknown as AoARIORead,
+      } as unknown as ARIORead,
     });
 
     // let the cache hydrate
@@ -87,7 +87,7 @@ describe('ArNSNamesCache', () => {
             nextCursor: undefined,
           };
         },
-      } as unknown as AoARIORead,
+      } as unknown as ARIORead,
     });
 
     // Request the name immediately, before hydration completes
@@ -118,7 +118,7 @@ describe('ArNSNamesCache', () => {
             nextCursor: undefined,
           };
         },
-      } as unknown as AoARIORead,
+      } as unknown as ARIORead,
     });
 
     // let the cache hydrate
@@ -152,7 +152,7 @@ describe('ArNSNamesCache', () => {
             nextCursor: undefined,
           };
         },
-      } as unknown as AoARIORead,
+      } as unknown as ARIORead,
     });
 
     // let the cache hydrate
@@ -208,7 +208,7 @@ describe('ArNSNamesCache', () => {
           }
           throw new Error('Network error');
         },
-      } as unknown as AoARIORead,
+      } as unknown as ARIORead,
     });
 
     // let the cache hydrate
@@ -250,7 +250,7 @@ describe('ArNSNamesCache', () => {
           }
           throw new Error('Network error');
         },
-      } as unknown as AoARIORead,
+      } as unknown as ARIORead,
     });
 
     // let the cache hydrate
@@ -302,7 +302,7 @@ describe('ArNSNamesCache', () => {
             nextCursor: undefined,
           };
         },
-      } as unknown as AoARIORead,
+      } as unknown as ARIORead,
     });
 
     // let the cache hydrate
@@ -352,7 +352,7 @@ describe('ArNSNamesCache', () => {
             nextCursor: undefined,
           };
         },
-      } as unknown as AoARIORead,
+      } as unknown as ARIORead,
     });
 
     // call count will get incremented on instantiation of the cache
@@ -401,7 +401,7 @@ describe('ArNSNamesCache', () => {
 
           return { items: [], nextCursor: undefined };
         },
-      } as unknown as AoARIORead,
+      } as unknown as ARIORead,
     });
 
     // Wait for initial hydration
@@ -447,7 +447,7 @@ describe('ArNSNamesCache', () => {
             nextCursor: undefined,
           };
         },
-      } as unknown as AoARIORead,
+      } as unknown as ARIORead,
     });
 
     // Wait for initial hydration
@@ -481,7 +481,7 @@ describe('ArNSNamesCache', () => {
           callCount++;
           throw new Error('AO service unavailable');
         },
-      } as unknown as AoARIORead,
+      } as unknown as ARIORead,
     });
 
     // Wait for initial hydration attempt

--- a/src/resolution/arns-names-cache.ts
+++ b/src/resolution/arns-names-cache.ts
@@ -6,11 +6,7 @@
  */
 import winston from 'winston';
 
-import {
-  AoARIORead,
-  AoArNSNameDataWithName,
-  PaginationResult,
-} from '@ar.io/sdk';
+import { ARIORead, ArNSNameDataWithName, PaginationResult } from '@ar.io/sdk';
 import * as config from '../config.js';
 import { KvDebounceStore } from '../store/kv-debounce-store.js';
 import { KVBufferStore } from '../types.js';
@@ -33,7 +29,7 @@ const DEFAULT_CACHE_HIT_DEBOUNCE_TTL =
  */
 export class ArNSNamesCache {
   private log: winston.Logger;
-  private networkProcess: AoARIORead;
+  private networkProcess: ARIORead;
   private arnsRegistryKvCache: KVBufferStore;
   private arnsDebounceCache: KvDebounceStore;
 
@@ -46,7 +42,7 @@ export class ArNSNamesCache {
   }: {
     log: winston.Logger;
     registryCache: KVBufferStore;
-    networkProcess: AoARIORead;
+    networkProcess: ARIORead;
     cacheMissDebounceTtl?: number;
     cacheHitDebounceTtl?: number;
   }) {
@@ -102,7 +98,7 @@ export class ArNSNamesCache {
             const {
               items: records,
               nextCursor,
-            }: PaginationResult<AoArNSNameDataWithName> =
+            }: PaginationResult<ArNSNameDataWithName> =
               await this.networkProcess.getArNSRecords({ cursor, limit: 1000 });
 
             for (const record of records) {
@@ -196,7 +192,7 @@ export class ArNSNamesCache {
   async getCachedArNSBaseName(
     name: string,
     parentSpan?: Span,
-  ): Promise<AoArNSNameDataWithName | undefined> {
+  ): Promise<ArNSNameDataWithName | undefined> {
     const span = parentSpan
       ? tracer.startSpan(
           'ArNSNamesCache.getCachedArNSBaseName',
@@ -218,7 +214,7 @@ export class ArNSNamesCache {
       if (record) {
         metrics.arnsNameCacheHitCounter.inc();
         span.setAttributes({ 'arns.cache.hit': true });
-        return <AoArNSNameDataWithName>JSON.parse(record.toString());
+        return <ArNSNameDataWithName>JSON.parse(record.toString());
       }
       metrics.arnsNameCacheMissCounter.inc();
       span.setAttributes({ 'arns.cache.hit': false });
@@ -233,7 +229,7 @@ export class ArNSNamesCache {
    * @param name - The name to set the ArNS name data for.
    * @param record - The ArNS name data to set.
    */
-  async setCachedArNSBaseName(name: string, record: AoArNSNameDataWithName) {
+  async setCachedArNSBaseName(name: string, record: ArNSNameDataWithName) {
     return this.arnsRegistryKvCache.set(
       name,
       Buffer.from(JSON.stringify(record)),

--- a/src/resolution/composite-arns-resolver.ts
+++ b/src/resolution/composite-arns-resolver.ts
@@ -14,7 +14,7 @@ import * as metrics from '../metrics.js';
 import { KvArNSResolutionStore } from '../store/kv-arns-name-resolution-store.js';
 import { KvArNSRegistryStore } from '../store/kv-arns-base-name-store.js';
 import { ArNSNamesCache } from './arns-names-cache.js';
-import { AoARIORead } from '@ar.io/sdk';
+import { ARIORead } from '@ar.io/sdk';
 import * as config from '../config.js';
 import { tracer } from '../tracing.js';
 
@@ -58,7 +58,7 @@ export class CompositeArNSResolver implements NameResolver {
     resolvers: NameResolver[];
     resolutionCache: KvArNSResolutionStore;
     registryCache: KvArNSRegistryStore;
-    networkProcess: AoARIORead;
+    networkProcess: ARIORead;
     overrides?: {
       ttlSeconds?: number;
     };

--- a/src/resolution/on-demand-arns-resolver.ts
+++ b/src/resolution/on-demand-arns-resolver.ts
@@ -8,8 +8,7 @@ import winston from 'winston';
 
 import { isValidDataId } from '../lib/validation.js';
 import { NameResolution, NameResolver } from '../types.js';
-import { AoArNSNameDataWithName } from '@ar.io/sdk';
-import { SolanaANTReadable } from '@ar.io/sdk/solana';
+import { ArNSNameDataWithName, SolanaANTReadable } from '@ar.io/sdk';
 import { address, type Rpc, type SolanaRpcApiMainnet } from '@solana/kit';
 import * as config from '../config.js';
 import CircuitBreaker from 'opossum';
@@ -38,7 +37,7 @@ export class OnDemandArNSResolver implements NameResolver {
     name: string;
     baseArNSRecordFn: (
       parentSpan?: any,
-    ) => Promise<AoArNSNameDataWithName | undefined>;
+    ) => Promise<ArNSNameDataWithName | undefined>;
   }): Promise<NameResolution> {
     this.log.info('Resolving name...', { name });
     try {

--- a/src/store/kv-arns-base-name-store.ts
+++ b/src/store/kv-arns-base-name-store.ts
@@ -15,7 +15,7 @@ import { KVBufferStore } from '../types.js';
  * {
  *   key: 'ardrive',
  *   value: {
- *      processId: AO_PROCESS_ID,
+ *      antId: ANT_PROGRAM_ADDRESS,
  *      undernameLimit: UNDERNAME_LIMIT,
  *      type: 'permabuy' | 'lease',
  *      startTimestamp: TIMESTAMP,

--- a/src/system.ts
+++ b/src/system.ts
@@ -7,8 +7,7 @@
 import { default as Arweave } from 'arweave';
 import EventEmitter from 'node:events';
 import fs from 'node:fs';
-import { Logger as ARIOLogger } from '@ar.io/sdk';
-import { SolanaARIOReadable } from '@ar.io/sdk/solana';
+import { Logger as ARIOLogger, SolanaARIOReadable } from '@ar.io/sdk';
 import {
   createSolanaRpc,
   type Address,
@@ -181,11 +180,7 @@ export const solanaRpc: Rpc<SolanaRpcApi> = createSolanaRpc(
 );
 
 const networkProcess = new SolanaARIOReadable({
-  // `@ar.io/sdk` ships a nested `@solana/rpc-spec` whose Rpc<...> type
-  // drifts from the top-level `@solana/kit` copy. Runtime is
-  // structurally identical; `as any` is a TS-only workaround until
-  // the deps align. Matches ar-io-observer/src/system.ts.
-  rpc: solanaRpc as any,
+  rpc: solanaRpc,
   // Optional program-id overrides for devnet / localnet. Undefined keys
   // are dropped via spread so the SDK falls back to its bundled defaults.
   ...(config.ARIO_CORE_PROGRAM_ID !== undefined
@@ -641,11 +636,7 @@ const gatewaysDataSource = new FilteredContiguousDataSource({
 
 export const arIOPeerManager = new ArIOPeerManager({
   log,
-  // Solana readable is structurally compatible with the AoARIORead
-  // surface this consumer uses (getGateways) — the only nominal
-  // mismatch is the AO-only `process: AOProcess` field which is unused.
-
-  networkProcess: networkProcess as any,
+  networkProcess,
   nodeWallet: config.AR_IO_WALLET,
 });
 
@@ -1431,11 +1422,7 @@ export const nameResolver = createArNSResolver({
   trustedGatewayUrl: config.TRUSTED_ARNS_GATEWAY_URL,
   trustedArnsResolverHostHeader: config.TRUSTED_ARNS_RESOLVER_HOST_HEADER,
   resolutionOrder: config.ARNS_RESOLVER_PRIORITY_ORDER,
-  // Solana readable is structurally compatible with AoARIORead for
-  // the surface this consumer uses (getArNSRecords); the only nominal
-  // mismatch is the AO-only `process` field which is unused.
-
-  networkProcess: networkProcess as any,
+  networkProcess,
   resolutionCache: arnsResolutionCache,
   registryCache: arnsRegistryCache,
   solanaRpc,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { Readable, Writable } from 'node:stream';
-import { AoArNSNameDataWithName } from '@ar.io/sdk';
+import { ArNSNameDataWithName } from '@ar.io/sdk';
 import { Span } from '@opentelemetry/api';
 
 export interface B64uTag {
@@ -1160,7 +1160,7 @@ export interface NameResolver {
     name: string;
     baseArNSRecordFn?: (
       parentSpan?: Span,
-    ) => Promise<AoArNSNameDataWithName | undefined>;
+    ) => Promise<ArNSNameDataWithName | undefined>;
     signal?: AbortSignal;
   }): Promise<NameResolution>;
 }

--- a/test/end-to-end/utils.ts
+++ b/test/end-to-end/utils.ts
@@ -123,7 +123,6 @@ export const composeUp = async ({
   TRUSTED_NODE_URL = 'https://arweave.net',
   TRUSTED_GATEWAYS_URLS = '{"https://arweave.net": 1, "https://turbo-gateway.com": 2}',
   BACKGROUND_RETRIEVAL_ORDER = 'trusted-gateways',
-  AO_CU_URL = 'https://cu.ardrive.io', // TODO: replace with local ao-cu
   ...ENVIRONMENT
 }: Environment = {}) => {
   // disable .env file read

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,24 +134,19 @@
   dependencies:
     xss "^1.0.8"
 
-"@ar.io/sdk@4.0.0-solana.8":
-  version "4.0.0-solana.8"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.0-solana.8.tgz#5b0ec089dd0ee732e027094107375d7adf782af3"
-  integrity sha512-+xusf3K9qhHsALPxqpc7HeivQ6dNdFp48Sd/E7HzmnfFH/wPiKASC2z135yUV3B2SJAmO4/SqIvoEnj8APppcQ==
+"@ar.io/sdk@^4.0.0-solana.14":
+  version "4.0.0-solana.14"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.0-solana.14.tgz#b5eb5e2550b388f7ca7c2707a13d279f619f60c1"
+  integrity sha512-6Z1/4mclslBh2AZTK3rpHlYIVmX6McF5Y0t7fMEmmcj10deOJe+Mc6fGD7cWJUp2cQzwzOkozl4SqujEKtheQw==
   dependencies:
     "@ar.io/solana-contracts" "0.1.0-devnet.0"
-    "@ardrive/turbo-sdk" "^1.19.0"
-    "@dha-team/arbundles" "^1.0.1"
-    "@permaweb/aoconnect" "0.0.68"
     "@solana-program/compute-budget" "^0.15.0"
     "@solana-program/token" "^0.13.0"
     "@solana/kit" "^6.8.0"
-    arweave "1.15.5"
-    axios "^1.13.2"
     bs58 "^6.0.0"
     commander "^12.1.0"
-    eventemitter3 "^5.0.1"
     prompts "^2.4.2"
+    zod "^3.25.76"
 
 "@ar.io/solana-contracts@0.1.0-devnet.0":
   version "0.1.0-devnet.0"
@@ -164,30 +159,6 @@
   integrity sha512-S77u7ROUl+enHDZ5XJvcCoNR453Fmym8dG4jkwUcxI1GJ9OZ7+3bq6fRKiWLfJN9oZHmT/qGxKyJKYZj4PTwzw==
   dependencies:
     "@alexsasharegan/simple-cache" "^3.3.3"
-
-"@ardrive/turbo-sdk@^1.19.0":
-  version "1.41.2"
-  resolved "https://registry.yarnpkg.com/@ardrive/turbo-sdk/-/turbo-sdk-1.41.2.tgz#83637bae16214fa305f7d5e67d9ef95e327d5af5"
-  integrity sha512-SQUannhzLzW+YqoYNfJAod5VLuf30vd0JU+VT2wlAL47UMeCgdgBPbXIJG1NzuMmVu5epL5+JSEaCimpSXrvHw==
-  dependencies:
-    "@cosmjs/proto-signing" "^0.33.1"
-    "@cosmjs/stargate" "^0.33.1"
-    "@dha-team/arbundles" "^1.0.1"
-    "@ethersproject/signing-key" "^5.7.0"
-    "@permaweb/aoconnect" "0.0.57"
-    "@solana/web3.js" "^1.91.7"
-    arweave "^1.15.1"
-    bignumber.js "^9.1.2"
-    bs58 "^5.0.0"
-    cli-progress "^3.12.0"
-    commander "^12.1.0"
-    ethers "^6.12.0"
-    eventemitter3 "^5.0.1"
-    mime-types "^2.1.35"
-    plimit-lit "^3.0.1"
-    prompts "^2.4.2"
-    tweetnacl "^1.0.3"
-    x402-fetch "^1.0.0"
 
 "@ardrive/turbo-sdk@^1.40.2":
   version "1.40.2"
@@ -4093,7 +4064,7 @@
   resolved "https://registry.yarnpkg.com/@paulmillr/qr/-/qr-0.2.1.tgz#76ade7080be4ac4824f638146fd8b6db1805eeca"
   integrity sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==
 
-"@permaweb/ao-scheduler-utils@~0.0.20", "@permaweb/ao-scheduler-utils@~0.0.25":
+"@permaweb/ao-scheduler-utils@~0.0.20":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@permaweb/ao-scheduler-utils/-/ao-scheduler-utils-0.0.29.tgz#9dcfffd5a63a606d70156a1699a3f87840ba64f2"
   integrity sha512-tzuNsy2NUcATLMG+SKaO1PxbXaDpfoQikEfI7BABkNWk6AyQoBLy0Zwuu0eypGEHeNP6gugXEo1j8oZez/8fXA==
@@ -4115,27 +4086,6 @@
     ramda "^0.30.1"
     warp-arbundles "^1.0.4"
     zod "^3.23.8"
-
-"@permaweb/aoconnect@0.0.68":
-  version "0.0.68"
-  resolved "https://registry.yarnpkg.com/@permaweb/aoconnect/-/aoconnect-0.0.68.tgz#216ad607929e92d5cf4de6a7ff6a41442ff2500d"
-  integrity sha512-QK8VJ/rbmyZ7esuk6O2F4uJG0AKiYNzDuQNzsdgCLH7kt+0FlKTS4MKM1KH9fvXivqXdXYs02OxmzkkWprNxog==
-  dependencies:
-    "@permaweb/ao-scheduler-utils" "~0.0.25"
-    "@permaweb/protocol-tag-utils" "~0.0.2"
-    buffer "^6.0.3"
-    debug "^4.4.0"
-    http-message-signatures "^1.0.4"
-    hyper-async "^1.1.2"
-    mnemonist "^0.39.8"
-    ramda "^0.30.1"
-    warp-arbundles "^1.0.4"
-    zod "^3.24.1"
-
-"@permaweb/protocol-tag-utils@~0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@permaweb/protocol-tag-utils/-/protocol-tag-utils-0.0.2.tgz#c8a2eddf7da15d70a6e60aecff839730cb59aee3"
-  integrity sha512-2IiKu71W7pkHKIzxabCGQ5q8DSppZaE/sPcPF2hn+OWwfe04M7b5X5LHRXQNPRuxHWuioieGdPQb3F7apOlffQ==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -5929,7 +5879,7 @@
     "@solana/nominal-types" "6.9.0"
     "@solana/promises" "6.9.0"
 
-"@solana/kit@^2.1.0", "@solana/kit@^2.1.1":
+"@solana/kit@^2.1.1":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@solana/kit/-/kit-2.3.0.tgz#92deb7c4883293617209aecac9a43d5e41ccf092"
   integrity sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==
@@ -8659,16 +8609,6 @@ arweave-stream-tx@1.1.0:
     exponential-backoff "^3.1.0"
     stream-chunker "^1.2.8"
 
-arweave@1.15.5:
-  version "1.15.5"
-  resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.15.5.tgz#d0fb209de01bfc9dc97d5da70270928a83ecee83"
-  integrity sha512-Zj3b8juz1ZtDaQDPQlzWyk2I4wZPx3RmcGq8pVJeZXl2Tjw0WRy5ueHPelxZtBLqCirGoZxZEAFRs6SZUSCBjg==
-  dependencies:
-    arconnect "^0.4.2"
-    asn1.js "^5.4.1"
-    base64-js "^1.5.1"
-    bignumber.js "^9.0.2"
-
 arweave@1.15.7, arweave@^1.10.13, arweave@^1.13.7, arweave@^1.15.1:
   version "1.15.7"
   resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.15.7.tgz#d09265d128e93a471203649de083ba7fec52cb29"
@@ -8775,7 +8715,7 @@ axios-retry@^4.5.0:
   dependencies:
     is-retry-allowed "^2.2.0"
 
-axios@1.15.0, axios@^1.12.2, axios@^1.13.2, axios@^1.15.0, axios@^1.6.0:
+axios@1.15.0, axios@^1.12.2, axios@^1.15.0, axios@^1.6.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
   integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
@@ -11327,13 +11267,6 @@ http-errors@~1.6.2:
     inherits "2.0.3"
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
-
-http-message-signatures@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/http-message-signatures/-/http-message-signatures-1.0.4.tgz#3d1f614977d3a435af7c1d35a75e1e48d9094075"
-  integrity sha512-gavCQWnxHFg0BVlKs6CmYK7hNSH1o0x0mHTC68yBAHYOYuTVXPv52mEE7QuT5TenfiagTdOa/zPJzen4lEX7Rg==
-  dependencies:
-    structured-headers "^1.0.1"
 
 http-proxy-agent@^5.0.0:
   version "5.0.0"
@@ -14513,11 +14446,6 @@ strnum@^2.2.2:
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.2.tgz#f11fd94ab62b536ba2ecc615858f3747c2881b3f"
   integrity sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==
 
-structured-headers@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/structured-headers/-/structured-headers-1.0.1.tgz#1821e434e0fe45bdd78f07c779b16519ab520415"
-  integrity sha512-QYBxdBtA4Tl5rFPuqmbmdrS9kbtren74RTJTcs0VSQNVV5iRhJD4QlYTLD0+81SBwUQctjEQzjTRI3WG4DzICA==
-
 stylus-lookup@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/stylus-lookup/-/stylus-lookup-6.1.0.tgz#f0fe88a885b830dc7520f51dd0a7e59e5d3307b4"
@@ -15694,7 +15622,7 @@ zod@3.22.4:
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
   integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==
 
-zod@^3.23.5, zod@^3.23.8, zod@^3.24.1, zod@^3.24.2, zod@^3.24.4:
+zod@^3.23.5, zod@^3.23.8, zod@^3.24.2, zod@^3.24.4, zod@^3.25.76:
   version "3.25.76"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==


### PR DESCRIPTION
## Summary

SDK \`4.0.0-solana.14\` finalizes the AO removal in \`@ar.io/sdk\`:

- Drops \`@permaweb/aoconnect\` as a direct dep (still arrives transitively through \`@ardrive/turbo-sdk\` — outside our control).
- Renames every \`Ao*\` type to its bare name (no compat aliases).
- Collapses \`/solana\` subpath into root (kept as a deprecation alias in \`.14\` only; migrating now to be future-proof).
- We were stuck at \`4.0.0-solana.8\` with \`@solana/kit ^2.1.0\`, while the SDK shipped a nested \`@solana/kit@6.9\`. This PR aligns kit to \`^6.8.0\` so there's a single resolution and the \`rpc: solanaRpc as any\` cast in \`system.ts\` becomes unnecessary.

## Changes

- \`package.json\`: \`@ar.io/sdk 4.0.0-solana.8\` → \`^4.0.0-solana.14\`; \`@solana/kit ^2.1.0\` → \`^6.8.0\`
- \`yarn.lock\`: regenerated, ~90 lines smaller
- **Mechanical Ao* → bare rename** across 8 src + 3 test files:
  - \`AoARIORead\` → \`ARIORead\`
  - \`AoArNSNameDataWithName\` → \`ArNSNameDataWithName\`
- \`src/system.ts\`: drop \`/solana\` import suffix; remove the two stale \`as any\` casts on \`networkProcess\` and the kit-mismatch comment + cast on \`solanaRpc\` (all now type-correct)
- \`src/resolution/on-demand-arns-resolver.ts\`: drop \`/solana\` suffix
- \`src/store/kv-arns-base-name-store.ts\`: update JSDoc example \`processId: AO_PROCESS_ID\` → \`antId: ANT_PROGRAM_ADDRESS\` to match the \`processId → antId\` rename in #732
- \`test/end-to-end/utils.ts\`: drop the destructured-but-never-used \`AO_CU_URL\` parameter

## Reward-share scale audit (solana.12)

\`solana.12\` converts delegate reward share from basis points → percent. Grepped this repo for \`rewardShare\` / \`reward_share\` / \`basisPoints\` / \`delegateReward\` — **zero hits in src/**. Not a consumer here, no audit needed.

## Verified

- \`npx tsc --noEmit\`: 0 errors
- \`yarn lint:check\`: clean
- \`yarn build\`: clean

## Known pre-existing breakage (not caused by this PR)

Two test files fail to load with:
> \`@solana/codecs-core\` does not provide an export named \`toArrayBuffer\`

(\`src/data/ar-io-data-source.test.ts\`, \`src/resolution/arns-names-cache.test.ts\`)

**Reproduced against \`origin/solana\` HEAD before any changes in this PR.** Root cause is \`ts-node/esm\` mishandling the dual CJS/ESM resolution in \`@solana/codecs-core@6.9.0\` when imported transitively via the nested kit@6 in \`node_modules\`. A direct \`node --input-type=module -e "import('@solana/codecs-core')...\"\` succeeds — the export is there, the loader chain just can't find it. Separate issue; should be fixed in a follow-up PR (likely by tightening the kit resolution in package.json \`resolutions\`, or by switching the test loader).

## Test plan

- [x] typecheck
- [x] lint
- [x] build
- [x] verify zero \`Ao*\` identifiers remain in \`src/\` + \`test/\`
- [x] reward-share scale audit
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)