### PR TITLE
fix(gql): truthful hasNextPage when id-dedup collapses a full ClickHouse page

### DIFF
--- a/src/database/composite-clickhouse.test.ts
+++ b/src/database/composite-clickhouse.test.ts
@@ -412,6 +412,47 @@ describe('CompositeClickHouseDatabase', () => {
       assert.equal(result.edges.length, 2);
       assert.equal(result.pageInfo.hasNextPage, false);
     });
+
+    it('is true when a full leg collapses to pageSize after id-dedup (PE-9124)', async () => {
+      // A single leg returns its full `pageSize + 1` rows, but a stale
+      // duplicate (same id, different block_transaction_index — the SQL's
+      // full-key `LIMIT 1 BY` does not fold it) collapses the deduped set to
+      // exactly `pageSize`. hasNextPage MUST stay true: the leg came back full,
+      // so more matching rows exist beyond this page. Counting deduped edges
+      // alone would report `2 > 2 == false` and silently strand every later
+      // page.
+      const composite = buildComposite({
+        sqlite,
+        chRowsByLeg: {
+          stable: [
+            chRow({
+              id: id('dupitem'),
+              height: 1,
+              blockTransactionIndex: 0,
+              isDataItem: true,
+            }),
+            chRow({
+              id: id('dupitem'),
+              height: 1,
+              blockTransactionIndex: 12,
+              isDataItem: true,
+            }),
+            chRow({ id: id('itemb'), height: 2 }),
+          ],
+        },
+      });
+
+      const result = await composite.getGqlTransactions({
+        pageSize: 2,
+        sortOrder: 'HEIGHT_ASC',
+      });
+      assert.equal(result.edges.length, 2);
+      assert.deepEqual(
+        result.edges.map((e) => e.node.id),
+        [id('dupitem'), id('itemb')],
+      );
+      assert.equal(result.pageInfo.hasNextPage, true);
+    });
   });
 
   describe('SQLite fallback behavior', () => {

--- a/src/database/composite-clickhouse.ts
+++ b/src/database/composite-clickhouse.ts
@@ -888,8 +888,10 @@ export class CompositeClickHouseDatabase implements GqlQueryable {
     // SQLite leg: rejection degrades same as today.
     const sqliteSettled = await sqliteSettledPromise;
     let sqliteEdges: GqlTransactionsResult['edges'] = [];
+    let sqliteHasNextPage = false;
     if (sqliteSettled.status === 'fulfilled') {
       sqliteEdges = sqliteSettled.value.edges;
+      sqliteHasNextPage = sqliteSettled.value.pageInfo.hasNextPage;
       if (
         sqliteSettled.value.warnings !== undefined &&
         sqliteSettled.value.warnings.length > 0
@@ -966,9 +968,26 @@ export class CompositeClickHouseDatabase implements GqlQueryable {
       return bufA.compare(bufB) * sortOrderModifier;
     });
 
+    // `hasNextPage` must reflect whether any leg has rows BEYOND this page,
+    // derived from each leg's RAW result before the cross-leg id-dedup above.
+    // Both ClickHouse legs fetch `pageSize + 1` rows (see buildChTransactionsSql),
+    // so a leg that comes back with more than `pageSize` rows has more matching
+    // data to give. Relying on the deduped `edges.length > pageSize` alone
+    // under-reports: when duplicate ids collapse the merged set to `pageSize` or
+    // fewer — e.g. stale rows that share an `id` but differ on
+    // `block_transaction_index`, which the SQL's full-key `LIMIT 1 BY` does not
+    // fold — the page falsely signals completeness and every later page is
+    // silently stranded. Erring toward `true` is safe: the worst case is one
+    // extra page fetch that comes back empty.
+    const hasNextPage =
+      edges.length > pageSize ||
+      stableTxs.length > pageSize ||
+      unstableTxs.length > pageSize ||
+      sqliteHasNextPage;
+
     return {
       pageInfo: {
-        hasNextPage: edges.length > pageSize,
+        hasNextPage,
       },
       edges: edges.slice(0, pageSize),
       ...(warnings.length > 0 ? { warnings } : {}),

--- a/src/database/composite-clickhouse.ts
+++ b/src/database/composite-clickhouse.ts
@@ -672,10 +672,12 @@ export class CompositeClickHouseDatabase implements GqlQueryable {
    * Set-based dedup with stable > unstable > sqlite precedence handles
    * the stabilization-overlap window where the same `id` briefly lives
    * in both `transactions` and `new_transactions` until TTL drops the
-   * unstable copy. JS-side sort + slice produces a deterministic page;
-   * `hasNextPage` is computed against the deduped edge list (not the
-   * raw concatenation) so cross-leg duplicates that collapse the page
-   * don't falsely advertise more results.
+   * unstable copy. JS-side sort + slice produces a deterministic page.
+   * `hasNextPage` is derived from each leg's raw result *before*
+   * cross-leg id-dedup: a leg returning more than `pageSize` rows has
+   * more matching data to give. Computing it against the deduped edge
+   * count instead would falsely signal completeness whenever duplicate
+   * ids collapse the merged page to `pageSize` or fewer (see PE-9124).
    *
    * See `clickhouse-pipeline.md` and PR #699 for the design rationale.
    */


### PR DESCRIPTION
## Problem

Windowed GraphQL `transactions` queries against the ClickHouse-backed indexer could return a partial page with `pageInfo.hasNextPage = false` and **no error**, silently stranding every subsequent page. A cursor client paging until `hasNextPage` is false (the standard Arweave GQL contract, including `ardrive-core-js`) under-reports results for dense wallets/ranges with no in-band signal that anything is wrong.

Confirmed against a canary indexer: a 100k-block windowed `HEIGHT_ASC` query for a dense wallet returned 98 edges / `hasNextPage:false`, while the full result set is thousands of entities. ClickHouse itself was healthy — `QueryFinish`, `read_rows` well under the cap, `result_rows = 101` (a correct full page).

## Root cause

The ClickHouse legs fetch `pageSize + 1` rows with a full-key `LIMIT 1 BY height, block_transaction_index, is_data_item, id`, but the composite then dedups by **`id` alone**. Stale rows that share an `id` and `height` while differing on `block_transaction_index` (a placeholder `bti=0` left by an earlier indexing pass alongside the real `bti`) are **not** folded by the SQL `LIMIT 1 BY`, yet collapse in the gateway's id-dedup. When that shrinks the merged set to `pageSize` or fewer, `edges.length > pageSize` reads false even though the leg came back full — and the `+1` sentinel is lost.

This is why the unbounded query *throws* (`TOO_MANY_ROWS` at the row-cap precheck) but the windowed query *silently truncates* — two independent code paths.

## Fix

Derive `hasNextPage` from each leg's **raw** result before the cross-leg id-dedup: a CH leg returning more than `pageSize` rows, or the SQLite leg's own `hasNextPage`, means more matching rows exist.

```js
const hasNextPage =
  edges.length > pageSize ||
  stableTxs.length > pageSize ||
  unstableTxs.length > pageSize ||
  sqliteHasNextPage;
```

Erring toward `true` is safe — the worst case is one extra page fetch that comes back empty. No SQL or cursor changes; low blast radius; robust to **any** dedup-shrinkage cause (placeholder `bti`, ReplacingMergeTree versions, cross-leg overlap), not just this one artifact.

## Testing

- Adds a regression test reproducing the production shape (same `id`, `bti` 0 vs 12, both data items) collapsing a full page to `pageSize` — fails before, passes after.
- Full `composite-clickhouse.test.ts` suite green (15/15); the existing `counts cross-leg duplicates only once` test still passes (its duplicate is across legs, so no single leg exceeds `pageSize`).
- `yarn lint:check` clean.

## Follow-ups (not in this PR)

- **Data hygiene (low priority):** ~1,470 stale `bti=0` placeholder data-item rows table-wide; patch the indexing path that writes `bti=0` on the optimistic pass. With this fix, cleanup only reduces occasional under-filled pages — it's no longer a correctness requirement.
- Pages can now return fewer than `pageSize` edges with `hasNextPage:true` (contract-legal). A SQL-level `LIMIT 1 BY id` could keep pages full but touches cursor semantics — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)