### PR TITLE
fix(observer): forward assessment-concurrency + log-report-sink env to observer

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -624,6 +624,14 @@ services:
       - OBSERVATION_WINDOW_FRACTION=${OBSERVATION_WINDOW_FRACTION:-}
       - OBSERVATION_CYCLE_INTERVAL_MS=${OBSERVATION_CYCLE_INTERVAL_MS:-}
       - MAJORITY_VOTE_THRESHOLD=${MAJORITY_VOTE_THRESHOLD:-}
+      # Per-cycle assessment parallelism (gateway + ArNS-name probes). Without
+      # these the observer falls back to its built-in defaults regardless of
+      # the .env value — see ar-io-observer src/config.ts.
+      - GATEWAY_ASSESSMENT_CONCURRENCY=${GATEWAY_ASSESSMENT_CONCURRENCY:-}
+      - NAME_ASSESSMENT_CONCURRENCY=${NAME_ASSESSMENT_CONCURRENCY:-}
+      # Enable the LogReportSink — logs full per-gateway assessment detail at
+      # info level (off by default).
+      - ENABLE_LOG_REPORT_SINK=${ENABLE_LOG_REPORT_SINK:-}
       # Epoch-relative submission window (defaults tuned for mainnet's ~24h
       # epochs; shorter-epoch networks like devnet must shrink these or the
       # observer rejects with "Epoch duration too short for configured buffers").

--- a/docs/envs.md
+++ b/docs/envs.md
@@ -422,6 +422,9 @@ These settings control the continuous observation mode, which spreads observatio
 | OBSERVATION_WINDOW_FRACTION                      | Number               | 0.5                                           | Fraction of the epoch window (0.1-0.9) during which observations are spread. Higher values spread observations over more time                                       |
 | OBSERVATION_CYCLE_INTERVAL_MS                    | Number               | 60000                                         | Interval in milliseconds between observation cycles. Each cycle processes scheduled observations                                                                    |
 | MAJORITY_VOTE_THRESHOLD                          | Number               | 2                                             | Number of passing observations needed for a gateway to pass overall. Should be ≤ OBSERVATIONS_PER_GATEWAY                                                           |
+| GATEWAY_ASSESSMENT_CONCURRENCY                   | Number               | 10                                            | Parallel gateway assessments per observation cycle (network-bound). Higher values speed assessment but add concurrent outbound load                                 |
+| NAME_ASSESSMENT_CONCURRENCY                      | Number               | 5                                             | Parallel ArNS-name resolution checks per gateway during assessment                                                                                                  |
+| ENABLE_LOG_REPORT_SINK                           | Boolean              | false                                         | When true, enables the LogReportSink which logs full per-gateway assessment detail at info level                                                                    |
 
 ### Offset Observation Configuration
 


### PR DESCRIPTION
## Problem
Three observer config vars are read by `ar-io-observer` (`src/config.ts`) but are **not enumerated in the observer service's `environment:` block** in `docker-compose.yaml`. Docker only forwards env vars that a service explicitly lists, so setting these in `.env` has **no effect** — the observer silently falls back to its built-in defaults:

| Var | Observer default | Effect of the gap |
| --- | --- | --- |
| `GATEWAY_ASSESSMENT_CONCURRENCY` | `10` | gateway-assessment parallelism can't be tuned |
| `NAME_ASSESSMENT_CONCURRENCY` | `5` | ArNS-name assessment parallelism can't be tuned |
| `ENABLE_LOG_REPORT_SINK` | `false` | `ENABLE_LOG_REPORT_SINK=true` never enables the `LogReportSink` |

Reported by operators who set `GATEWAY_ASSESSMENT_CONCURRENCY` / `ENABLE_LOG_REPORT_SINK=true` and saw no change.

## Fix
Add the three passthroughs to the observer service `environment:` (next to the existing Continuous Observation config), and document them in `docs/envs.md` (per the repo's compose↔docs sync rule).

```yaml
- GATEWAY_ASSESSMENT_CONCURRENCY=${GATEWAY_ASSESSMENT_CONCURRENCY:-}
- NAME_ASSESSMENT_CONCURRENCY=${NAME_ASSESSMENT_CONCURRENCY:-}
- ENABLE_LOG_REPORT_SINK=${ENABLE_LOG_REPORT_SINK:-}
```

`docker compose config` validates; the vars resolve into the observer env. The observer code already reads + uses all three (`config.ts` → `system.ts` → `observer.ts` `pMap` concurrency / `LogReportSink` wiring) — this only fixes the missing passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)