### PR TITLE
chore(deps): bump @ar.io/sdk from 4.0.0-solana.14 to ^4.0.0-solana.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/ar-io/ar-io-node"
   },
   "dependencies": {
-    "@ar.io/sdk": "^4.0.0-solana.14",
+    "@ar.io/sdk": "^4.0.0-solana.22",
     "@ardrive/ardrive-promise-cache": "^1.4.0",
     "@ardrive/turbo-sdk": "^1.40.2",
     "@solana/kit": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,12 +134,12 @@
   dependencies:
     xss "^1.0.8"
 
-"@ar.io/sdk@^4.0.0-solana.14":
-  version "4.0.0-solana.14"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.0-solana.14.tgz#b5eb5e2550b388f7ca7c2707a13d279f619f60c1"
-  integrity sha512-6Z1/4mclslBh2AZTK3rpHlYIVmX6McF5Y0t7fMEmmcj10deOJe+Mc6fGD7cWJUp2cQzwzOkozl4SqujEKtheQw==
+"@ar.io/sdk@^4.0.0-solana.22":
+  version "4.0.0-solana.22"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.0-solana.22.tgz#0bdc5698f0ad76c34d842b83af2eb405205ea41d"
+  integrity sha512-6Diug3UzO5dbOlAcJyONunuzAlea3jFkgIdWeWDnq36mj+z9PLM9AvdkO8I/7wKCuAHVy/u++UJDIdUwM/TBfA==
   dependencies:
-    "@ar.io/solana-contracts" "0.1.0-devnet.0"
+    "@ar.io/solana-contracts" "0.4.0"
     "@solana-program/compute-budget" "^0.15.0"
     "@solana-program/token" "^0.13.0"
     "@solana/kit" "^6.8.0"
@@ -148,10 +148,13 @@
     prompts "^2.4.2"
     zod "^3.25.76"
 
-"@ar.io/solana-contracts@0.1.0-devnet.0":
-  version "0.1.0-devnet.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-0.1.0-devnet.0.tgz#b03d1fd243b80665bd289232b335a25a22e3795a"
-  integrity sha512-MzdoB2lBHWNqGRi5Ki7a8legTv8YuoymwuahPSQr6lk75UMr7dMz5VWF2ypXLv2GJZODz69ChNSd/eTP7X4n8g==
+"@ar.io/solana-contracts@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-0.4.0.tgz#f658a2bcb926451188302cbbcc4a1d1f49f875ee"
+  integrity sha512-rLQVlNS1YBJq2cG5xu9qOmWF0qOPiLXD0AGVlW2WFeNxIXLvDYiARXLJXQ26kvnfIED/Fx3X5cg7Y4m4L1ZF4A==
+  dependencies:
+    "@noble/hashes" "^1.5.0"
+    bs58 "^6.0.0"
 
 "@ardrive/ardrive-promise-cache@^1.4.0":
   version "1.4.0"
@@ -14338,16 +14341,7 @@ string-argv@~0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14393,14 +14387,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15352,7 +15339,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15365,15 +15352,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Why

Observed against ar-io.nexus (running develop tip `98a4e9a6` + this SDK pin):

| Name | Exists on staging (SDK direct) | Resolves via gateway |
|---|---|---|
| vilenarios | ✅ | ✅ HTTP 200 |
| 1984 | ✅ | ❌ HTTP 404 ("Base name not found in ArNS names cache") |
| ardrive | ✅ | ❌ HTTP 404 |
| ao | ✅ | ❌ HTTP 404 |
| roam | ✅ | ❌ HTTP 404 |

`ArNSNamesCache.hydrateArNSNamesCache()` (`src/resolution/arns-names-cache.ts`) paginates via `networkProcess.getArNSRecords({ cursor, limit: 1000 })`. With staging having **3,505 ArnsRecord PDAs**, hydration should fetch ~4 pages but finishes in ~4 seconds and only a small subset ends up cached. Resolver wiring is correct — `/ar-io/info` reports the right programIds and the same `vilenarios` resolves end-to-end via the manifest path — but most names are silently absent.

Strongly consistent with a paginated-response shape mismatch between `solana.14`'s `SolanaARIO.getArNSRecords()` and what the current staging program emits. `solana.15` → `solana.22` carry numerous Solana-backend read-path fixes.

## What

Bump `"@ar.io/sdk": "^4.0.0-solana.14"` → `"^4.0.0-solana.22"`. Only `package.json` and `yarn.lock` touched.

## Validation

- `npx tsc --project tsconfig.prod.json --noEmit` → exit 0 (no breaking API changes against 8 versions of skip)
- Targeted resolver tests pass: **10/10**
  ```
  src/resolution/arns-names-cache.test.ts
  src/resolution/composite-arns-resolver.test.ts
  src/resolution/trusted-gateway-arns-resolver.test.ts
  ```
- Full test suite + multi-arch image build will exercise on develop CI.

## Expected outcome

After merge + image rebuild + `docker compose pull && up -d --force-recreate core`, ArNS resolution should pick up all 3,505+ staging names (and newly-purchased ones on each hit-refresh cycle). I'll re-test against the same 5 names on the post-bump image.