### PR TITLE
chore: point default observer image at the Solana 4.0.0 container (db292b8e)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -550,7 +550,7 @@ services:
       - clickhouse
 
   observer:
-    image: ghcr.io/ar-io/ar-io-observer:${OBSERVER_IMAGE_TAG:-d6283a103a55277a2e92c783a77ec3da61bc82b5}
+    image: ghcr.io/ar-io/ar-io-observer:${OBSERVER_IMAGE_TAG:-db292b8e368cdd8dab0b600bd426ade3768eaa75}
     restart: unless-stopped
     ports:
       - ${OBSERVER_PORT:-5050}:5050


### PR DESCRIPTION
Bumps the default `OBSERVER_IMAGE_TAG` in `docker-compose.yaml` to the **4.0.0 observer build**:

- from `d6283a103a55277a2e92c783a77ec3da61bc82b5` (pre-Solana observer)
- to `db292b8e368cdd8dab0b600bd426ade3768eaa75` — the `ar-io-observer` 4.0.0 build (develop HEAD, promoted to `main` via ar-io/ar-io-observer#99). Matches the existing convention of pinning the observer's build commit SHA. Image verified published to GHCR.

Wires the node to the Solana migration's observer alongside #765 (SDK `^4.0.0`, merged) and #766 (mainnet program-ID defaults, merged). Lands as part of release **r80**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)