### PR TITLE
PE-9114: fix production deploy step skipped on main push

### DIFF
--- a/.github/workflows/deploy-core-image.yml
+++ b/.github/workflows/deploy-core-image.yml
@@ -30,7 +30,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Trigger Deployment For ardrive.net
-        if: github.event.workflow_run.head_branch == 'main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           aws lambda invoke \
             --function-name ario-dev-deployment-trigger \


### PR DESCRIPTION
The job-level trigger for main was migrated to the push event in 93b61984, but the ardrive.net production step's condition still tested github.event.workflow_run.head_branch == 'main'. On a push event the workflow_run context is empty, so that condition is never true and the production deploy step was always skipped.

Gate the step on the push-to-main event instead, matching how the job is now triggered for main.