### PR TITLE
ci(deploy-core-image): fix production deploy step skipped on main push PE-9114

### DIFF
--- a/.github/workflows/deploy-core-image.yml
+++ b/.github/workflows/deploy-core-image.yml
@@ -30,7 +30,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Trigger Deployment For ardrive.net
-        if: github.event.workflow_run.head_branch == 'main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           aws lambda invoke \
             --function-name ario-dev-deployment-trigger \


### PR DESCRIPTION
## Problem

Production (ardrive.net) deploys have been silently broken since commit `93b61984` (Mar 2025). On a push to `main`, the `deploy-core-image` job runs but the **Trigger Deployment For ardrive.net** step is always skipped, so nothing deploys to production.

Example run (push to `main`, every step skipped): https://github.com/ar-io/ar-io-node/actions/runs/27050372812/job/79844611035

## Root cause

`93b61984` ("fix main branch trigger condition") migrated the **job-level** trigger for `main` from the `workflow_run` event to a direct `push: branches: [main]` trigger, but left the **step-level** condition still testing `github.event.workflow_run.head_branch == 'main'`.

On a `push` event the `workflow_run` context is empty, so that condition is never true → the production step is always skipped. The `workflow_run`-triggered path can't reach it either, because the job-level `if` now requires `head_branch == 'develop'`.

## Fix

Gate the production step on the same push-to-`main` event that now triggers the job:

```diff
- if: github.event.workflow_run.head_branch == 'main'
+ if: github.event_name == 'push' && github.ref == 'refs/heads/main'
```

The `ar-io.dev` step is unchanged — it correctly runs on the `develop` `workflow_run` path.

## Note for reviewers

This production path has effectively never run since March 2025. Worth confirming the lambda payload (`event_type: deploy-ar-io-production`, no `image_sha`) is still what `ario-dev-deployment-trigger` expects before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)