### PR TITLE
feat(graphql): address-keyed owner-key cache + coalescer + observability (PE-9120)

### DIFF
--- a/docs/drafts/2026-06-12-PE-9120-owner-key-address-cache.md
+++ b/docs/drafts/2026-06-12-PE-9120-owner-key-address-cache.md
@@ -1,7 +1,7 @@
 # PE-9120 — Address-keyed owner-key cache (+ in-flight coalescer)
 
-**Branch:** `PE-9120-owner-key-address-cache` (off `PE-9118`)
-**Status:** spec / scoping — no implementation yet
+**Branch:** `PE-9120-owner-key-address-cache` (PR #777 → `develop`)
+**Status:** implemented — decisions resolved (see end), `tsc` clean + unit tests passing.
 **Goal:** make bulk `owner.key` GraphQL resolution serve from one fetch **per unique owner** instead of one fetch **per data item**.
 
 ---

--- a/docs/drafts/2026-06-12-PE-9120-owner-key-address-cache.md
+++ b/docs/drafts/2026-06-12-PE-9120-owner-key-address-cache.md
@@ -160,9 +160,20 @@ don't select `owner { key }` (those are already inline/fast).
 - Manual: re-run the attestation script against a canary and compare page times
   to Goldsky.
 
-## Open questions
+## Decisions (2026-06-12) — IMPLEMENTED
 
-1. Dual-write the admin path (1a) now, or accept one-fetch-per-address warmup?
-2. Keep the id-fallback read for one TTL window, or hard-cut to address-only?
-3. Bump owner TTL / move owners to `lmdb` for persistence (separate PE)?
-4. Apply the same to `getTransactionOwner` (L1) in this PR or a follow-up?
+1. **Dual-write the admin path: yes.** `queue-data-item` now writes `ownerStore`
+   by both `id` and `owner_address`.
+2. **Keep the id-keyed fallback read** — both keys are read in parallel via
+   `Promise.any` (first hit wins; a miss rejects so it's ignored). Revisit
+   dropping the id read once the dependency on legacy entries is gone.
+3. **lmdb / TTL persistence: separate effort.** This change stays on the current
+   store (Redis, 4h TTL); only the cache *key* changes.
+4. **`getTransactionOwner` (L1): included** — same address-keyed read + dual-key
+   write + coalescer.
+
+Implemented on `PE-9120`: `attribute-fetchers.ts` (read/cache/coalesce helpers +
+both fetch methods), `resolvers.ts` (passes `tx.ownerAddress`), `ar-io.ts`
+(admin dual-write), `types.d.ts` (interface). Tests in
+`attribute-fetchers.test.ts` (address hit, id fallback, dual-write, coalescer);
+`tsc` clean, 56/56 local tests pass.

--- a/docs/drafts/2026-06-12-PE-9120-owner-key-address-cache.md
+++ b/docs/drafts/2026-06-12-PE-9120-owner-key-address-cache.md
@@ -1,0 +1,168 @@
+# PE-9120 — Address-keyed owner-key cache (+ in-flight coalescer)
+
+**Branch:** `PE-9120-owner-key-address-cache` (off `PE-9118`)
+**Status:** spec / scoping — no implementation yet
+**Goal:** make bulk `owner.key` GraphQL resolution serve from one fetch **per unique owner** instead of one fetch **per data item**.
+
+---
+
+## Problem
+
+GraphQL `owner.key` on a data item is resolved by fetching the owner public-key
+bytes from the parent bundle (`OwnerFetcher.getDataItemOwner` →
+`fetchDataFromParent` → data-source cascade). The cache in front of it
+(`ownerStore`, a `KvB64UrlStore` over Redis, 4h TTL) is **keyed by data-item
+`id`**:
+
+```ts
+// src/data/attribute-fetchers.ts  (getDataItemOwner)
+const owner = await this.ownerStore.get(id);   // ~619
+...
+await this.ownerStore.set(id, owner);          // ~682
+```
+
+So every data item is a unique key → **zero cross-item reuse**. A `transactions`
+page selecting `owner { key }` for 100 items by a handful of owners still does
+~100 fetches. Observed: ~8.4s/page on the gateway vs Goldsky's ~0.6s (Goldsky
+stores the key inline). The indexers themselves are fast (~46ms); the cost is
+entirely the gateway's per-item owner-key resolution.
+
+## Key insight (why address-keying is valid)
+
+For Arweave, `owner_address = sha256(owner_public_key)`. The hash is
+deterministic and collision-resistant, so:
+
+- **All data items with the same `owner_address` have the same `owner.key`.**
+- `owner_address` is **already inline** (stored column; `resolveTxOwnerAddress`
+  returns `tx.ownerAddress` with no fetch).
+
+Therefore the owner-key value can be cached **by address**: given an address,
+the key is well-defined, and the address is free to obtain. This collapses N
+per-item fetches to **U unique owners** for any query spanning many items by few
+owners (e.g. the AR-IO-Solana-Registration attestation scan).
+
+> Applies to **owner only**. Signatures are genuinely per-item (each data item
+> has a distinct signature), so `signatureStore` must stay id-keyed — this trick
+> does not transfer to `signature`.
+
+---
+
+## Design
+
+### 1. Cache key: address, not id
+
+`getDataItemOwner` should look up / store the owner key by `ownerAddress`. The
+caller already has it:
+
+```ts
+// src/routes/graphql/resolvers.ts  (fetchTxOwnerKey)
+//   tx.ownerAddress is inline/cheap — thread it down
+return ownerFetcher.getDataItemOwner({
+  id: tx.id,
+  parentId: tx.parentId,
+  ownerSize, ownerOffset,
+  ownerAddress: tx.ownerAddress,   // NEW
+  signal,
+}) ?? NOT_FOUND;                    // (PE-9118 sentinel already in place)
+```
+
+`getDataItemOwner`:
+1. If `ownerAddress` present → `ownerStore.get(ownerAddress)`; hit → return.
+2. (fallback) legacy `ownerStore.get(id)` for warm id-keyed entries — optional,
+   see Migration.
+3. Miss → existing fetch from parent bundle.
+4. On success → `ownerStore.set(ownerAddress, owner)` (and optionally also `id`
+   during transition).
+
+### 2. In-flight coalescer (address-keyed)
+
+The cache alone fixes reuse **across pages** but not **within** a page: a single
+page resolves all 100 `owner.key` fields concurrently, so the first page fires
+~U–100 concurrent misses before anything is cached (the existing
+`parent.keyPromise` memoization in `resolveTxOwnerKey` is **per data-item
+node**, not per address).
+
+Add an **address-keyed pending-promise map** in `OwnerFetcher`:
+
+```ts
+private inFlight = new Map<string, Promise<string | undefined>>();
+// in getDataItemOwner, after cache miss:
+const existing = this.inFlight.get(ownerAddress);
+if (existing) return existing;
+const p = this.fetchAndCache(...).finally(() => this.inFlight.delete(ownerAddress));
+this.inFlight.set(ownerAddress, p);
+return p;
+```
+
+So 100 concurrent items by one owner → **1** in-flight fetch, the other 99 await
+it. This is the piece that makes the *first* page fast, not just subsequent ones.
+
+---
+
+## Implementation plan (files)
+
+| file | change |
+|---|---|
+| `src/data/attribute-fetchers.ts` | `getDataItemOwner`: accept `ownerAddress`; address-keyed get/set; address-keyed in-flight coalescer (`Map`). Keep the incomplete-root-atom guard and PE-9098 span. |
+| `src/routes/graphql/resolvers.ts` | `fetchTxOwnerKey`: pass `tx.ownerAddress` to `getDataItemOwner`. (Sentinel coercion already landed in PE-9118.) |
+| `src/types.d.ts` / interfaces | extend `OwnerSource.getDataItemOwner` arg with optional `ownerAddress`. |
+| `src/system.ts` | no wiring change (same `ownerStore`). |
+| `src/routes/ar-io.ts` (admin `queue-data-item`) | Migration consideration — see below. |
+| tests | `attribute-fetchers` unit tests: address hit, address miss→fetch→cache-by-address, coalescer (N concurrent → 1 fetch), id-fallback (if kept). |
+
+`getTransactionOwner` (L1 owners) is also per-owner-address and could adopt the
+same address-keying later — out of scope for the first cut, but the coalescer
+infra is reusable.
+
+---
+
+## Caveats / decisions to make
+
+1. **Admin path consistency.** Turbo's `queue-data-item` route does
+   `ownerStore.set(dataItemHeader.id, owner)` (id-keyed). Options:
+   - (a) also `set(ownerAddress, owner)` there (dual-write) — keeps Turbo's warm
+     cache useful to the new read path; **recommended**.
+   - (b) leave it; the new read path just misses on Turbo-posted items and
+     re-fetches once per address.
+2. **Backward compatibility.** Existing id-keyed Redis entries become dead
+   weight (4h TTL clears them). Optional id-fallback read (step 2 above) avoids a
+   cold start; can be dropped after one TTL window.
+3. **TTL.** Still 4h Redis (`CHAIN_CACHE_TYPE=redis`). Address-keying multiplies
+   the *value* of each entry (shared across items), so a longer TTL or a
+   persistent backend (`lmdb`) becomes more attractive — separate decision, not
+   required for this change.
+4. **Memory.** The in-flight `Map` is bounded by concurrent unique owners in
+   flight; entries delete on settle. No unbounded growth.
+5. **Correctness of `ownerAddress` provenance.** It must be the address derived
+   from *this item's* owner. It comes from the same GQL row as the offsets, so
+   it's consistent. (We are not trusting a client-supplied address.)
+6. **Negative results.** Keep returning `undefined` on genuine miss/abort (→
+   PE-9118 `NOT_FOUND` sentinel at the resolver). Do **not** cache `undefined`
+   under the address (would poison all of that owner's items) — only cache
+   successful key bytes. (We deprioritized negative caching generally; this is
+   consistent with that.)
+
+---
+
+## Expected impact
+
+For a query over M items spanning U unique owners: fetches drop from ~M to ~U.
+Attestation scan (finite registrant set) → likely 10–100× fewer owner fetches →
+turbo page latency from ~8.4s toward Goldsky's ~0.6s. No effect on queries that
+don't select `owner { key }` (those are already inline/fast).
+
+## Testing
+
+- Unit (no `system.js` boot — inject a mock `ownerStore` + `dataSource` into
+  `OwnerFetcher` directly): address hit returns without fetch; concurrent N-by-1
+  owner → exactly 1 `dataSource.getData`; distinct owners → N fetches; miss
+  returns `undefined`; (optional) id-fallback hit.
+- Manual: re-run the attestation script against a canary and compare page times
+  to Goldsky.
+
+## Open questions
+
+1. Dual-write the admin path (1a) now, or accept one-fetch-per-address warmup?
+2. Keep the id-fallback read for one TTL window, or hard-cut to address-only?
+3. Bump owner TTL / move owners to `lmdb` for persistence (separate PE)?
+4. Apply the same to `getTransactionOwner` (L1) in this PR or a follow-up?

--- a/docs/drafts/2026-06-12-PE-9120-owner-key-address-cache.md
+++ b/docs/drafts/2026-06-12-PE-9120-owner-key-address-cache.md
@@ -151,6 +151,34 @@ Attestation scan (finite registrant set) → likely 10–100× fewer owner fetch
 turbo page latency from ~8.4s toward Goldsky's ~0.6s. No effect on queries that
 don't select `owner { key }` (those are already inline/fast).
 
+## Observability
+
+Reuses the existing `attribute_fetch_total{kind,subject,source,outcome}` counter
+and `attribute_fetch_duration_seconds{kind,subject,source}` histogram — no new
+metrics for the common cases — plus one small counter for the coalescer.
+
+- **Successful retrievals / hits vs misses by cache type** —
+  `attribute_fetch_total{kind="owner",outcome="hit"}` sliced by `source`:
+  - `store_address` — served from the shared `owner_address` key (the cross-item
+    reuse this effort adds; a hit on an item whose own id was never written is
+    proof the optimization is working)
+  - `store_id` — served from the per-item / admin-written key
+  - `parent_data` / `chain` / `derived` — a cache **miss** that went to fetch
+    (data-item parent bytes vs L1 chain vs secp256k1 recovery)
+  - cache hit rate = `(store_address + store_id) / all owner hits`. Rising
+    `store_address` over time = address-keying paying off.
+- **Timing around owner lookups** — `attribute_fetch_duration_seconds{kind="owner",source}`
+  already exists; `store_*` latency (cache, ~ms) vs `parent_data` latency
+  (network, the slow tail) is directly comparable, by `subject`
+  (`data_item` / `transaction`).
+- **Coalescer effectiveness** — `owner_fetch_coalesced_total{subject}` counts
+  concurrent fetches collapsed onto one in-flight call. High relative to owner
+  `parent_data` fetches = intra-page dedup working.
+
+New label values: 2 (`store_address`, `store_id`) on the existing counter/
+histogram; 1 new counter (`owner_fetch_coalesced_total`, 2 series). Deliberately
+no new histogram — timing rides the existing one.
+
 ## Testing
 
 - Unit (no `system.js` boot — inject a mock `ownerStore` + `dataSource` into

--- a/src/data/attribute-fetchers.test.ts
+++ b/src/data/attribute-fetchers.test.ts
@@ -886,6 +886,97 @@ describe('OwnerFetcher', () => {
     });
   });
 
+  describe('address-keyed owner cache (PE-9120)', () => {
+    const ADDR = 'owner-address-1';
+
+    const ownerStreamMock = () =>
+      mock.method(mocks.dataSource, 'getData', async () => ({
+        stream: {
+          [Symbol.asyncIterator]: async function* () {
+            yield Buffer.from('testOwner');
+          },
+        },
+      }));
+
+    it('returns from the address-keyed entry without fetching', async () => {
+      mock.method(mocks.ownerStore, 'get', async (key: string) =>
+        key === ADDR ? 'owner-by-address' : undefined,
+      );
+      const getDataMock = ownerStreamMock();
+
+      const result = await ownerFetcher.getDataItemOwner({
+        id: 'item-1',
+        parentId: 'parent',
+        ownerOffset: 1,
+        ownerSize: 9,
+        ownerAddress: ADDR,
+      });
+
+      assert.strictEqual(result, 'owner-by-address');
+      assert.strictEqual(getDataMock.mock.calls.length, 0);
+      assert.strictEqual((mocks.ownerStore.set as any).mock.calls.length, 0);
+    });
+
+    it('falls back to the id-keyed entry when address misses', async () => {
+      mock.method(mocks.ownerStore, 'get', async (key: string) =>
+        key === 'item-1' ? 'owner-by-id' : undefined,
+      );
+      const getDataMock = ownerStreamMock();
+
+      const result = await ownerFetcher.getDataItemOwner({
+        id: 'item-1',
+        parentId: 'parent',
+        ownerOffset: 1,
+        ownerSize: 9,
+        ownerAddress: ADDR,
+      });
+
+      assert.strictEqual(result, 'owner-by-id');
+      assert.strictEqual(getDataMock.mock.calls.length, 0);
+    });
+
+    it('dual-writes by id and address after a fetch', async () => {
+      mock.method(mocks.ownerStore, 'get', async () => undefined);
+      ownerStreamMock();
+
+      await ownerFetcher.getDataItemOwner({
+        id: 'item-1',
+        parentId: 'parent',
+        ownerOffset: 1,
+        ownerSize: 9,
+        ownerAddress: ADDR,
+      });
+
+      const setCalls = (mocks.ownerStore.set as any).mock.calls;
+      assert.strictEqual(setCalls.length, 2);
+      const keys = setCalls.map((c: any) => c.arguments[0]).sort();
+      assert.deepStrictEqual(keys, ['item-1', ADDR].sort());
+    });
+
+    it('coalesces concurrent fetches for the same address to one parent fetch', async () => {
+      mock.method(mocks.ownerStore, 'get', async () => undefined);
+      const getDataMock = ownerStreamMock();
+
+      const results = await Promise.all(
+        ['a', 'b', 'c'].map((id) =>
+          ownerFetcher.getDataItemOwner({
+            id,
+            parentId: 'parent',
+            ownerOffset: 1,
+            ownerSize: 9,
+            ownerAddress: ADDR,
+          }),
+        ),
+      );
+
+      assert.deepStrictEqual(
+        results,
+        results.map(() => Buffer.from('testOwner').toString('base64url')),
+      );
+      assert.strictEqual(getDataMock.mock.calls.length, 1);
+    });
+  });
+
   describe('getTransactionOwner', () => {
     it('should return owner from owner store if it exists', async () => {
       mock.method(mocks.ownerStore, 'get', async () => 'owner-from-store');

--- a/src/data/attribute-fetchers.test.ts
+++ b/src/data/attribute-fetchers.test.ts
@@ -975,6 +975,31 @@ describe('OwnerFetcher', () => {
       );
       assert.strictEqual(getDataMock.mock.calls.length, 1);
     });
+
+    it('does not fan out a failed leader fetch to coalesced callers', async () => {
+      mock.method(mocks.ownerStore, 'get', async () => undefined);
+      // Every fetch fails. A poisoning coalescer would issue one call and hand
+      // the leader's undefined to all callers; the correct behavior is that a
+      // failed leader makes each follower fall back to its own fetch.
+      const getDataMock = mock.method(mocks.dataSource, 'getData', async () => {
+        throw new Error('boom');
+      });
+
+      const results = await Promise.all(
+        ['a', 'b', 'c'].map((id) =>
+          ownerFetcher.getDataItemOwner({
+            id,
+            parentId: 'parent',
+            ownerOffset: 1,
+            ownerSize: 9,
+            ownerAddress: ADDR,
+          }),
+        ),
+      );
+
+      assert.deepStrictEqual(results, [undefined, undefined, undefined]);
+      assert.strictEqual(getDataMock.mock.calls.length, 3);
+    });
   });
 
   describe('getTransactionOwner', () => {

--- a/src/data/attribute-fetchers.ts
+++ b/src/data/attribute-fetchers.ts
@@ -599,30 +599,137 @@ export class OwnerFetcher extends AttributeFetchers implements OwnerSource {
     this.ownerStore = ownerStore;
   }
 
+  // Dedup concurrent owner fetches for the same owner address (PE-9120): a
+  // GraphQL page of N items by one owner resolves owner.key concurrently, so
+  // without coalescing the first page would fire N identical fetches before
+  // any of them populates the cache.
+  private readonly inFlightOwnerByAddress = new Map<
+    string,
+    Promise<string | undefined>
+  >();
+
+  /**
+   * Read the cached owner key. owner_address = sha256(owner_key), so the key is
+   * identical for every item by an owner; we cache by address for cross-item
+   * reuse and fall back to the item id for legacy / admin-written entries. The
+   * two reads race — the first hit wins (PE-9120).
+   */
+  private async readCachedOwner(
+    ownerAddress: string | undefined,
+    id: string,
+  ): Promise<string | undefined> {
+    const hitOrThrow = async (key: string): Promise<string> => {
+      const value = await this.ownerStore.get(key);
+      if (value === undefined) {
+        throw new Error('owner-store miss');
+      }
+      return value;
+    };
+    const reads: Promise<string>[] = [];
+    if (ownerAddress !== undefined && ownerAddress.length > 0) {
+      reads.push(hitOrThrow(ownerAddress));
+    }
+    reads.push(hitOrThrow(id));
+    try {
+      return await Promise.any(reads);
+    } catch {
+      // Both reads missed (or errored) — fall through to a fresh fetch.
+      return undefined;
+    }
+  }
+
+  /**
+   * Cache an owner key under both its address (shared across the owner's items)
+   * and the item id (so legacy id-keyed reads stay warm during migration).
+   */
+  private async cacheOwner(
+    ownerAddress: string | undefined,
+    id: string,
+    owner: string | undefined,
+  ): Promise<void> {
+    if (owner === undefined) {
+      return;
+    }
+    await this.ownerStore.set(id, owner);
+    if (ownerAddress !== undefined && ownerAddress.length > 0) {
+      await this.ownerStore.set(ownerAddress, owner);
+    }
+  }
+
+  /** Collapse concurrent fetches for one owner address to a single in-flight call. */
+  private coalesceOwnerFetch(
+    ownerAddress: string | undefined,
+    fetch: () => Promise<string | undefined>,
+  ): Promise<string | undefined> {
+    if (ownerAddress === undefined || ownerAddress.length === 0) {
+      return fetch();
+    }
+    const existing = this.inFlightOwnerByAddress.get(ownerAddress);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const promise = fetch().finally(() => {
+      this.inFlightOwnerByAddress.delete(ownerAddress);
+    });
+    this.inFlightOwnerByAddress.set(ownerAddress, promise);
+    return promise;
+  }
+
   async getDataItemOwner({
     id,
     parentId,
     ownerSize,
     ownerOffset,
+    ownerAddress,
     signal,
   }: {
     id: string;
     parentId?: string;
     ownerSize?: number;
     ownerOffset?: number;
+    ownerAddress?: string;
     signal?: AbortSignal;
   }): Promise<string | undefined> {
     const log = this.log.child({ method: 'getDataItemOwner' });
     const start = Date.now();
-    log.debug('Fetching data item owner', { id });
+    log.debug('Fetching data item owner', { id, ownerAddress });
 
-    const owner = await this.ownerStore.get(id);
-
-    if (owner !== undefined) {
+    const cached = await this.readCachedOwner(ownerAddress, id);
+    if (cached !== undefined) {
       log.debug('Data item owner fetched from store', { id });
       recordAttributeFetch('owner', 'data_item', 'store', 'hit', start);
-      return owner;
+      return cached;
     }
+
+    return this.coalesceOwnerFetch(ownerAddress, () =>
+      this.fetchDataItemOwnerFromParent({
+        id,
+        parentId,
+        ownerSize,
+        ownerOffset,
+        ownerAddress,
+        signal,
+      }),
+    );
+  }
+
+  private async fetchDataItemOwnerFromParent({
+    id,
+    parentId,
+    ownerSize,
+    ownerOffset,
+    ownerAddress,
+    signal,
+  }: {
+    id: string;
+    parentId?: string;
+    ownerSize?: number;
+    ownerOffset?: number;
+    ownerAddress?: string;
+    signal?: AbortSignal;
+  }): Promise<string | undefined> {
+    const log = this.log.child({ method: 'getDataItemOwner' });
+    const start = Date.now();
 
     try {
       if (
@@ -679,7 +786,7 @@ export class OwnerFetcher extends AttributeFetchers implements OwnerSource {
         signal,
       });
 
-      await this.ownerStore.set(id, owner);
+      await this.cacheOwner(ownerAddress, id, owner);
       recordAttributeFetch('owner', 'data_item', 'parent_data', 'hit', start);
       return owner;
     } catch (error) {
@@ -700,22 +807,40 @@ export class OwnerFetcher extends AttributeFetchers implements OwnerSource {
 
   async getTransactionOwner({
     id,
+    ownerAddress,
     signal,
   }: {
     id: string;
+    ownerAddress?: string;
     signal?: AbortSignal;
   }): Promise<string | undefined> {
     const log = this.log.child({ method: 'getTransactionOwner' });
     const start = Date.now();
-    log.debug('Fetching transaction owner', { id });
+    log.debug('Fetching transaction owner', { id, ownerAddress });
 
-    const owner = await this.ownerStore.get(id);
-
-    if (owner !== undefined) {
+    const cached = await this.readCachedOwner(ownerAddress, id);
+    if (cached !== undefined) {
       log.debug('Transaction owner fetched from store', { id });
       recordAttributeFetch('owner', 'transaction', 'store', 'hit', start);
-      return owner;
+      return cached;
     }
+
+    return this.coalesceOwnerFetch(ownerAddress, () =>
+      this.fetchTransactionOwnerFromChain({ id, ownerAddress, signal }),
+    );
+  }
+
+  private async fetchTransactionOwnerFromChain({
+    id,
+    ownerAddress,
+    signal,
+  }: {
+    id: string;
+    ownerAddress?: string;
+    signal?: AbortSignal;
+  }): Promise<string | undefined> {
+    const log = this.log.child({ method: 'getTransactionOwner' });
+    const start = Date.now();
 
     // Track the source we are currently attempting so the catch block can
     // attribute errors/aborts to the correct upstream layer.
@@ -727,7 +852,7 @@ export class OwnerFetcher extends AttributeFetchers implements OwnerSource {
         transactionAttributes !== undefined &&
         typeof transactionAttributes.owner === 'string'
       ) {
-        await this.ownerStore.set(id, transactionAttributes.owner);
+        await this.cacheOwner(ownerAddress, id, transactionAttributes.owner);
         recordAttributeFetch(
           'owner',
           'transaction',
@@ -788,7 +913,7 @@ export class OwnerFetcher extends AttributeFetchers implements OwnerSource {
         return undefined;
       }
 
-      await this.ownerStore.set(id, ownerFromChain);
+      await this.cacheOwner(ownerAddress, id, ownerFromChain);
       recordAttributeFetch(
         'owner',
         'transaction',

--- a/src/data/attribute-fetchers.ts
+++ b/src/data/attribute-fetchers.ts
@@ -28,12 +28,19 @@ type AttributeKind = 'owner' | 'signature';
 type AttributeSubject = 'data_item' | 'transaction';
 type AttributeSource =
   | 'store'
+  // Owner-key store hits split by which key served them (PE-9120):
+  // `store_address` is the shared owner_address key (cross-item reuse),
+  // `store_id` is the per-item / admin-written key.
+  | 'store_address'
+  | 'store_id'
   | 'attributes'
   | 'parent_data'
   | 'chain'
   | 'derived'
   | 'incomplete_root';
 type AttributeOutcome = 'hit' | 'aborted' | 'error' | 'not_found';
+// Which owner_store key served a cache hit (PE-9120). Subset of AttributeSource.
+type OwnerCacheSource = 'store_address' | 'store_id';
 
 /**
  * Classify a thrown error into an `AttributeOutcome` for the metric label.
@@ -617,19 +624,22 @@ export class OwnerFetcher extends AttributeFetchers implements OwnerSource {
   private async readCachedOwner(
     ownerAddress: string | undefined,
     id: string,
-  ): Promise<string | undefined> {
-    const hitOrThrow = async (key: string): Promise<string> => {
+  ): Promise<{ owner: string; source: OwnerCacheSource } | undefined> {
+    const hitOrThrow = async (
+      key: string,
+      source: OwnerCacheSource,
+    ): Promise<{ owner: string; source: OwnerCacheSource }> => {
       const value = await this.ownerStore.get(key);
       if (value === undefined) {
         throw new Error('owner-store miss');
       }
-      return value;
+      return { owner: value, source };
     };
-    const reads: Promise<string>[] = [];
+    const reads: Promise<{ owner: string; source: OwnerCacheSource }>[] = [];
     if (ownerAddress !== undefined && ownerAddress.length > 0) {
-      reads.push(hitOrThrow(ownerAddress));
+      reads.push(hitOrThrow(ownerAddress, 'store_address'));
     }
-    reads.push(hitOrThrow(id));
+    reads.push(hitOrThrow(id, 'store_id'));
     try {
       return await Promise.any(reads);
     } catch {
@@ -659,6 +669,7 @@ export class OwnerFetcher extends AttributeFetchers implements OwnerSource {
   /** Collapse concurrent fetches for one owner address to a single in-flight call. */
   private coalesceOwnerFetch(
     ownerAddress: string | undefined,
+    subject: AttributeSubject,
     fetch: () => Promise<string | undefined>,
   ): Promise<string | undefined> {
     if (ownerAddress === undefined || ownerAddress.length === 0) {
@@ -666,6 +677,7 @@ export class OwnerFetcher extends AttributeFetchers implements OwnerSource {
     }
     const existing = this.inFlightOwnerByAddress.get(ownerAddress);
     if (existing !== undefined) {
+      metrics.ownerFetchCoalescedCounter.inc({ subject });
       return existing;
     }
     const promise = fetch().finally(() => {
@@ -697,11 +709,11 @@ export class OwnerFetcher extends AttributeFetchers implements OwnerSource {
     const cached = await this.readCachedOwner(ownerAddress, id);
     if (cached !== undefined) {
       log.debug('Data item owner fetched from store', { id });
-      recordAttributeFetch('owner', 'data_item', 'store', 'hit', start);
-      return cached;
+      recordAttributeFetch('owner', 'data_item', cached.source, 'hit', start);
+      return cached.owner;
     }
 
-    return this.coalesceOwnerFetch(ownerAddress, () =>
+    return this.coalesceOwnerFetch(ownerAddress, 'data_item', () =>
       this.fetchDataItemOwnerFromParent({
         id,
         parentId,
@@ -821,11 +833,11 @@ export class OwnerFetcher extends AttributeFetchers implements OwnerSource {
     const cached = await this.readCachedOwner(ownerAddress, id);
     if (cached !== undefined) {
       log.debug('Transaction owner fetched from store', { id });
-      recordAttributeFetch('owner', 'transaction', 'store', 'hit', start);
-      return cached;
+      recordAttributeFetch('owner', 'transaction', cached.source, 'hit', start);
+      return cached.owner;
     }
 
-    return this.coalesceOwnerFetch(ownerAddress, () =>
+    return this.coalesceOwnerFetch(ownerAddress, 'transaction', () =>
       this.fetchTransactionOwnerFromChain({ id, ownerAddress, signal }),
     );
   }

--- a/src/data/attribute-fetchers.ts
+++ b/src/data/attribute-fetchers.ts
@@ -677,8 +677,21 @@ export class OwnerFetcher extends AttributeFetchers implements OwnerSource {
     }
     const existing = this.inFlightOwnerByAddress.get(ownerAddress);
     if (existing !== undefined) {
-      metrics.ownerFetchCoalescedCounter.inc({ subject });
-      return existing;
+      // Reuse the in-flight leader only if it SUCCEEDS. A leader abort or a
+      // per-item miss (items share an owner_address but have different
+      // parent_id/offset, so retrievability can differ) must not be fanned out
+      // to concurrent callers that could resolve on their own — they fall back
+      // to their own fetch instead of inheriting the leader's failure.
+      return existing.then(
+        (leaderResult) => {
+          if (leaderResult !== undefined) {
+            metrics.ownerFetchCoalescedCounter.inc({ subject });
+            return leaderResult;
+          }
+          return fetch();
+        },
+        () => fetch(),
+      );
     }
     const promise = fetch().finally(() => {
       this.inFlightOwnerByAddress.delete(ownerAddress);

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -387,6 +387,21 @@ export const attributeFetchDurationHistogram = new promClient.Histogram({
   buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30],
 });
 
+// Owner-key cache observability (PE-9120). Hit/miss and timing by cache key
+// reuse attribute_fetch_total / attribute_fetch_duration_seconds via the
+// `store_address` (shared owner_address key — cross-item reuse) and `store_id`
+// (per-item / admin key) sources. This counter additionally tracks concurrent
+// fetches collapsed by the address-keyed in-flight coalescer.
+export const ownerFetchCoalescedCounter = new promClient.Counter({
+  name: 'owner_fetch_coalesced_total',
+  help:
+    'Count of owner-key fetches served by joining an in-flight fetch for the ' +
+    'same owner address instead of issuing a new one (PE-9120 coalescer). ' +
+    'High relative to owner `parent_data`/`chain` fetches means intra-page ' +
+    'dedup is working.',
+  labelNames: ['subject'],
+});
+
 //
 // Arweave client metrics
 //

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -475,6 +475,11 @@ arIoRouter.post(
           signatureStore.set(dataItemHeader.id, dataItemHeader.signature);
         }
         ownerStore.set(dataItemHeader.id, dataItemHeader.owner);
+        // Dual-write by owner_address so GraphQL owner.key resolution can serve
+        // every item by this owner from one cache entry (PE-9120).
+        if (dataItemHeader.owner_address.length > 0) {
+          ownerStore.set(dataItemHeader.owner_address, dataItemHeader.owner);
+        }
 
         system.dataItemIndexer.queueDataItem(
           {

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -470,15 +470,29 @@ arIoRouter.post(
       }
 
       for (const dataItemHeader of dataItemHeaders) {
+        // Fire-and-forget header-cache warming: never block the admin response
+        // or surface an unhandled rejection if a KV write fails.
+        const warnCacheWrite = (key: string) => (error: unknown) =>
+          log.warn('Failed to warm header cache from queue-data-item', {
+            key,
+            error: (error as Error).message,
+          });
+
         // cache signatures in signature store
         if (config.WRITE_ANS104_DATA_ITEM_DB_SIGNATURES === false) {
-          signatureStore.set(dataItemHeader.id, dataItemHeader.signature);
+          signatureStore
+            .set(dataItemHeader.id, dataItemHeader.signature)
+            .catch(warnCacheWrite(dataItemHeader.id));
         }
-        ownerStore.set(dataItemHeader.id, dataItemHeader.owner);
+        ownerStore
+          .set(dataItemHeader.id, dataItemHeader.owner)
+          .catch(warnCacheWrite(dataItemHeader.id));
         // Dual-write by owner_address so GraphQL owner.key resolution can serve
         // every item by this owner from one cache entry (PE-9120).
         if (dataItemHeader.owner_address.length > 0) {
-          ownerStore.set(dataItemHeader.owner_address, dataItemHeader.owner);
+          ownerStore
+            .set(dataItemHeader.owner_address, dataItemHeader.owner)
+            .catch(warnCacheWrite(dataItemHeader.owner_address));
         }
 
         system.dataItemIndexer.queueDataItem(

--- a/src/routes/graphql/resolvers.ts
+++ b/src/routes/graphql/resolvers.ts
@@ -176,6 +176,8 @@ async function fetchTxOwnerKey(
         parentId: tx.parentId,
         ownerSize: parseInt(tx.ownerSize),
         ownerOffset: parseInt(tx.ownerOffset),
+        // Shared cache key: all items by this owner reuse one fetch (PE-9120).
+        ownerAddress: tx.ownerAddress,
         signal,
       });
       return ownerKey ?? NOT_FOUND;
@@ -185,6 +187,7 @@ async function fetchTxOwnerKey(
 
   const ownerKey = await ownerFetcher.getTransactionOwner({
     id: tx.id,
+    ownerAddress: tx.ownerAddress,
     signal,
   });
   return ownerKey !== undefined ? ownerKey : NOT_FOUND;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1287,20 +1287,26 @@ export interface OwnerSource {
     parentId,
     ownerSize,
     ownerOffset,
+    ownerAddress,
     signal,
   }: {
     id: string;
     parentId?: string;
     ownerSize?: number;
     ownerOffset?: number;
+    // owner_address (= sha256(owner_key)); when present, used as the shared
+    // cache key so all items by an owner reuse one fetch (PE-9120).
+    ownerAddress?: string;
     signal?: AbortSignal;
   }): Promise<string | undefined>;
 
   getTransactionOwner({
     id,
+    ownerAddress,
     signal,
   }: {
     id: string;
+    ownerAddress?: string;
     signal?: AbortSignal;
   }): Promise<string | undefined>;
 }


### PR DESCRIPTION
## Problem
GraphQL `owner.key` is resolved by fetching the owner public-key bytes from the parent bundle, and the cache was keyed by data-item `id` — zero cross-item reuse. A `transactions` page selecting `owner { key }` for 100 items by a few owners did ~100 fetches (slow) vs an inline-storing search index's single-digit-ms-per-item (it stores the key inline).

## Change
`owner_address = sha256(owner_key)` is inline and identical across an owner's items, so cache by address:
- **Read** by address (preferred) and id (legacy/admin) in parallel via `Promise.any` (first hit wins; a miss rejects so it's ignored).
- **Dual-write** by both address and id on fetch, and in the admin `queue-data-item` path.
- **Coalesce** concurrent fetches for the same address to one in-flight call (makes the *first* page fast, not just later ones).
- Applied to both `getDataItemOwner` and `getTransactionOwner`.
- Stays on the current owner store (Redis, 4h TTL); lmdb/persistence is a separate effort.

Collapses N per-item fetches to U unique owners. Signatures are unaffected (genuinely per-item).

## Observability
- Owner cache hits split into `store_address` vs `store_id` on the existing `attribute_fetch_total` / `attribute_fetch_duration_seconds` — hits/misses + timing by cache type (and cache vs `parent_data`/`chain` fetch).
- New `owner_fetch_coalesced_total{subject}` for coalescer effectiveness.
- No new histograms.

## Test plan
- `tsc` clean. `attribute-fetchers.test.ts` (injected mocks, no system boot): 56/56 incl. address hit, id fallback, dual-write, coalescer (3 concurrent → 1 fetch).
- [ ] CI green.

Design doc: `docs/drafts/2026-06-12-PE-9120-owner-key-address-cache.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)