### PR TITLE
PE-9114: deploy core image on build completion, not on push (develop)

### DIFF
--- a/.github/workflows/deploy-core-image.yml
+++ b/.github/workflows/deploy-core-image.yml
@@ -4,18 +4,14 @@ on:
   workflow_run:
     workflows: ['build-core']
     types: [completed]
-  push:
-    branches:
-      - main
 
 jobs:
   ar-io-core-deployment:
     runs-on: ubuntu-latest
     if: >
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_branch == 'develop')
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.head_branch == 'develop' ||
+       github.event.workflow_run.head_branch == 'main')
 
     permissions:
       actions: write
@@ -30,7 +26,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Trigger Deployment For ardrive.net
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event.workflow_run.head_branch == 'main'
         run: |
           aws lambda invoke \
             --function-name ario-dev-deployment-trigger \


### PR DESCRIPTION
Forward-port of #773 to `develop`.

`develop` carries the push-based production deploy gating merged earlier under PE-9114 (#770), which races `build-core` and deploys the previous image. This applies the same fix as #773 so `develop` and `main` stay in sync.

This is a clean cherry-pick of the #773 commit, so the resulting file is byte-identical to `main` — a later `develop` → `main` merge will not conflict on this file.

See #773 for the full rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)