### PR TITLE
PE-9114: deploy core image on build completion, not on push

### DIFF
--- a/.github/workflows/deploy-core-image.yml
+++ b/.github/workflows/deploy-core-image.yml
@@ -4,18 +4,14 @@ on:
   workflow_run:
     workflows: ['build-core']
     types: [completed]
-  push:
-    branches:
-      - main
 
 jobs:
   ar-io-core-deployment:
     runs-on: ubuntu-latest
     if: >
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_branch == 'develop')
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.head_branch == 'develop' ||
+       github.event.workflow_run.head_branch == 'main')
 
     permissions:
       actions: write
@@ -30,7 +26,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Trigger Deployment For ardrive.net
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event.workflow_run.head_branch == 'main'
         run: |
           aws lambda invoke \
             --function-name ario-dev-deployment-trigger \


### PR DESCRIPTION
## Problem (regression from earlier PE-9114 work)

Pushing to `main` triggers **both** `build-core` and `deploy-core-image` from the same push event, concurrently. Because the production deploy step was gated on the `push` event, the deploy fired immediately (~26s) while `build-core` was still building the image — deploying the *previous* image, not the one just pushed.

Observed: `deploy-core-image #2602` completed in 26s while `build-core #4912` for the same commit was still in progress.

## Root cause

The `push: branches: [main]` trigger does not wait for anything. The only signal that the image has finished building is the `build-core` `workflow_run` completion — which is exactly what the ar-io.dev path already uses.

## Fix

- Remove the `push: branches: [main]` trigger.
- Gate the job on `build-core` `workflow_run` success for `develop` **or** `main`.
- Production (ardrive.net) step → `workflow_run.head_branch == 'main'`.
- ar-io.dev step → `workflow_run.head_branch == 'develop'` (unchanged).

This restores the build-then-deploy ordering and supersedes the push-based gating merged earlier under PE-9114 (#770 / #772).

## Note for reviewers

This relies on `build-core` producing a `workflow_run` completion with `head_branch == 'main'` on pushes to main — it runs `on: [push, workflow_dispatch]`, so it does. Production lambda payload is unchanged (`event_type: deploy-ar-io-production`, no `image_sha`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)