### PR TITLE
fix(test): replace stale .processId assertion with .programIds in ar-io.test.ts

### DIFF
--- a/test/end-to-end/ar-io.test.ts
+++ b/test/end-to-end/ar-io.test.ts
@@ -27,7 +27,10 @@ after(async function () {
 describe('ArIO', function () {
   it('should return the network contract info on the /info endpoint', async function () {
     const res = await axios.get('http://localhost:4000/ar-io/info');
-    assert.ok(res.data.processId);
+    // `processId` was the AO process ID; replaced by an object of Solana
+    // program IDs (core/gar/arns/ant) in the AO→Solana cutover (#709).
+    assert.ok(res.data.programIds);
+    assert.equal(typeof res.data.programIds, 'object');
     assert.ok(res.data.supportedManifestVersions);
     assert.ok(res.data.release);
     assert.ok(res.data.services.bundlers);


### PR DESCRIPTION
## Why

The AO→Solana cutover (#709) removed `processId` from `/ar-io/info` and replaced it with `programIds: { core, gar, arns, ant }`. The matching e2e assertion wasn't updated:

```ts
// test/end-to-end/ar-io.test.ts:30 (before this PR)
assert.ok(res.data.processId);   // ← always undefined post-#709 → assert fails
```

This has been failing on every develop build since #709 merged. It's only visible on `ubuntu-latest`; the `macos-latest` job skips the testcontainers-based e2e suite (no Docker on the macos runner). Confirmed in build-core run [26616455531](https://github.com/ar-io/ar-io-node/actions/runs/26616455531) where the **only** failing E2E test is "should return the network contract info on the /info endpoint".

## Fix

Replace the stale field assertion with one matching the post-cutover shape:

```ts
assert.ok(res.data.programIds);
assert.equal(typeof res.data.programIds, 'object');
```

The /info handler at `src/routes/ar-io.ts:174-` is the source of truth for the response shape.

Scope check: `grep -rnE '\.processId\b' test/ src/` finds **no other** stale references.

## Validation

- `yarn lint:check` → exit 0
- The assertion is straightforward — verified against the live ar-io.nexus `/ar-io/info` which already returns the `programIds` object.

## Context

This is one of the post-#709 cutover gaps unblocking the AO→Solana cutover's image rebuild on develop. The cdb64 property-test flake fix is the companion piece in #759.