### PR TITLE
PE-9108: only abort the source cascade on genuine client disconnect

### DIFF
--- a/src/data/sequential-data-source.test.ts
+++ b/src/data/sequential-data-source.test.ts
@@ -142,20 +142,51 @@ describe('SequentialDataSource', () => {
       assert.equal(mockSource2.getData.mock.callCount(), 0);
     });
 
-    it('should not try next source when AbortError is thrown', async () => {
+    it('should not try next source when AbortError is thrown and the request signal is aborted (client disconnect)', async () => {
+      const controller = new AbortController();
       mockSource1.getData = mock.fn(async () => {
+        // Simulate a client disconnect mid-fetch: the shared signal aborts and
+        // the in-flight source rejects with an AbortError.
+        controller.abort();
         const error = new Error('aborted');
         error.name = 'AbortError';
         throw error;
       });
 
-      await assert.rejects(sequentialDataSource.getData({ id: 'test-id' }), {
-        name: 'AbortError',
-      });
+      await assert.rejects(
+        sequentialDataSource.getData({
+          id: 'test-id',
+          signal: controller.signal,
+        }),
+        { name: 'AbortError' },
+      );
 
       // Verify second source was never tried
       assert.equal(mockSource1.getData.mock.callCount(), 1);
       assert.equal(mockSource2.getData.mock.callCount(), 0);
+    });
+
+    it('should continue to next source when an AbortError is thrown but the signal was not aborted (internal source timeout)', async () => {
+      // GatewaysDataSource (and other sources) surface their own per-request
+      // timeout as an AbortError via normalizeAbortError, without aborting the
+      // shared request signal. That must NOT fail the whole cascade.
+      mockSource1.getData = mock.fn(async () => {
+        const error = new Error('Connection timeout');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      const result = await sequentialDataSource.getData({ id: 'test-id' });
+
+      assert.equal(result.size, 18);
+      assert.equal(mockSource1.getData.mock.callCount(), 1);
+      assert.equal(mockSource2.getData.mock.callCount(), 1);
+
+      let receivedData = '';
+      for await (const chunk of result.stream) {
+        receivedData += chunk;
+      }
+      assert.equal(receivedData, 'data from source 2');
     });
 
     it('should check abort before each source attempt', async () => {

--- a/src/data/sequential-data-source.ts
+++ b/src/data/sequential-data-source.ts
@@ -137,8 +137,16 @@ export class SequentialDataSource implements ContiguousDataSource {
         } catch (error: any) {
           const sourceDuration = Date.now() - sourceStart;
 
-          // Re-throw AbortError immediately - don't try next source
-          if (error.name === 'AbortError') {
+          // Only short-circuit the whole cascade on a genuine client
+          // disconnect, i.e. when the shared request signal was actually
+          // aborted. A source's *internal* timeout (e.g. GatewaysDataSource's
+          // per-gateway connection timeout) is also surfaced as an AbortError
+          // via normalizeAbortError, but in that case the shared signal is NOT
+          // aborted — those must fall through to the next source rather than
+          // failing the entire request. This mirrors the
+          // `error.name === 'AbortError' && req.signal?.aborted` check used at
+          // the handler boundary in routes/data/handlers.ts.
+          if (error.name === 'AbortError' && signal?.aborted === true) {
             span.addEvent('Request aborted', {
               'sequential.source_index': i,
               'sequential.source_name': dataSource.constructor.name,

--- a/src/lib/stream.ts
+++ b/src/lib/stream.ts
@@ -55,13 +55,18 @@ export function attachStallTimeout(
   };
   const armTimer = () => {
     clearTimer();
+    // unref so the watchdog never keeps the process alive on its own. In a
+    // live gateway the HTTP server/sockets hold the loop open, so this still
+    // fires on schedule; it only stops mattering when it is the sole
+    // remaining handle (e.g. test teardown after a stream is never drained),
+    // preventing a 15-minute idle hang from the wall-clock cap below.
     timer = setTimeout(() => {
       stream.destroy(
         new Error(
           `Stream stall timeout: no data received for ${stallTimeoutMs}ms`,
         ),
       );
-    }, stallTimeoutMs);
+    }, stallTimeoutMs).unref();
   };
   const onResume = () => {
     if (stream.readableFlowing === true) {
@@ -91,13 +96,17 @@ export function attachStallTimeout(
   // backpressure-pause-then-upstream-stall wedge that the per-data stall
   // timer cannot see.
   if (maxRequestMs !== undefined) {
+    // unref for the same reason as the stall timer: in production other
+    // handles keep the loop alive so this still fires, but it must not by
+    // itself hold a process open (a stream that is never drained in tests
+    // would otherwise wedge the runner for the full maxRequestMs).
     maxTimer = setTimeout(() => {
       stream.destroy(
         new Error(
           `Stream wall-clock timeout: not complete within ${maxRequestMs}ms`,
         ),
       );
-    }, maxRequestMs);
+    }, maxRequestMs).unref();
   }
 
   // Re-pause the stream since adding a 'data' listener switches it to


### PR DESCRIPTION
SequentialDataSource re-threw any AbortError from a source and stopped trying the remaining sources, treating it as a client disconnect. But sources surface their own internal timeouts as AbortError too (via normalizeAbortError) — e.g. GatewaysDataSource's per-gateway connection timeout. The result: when the trusted-gateways tier times out, the cascade aborts before reaching trusted-gateways-offset-aware / chunks-offset-aware, producing 404s for data that those sources can serve (confirmed against old bundled data items on the canary gateways).

Gate the short-circuit on `signal?.aborted === true` so only a genuine client disconnect stops the cascade; internal source timeouts now fall through to the next source. Mirrors the existing `error.name === 'AbortError' && req.signal?.aborted` check at the handler boundary in routes/data/handlers.ts.