### PR TITLE
chore(deps): bump @ar.io/sdk 4.0.0-solana.26 → ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/ar-io/ar-io-node"
   },
   "dependencies": {
-    "@ar.io/sdk": "4.0.0-solana.26",
+    "@ar.io/sdk": "^4.0.0",
     "@ardrive/ardrive-promise-cache": "^1.4.0",
     "@ardrive/turbo-sdk": "^1.40.2",
     "@solana/kit": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,12 +134,13 @@
   dependencies:
     xss "^1.0.8"
 
-"@ar.io/sdk@4.0.0-solana.26":
-  version "4.0.0-solana.26"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.0-solana.26.tgz#7699e87ee6f060364332a39bbfb24862959552c2"
-  integrity sha512-15MaIRpv0ShlQE3BYh0hV+Fl6BqCuXX4EJiH0AqCjNd5MXX9RJBPJUO0Jth6VxaJrWltkpmRPh0L4zlwRcpoRA==
+"@ar.io/sdk@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.0.tgz#15e189f81f18a4be911cfefe5db2bed8e35eae37"
+  integrity sha512-ey6Eyt/qEYP3dv53rcmO7RjflQq9vVwcsispQ+CXvsv1zMi6x7PMAPth1ItRL+1akn3Y2R+dLyQclCR3KSGghA==
   dependencies:
-    "@ar.io/solana-contracts" "0.5.0-staging.15"
+    "@ar.io/solana-contracts" "1.0.0"
+    "@noble/hashes" "^1.8.0"
     "@solana-program/address-lookup-table" "^0.11.0"
     "@solana-program/compute-budget" "^0.15.0"
     "@solana-program/token" "^0.13.0"
@@ -150,10 +151,10 @@
     prompts "^2.4.2"
     zod "^3.25.76"
 
-"@ar.io/solana-contracts@0.5.0-staging.15":
-  version "0.5.0-staging.15"
-  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-0.5.0-staging.15.tgz#42dbf0e5703598eb8b8c02affdc5731e914fdd0c"
-  integrity sha512-8sgIr+9e+L08PXTOoNXMzRJLfiERP/fycEP3tVmZYESbGdA85VUHpmiCuUr86m3ZEhwNM035/9g4bkcg6pCKlw==
+"@ar.io/solana-contracts@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.0.0.tgz#56ec1354542991899c5d641a8221ee2b33b8b99d"
+  integrity sha512-/rmxIyViK9USkedcn4zrHWkg+tGBE160PSbJ2xwEcugtXDSOf5Cc0E6R8YoG7HT5oKkU0QY1QEeSeVvcYgMYBQ==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
Moves core off the `4.0.0-solana.26` prerelease pin to the stable **`^4.0.0`** release (now on npm).

**Why:** 4.0.0 includes the compound crank-step tx-size fix (`MAX_COMPOUND_BATCH` 12→6, ar-io/ar-io-sdk#670) plus the cumulative Solana fixes landed since `.26`.

**Verification:** `yarn build` (tsc, `tsconfig.prod.json`) compiles cleanly against 4.0.0 — no API/type changes required. `yarn.lock` updated. Full unit suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)