### PR TITLE
fix(chunks): reject and self-heal zero-length chunk cache poison

### DIFF
--- a/src/data/read-through-chunk-data-cache.test.ts
+++ b/src/data/read-through-chunk-data-cache.test.ts
@@ -115,5 +115,33 @@ describe('ReadThroughChunkDataCache', () => {
       assert.deepEqual(chunkDataStoreSetSpy.mock.callCount(), 1);
       assert.deepEqual(networkSpy.mock.callCount(), 1);
     });
+
+    it('should reject a zero-length chunk from the source without caching it', async () => {
+      const chunkDataStoreGetSpy = mock.method(
+        chunkDataStore,
+        'get',
+        async () => undefined,
+      );
+      const chunkDataStoreSetSpy = mock.method(chunkDataStore, 'set');
+      mock.method(chunkSource, 'getChunkDataByAny', async () => ({
+        hash: Buffer.alloc(0),
+        chunk: Buffer.alloc(0),
+      }));
+
+      await assert.rejects(
+        () =>
+          chunkCache.getChunkDataByAny({
+            txSize: TX_SIZE,
+            absoluteOffset: ABSOLUTE_OFFSET,
+            dataRoot: B64_DATA_ROOT,
+            relativeOffset: 0,
+          }),
+        { message: /zero-length chunk/ },
+      );
+
+      assert.deepEqual(chunkDataStoreGetSpy.mock.callCount(), 1);
+      // The invalid empty chunk must not be persisted.
+      assert.deepEqual(chunkDataStoreSetSpy.mock.callCount(), 0);
+    });
   });
 });

--- a/src/data/read-through-chunk-data-cache.ts
+++ b/src/data/read-through-chunk-data-cache.ts
@@ -7,6 +7,7 @@
 import winston from 'winston';
 import { tracer } from '../tracing.js';
 import { isValidationParams } from '../lib/validation.js';
+import * as metrics from '../metrics.js';
 
 import {
   ChunkData,
@@ -121,6 +122,19 @@ export class ReadThroughChunkDataCache implements ChunkDataByAnySource {
         signal,
       );
       const sourceDuration = Date.now() - sourceStart;
+
+      // Reject invalid empty chunks at the cache boundary: never cache them
+      // (which would poison this offset) and surface an error so the caller's
+      // retrieval cascade can fall through to another source instead of
+      // looping on a non-advancing chunk.
+      if (chunkData.chunk.length === 0) {
+        metrics.chunkZeroLengthTotal.inc({ stage: 'source_fetch' });
+        span.setAttribute('chunk.zero_length_source', true);
+        throw new Error(
+          `Chunk source returned a zero-length chunk for dataRoot ${dataRoot} ` +
+            `relativeOffset ${relativeOffset}`,
+        );
+      }
 
       span.setAttributes({
         'chunk.source_fetch_duration_ms': sourceDuration,

--- a/src/data/tx-chunks-data-source.test.ts
+++ b/src/data/tx-chunks-data-source.test.ts
@@ -190,6 +190,86 @@ describe('TxChunksDataSource', () => {
     });
   });
 
+  describe('forward-progress guards', () => {
+    it('should abort the stream when a zero-length chunk is returned', async () => {
+      mock.method(metrics.chunkStreamAbortsTotal, 'inc');
+      // A chunk that returns no bytes would never advance the byte counter,
+      // re-requesting the same offset forever. The guard must surface an
+      // error instead of spinning.
+      mock.method(chunkSource, 'getChunkDataByAny', async () => ({
+        hash: Buffer.alloc(0),
+        chunk: Buffer.alloc(0),
+      }));
+
+      const data = await txChunkRetriever.getData({
+        id: TX_ID,
+        requestAttributes,
+      });
+
+      await assert.rejects(
+        (async () => {
+          for await (const _chunk of data.stream) {
+            // consume
+          }
+        })(),
+        { message: /Zero-length chunk/ },
+      );
+
+      assert.equal(
+        (metrics.chunkStreamAbortsTotal.inc as any).mock.callCount(),
+        1,
+      );
+      assert.equal(
+        (metrics.chunkStreamAbortsTotal.inc as any).mock.calls[0].arguments[0]
+          .reason,
+        'zero_length_chunk',
+      );
+    });
+
+    it('should abort the stream when the chunk count exceeds the tx size bound', async () => {
+      mock.method(metrics.chunkStreamAbortsTotal, 'inc');
+      // size is 256000 bytes (maxChunks = ceil(256000 / 262144) + 1 = 2).
+      // Returning a single byte per chunk would otherwise require 256000
+      // fetches; the backstop must abort once the count bound is hit.
+      mock.method(chunkSource, 'getChunkDataByAny', async () => ({
+        hash: Buffer.alloc(0),
+        chunk: Buffer.from([1]),
+      }));
+
+      const data = await txChunkRetriever.getData({
+        id: TX_ID,
+        requestAttributes,
+      });
+
+      let received = 0;
+      await assert.rejects(
+        (async () => {
+          for await (const _chunk of data.stream) {
+            received++;
+          }
+        })(),
+        { message: /Chunk count exceeded maximum/ },
+      );
+
+      // The exact count the consumer observes is timing-dependent (destroy()
+      // discards any buffered-but-unconsumed chunk), but it must abort near the
+      // bound rather than running the full size/1-byte = 256000 iterations.
+      assert.ok(
+        received <= 2,
+        `should abort near the chunk bound, emitted ${received}`,
+      );
+      assert.equal(
+        (metrics.chunkStreamAbortsTotal.inc as any).mock.callCount(),
+        1,
+      );
+      assert.equal(
+        (metrics.chunkStreamAbortsTotal.inc as any).mock.calls[0].arguments[0]
+          .reason,
+        'chunk_count_exceeded',
+      );
+    });
+  });
+
   describe('range requests', () => {
     it('should stream a range within a single chunk', async () => {
       // Mock range-specific metrics

--- a/src/data/tx-chunks-data-source.ts
+++ b/src/data/tx-chunks-data-source.ts
@@ -8,6 +8,7 @@ import { Readable } from 'node:stream';
 import { anySignal, ClearableSignal } from 'any-signal';
 import pLimit, { LimitFunction } from 'p-limit';
 import winston from 'winston';
+import { MAX_CHUNK_SIZE } from '../config.js';
 import { generateRequestAttributes } from '../lib/request-attributes.js';
 import { streamRangeData } from '../lib/stream-tx-range.js';
 import { startChildSpan } from '../tracing.js';
@@ -349,6 +350,14 @@ export class TxChunksDataSource implements ContiguousDataSource {
 
       const streamStartTime = Date.now();
 
+      // Upper bound on the number of chunks a well-formed tx can produce: each
+      // chunk is at most MAX_CHUNK_SIZE bytes, so `size` bytes need at most
+      // ceil(size / MAX_CHUNK_SIZE) chunks. The +1 tolerates boundary
+      // rebalancing of the final chunks. This is a backstop against
+      // pathological geometry (e.g. a corrupt tx size/offset) driving an
+      // unbounded number of fetches.
+      const maxChunks = Math.ceil(size / MAX_CHUNK_SIZE) + 1;
+
       const stream = new Readable({
         autoDestroy: true,
         read: async function () {
@@ -362,6 +371,33 @@ export class TxChunksDataSource implements ContiguousDataSource {
             }
 
             const chunkData = await chunkDataPromise;
+
+            // Forward-progress guard: a zero-length chunk would not advance
+            // `bytes`, leaving `bytes < size` true forever and re-requesting
+            // the same offset indefinitely (observed as multi-million-span
+            // traces of repeated cache hits on a single offset). Abort rather
+            // than spin.
+            if (chunkData.chunk.length === 0) {
+              metrics.chunkStreamAbortsTotal.inc({
+                reason: 'zero_length_chunk',
+              });
+              throw new Error(
+                `Zero-length chunk for ${id} at relativeOffset ${bytes}; ` +
+                  `aborting to avoid a non-terminating chunk loop`,
+              );
+            }
+
+            // Backstop guard: never read more chunks than the tx size can hold.
+            if (totalChunks >= maxChunks) {
+              metrics.chunkStreamAbortsTotal.inc({
+                reason: 'chunk_count_exceeded',
+              });
+              throw new Error(
+                `Chunk count exceeded maximum ${maxChunks} for ${id} ` +
+                  `(size ${size}); aborting chunk loop`,
+              );
+            }
+
             this.push(chunkData.chunk);
             totalChunks++;
             bytes += chunkData.chunk.length;

--- a/src/data/tx-chunks-data-source.ts
+++ b/src/data/tx-chunks-data-source.ts
@@ -377,7 +377,7 @@ export class TxChunksDataSource implements ContiguousDataSource {
             // the same offset indefinitely (observed as multi-million-span
             // traces of repeated cache hits on a single offset). Abort rather
             // than spin.
-            if (chunkData.chunk.length === 0) {
+            if (size > 0 && chunkData.chunk.length === 0) {
               metrics.chunkStreamAbortsTotal.inc({
                 reason: 'zero_length_chunk',
               });

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -833,6 +833,14 @@ export const chunkFirstDataTimeoutsTotal = new promClient.Counter({
   labelNames: ['request_type'] as const,
 });
 
+export const chunkStreamAbortsTotal = new promClient.Counter({
+  name: 'chunk_stream_aborts_total',
+  help:
+    'Count of chunk data streams aborted by a forward-progress guard ' +
+    '(zero-length chunk or chunk-count overrun)',
+  labelNames: ['reason'] as const,
+});
+
 //
 // Negative data cache metrics
 //

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -833,6 +833,16 @@ export const chunkFirstDataTimeoutsTotal = new promClient.Counter({
   labelNames: ['request_type'] as const,
 });
 
+/**
+ * Counts chunk-streaming requests aborted by a `TxChunksDataSource`
+ * forward-progress guard, preventing a non-terminating chunk loop.
+ *
+ * @remarks Label `reason` is one of:
+ * - `zero_length_chunk` — a chunk returned no bytes, so the stream could not
+ *   advance and would otherwise re-request the same offset forever.
+ * - `chunk_count_exceeded` — more chunks were read than the tx size can hold
+ *   (`> ceil(size / MAX_CHUNK_SIZE) + 1`), a backstop against bad geometry.
+ */
 export const chunkStreamAbortsTotal = new promClient.Counter({
   name: 'chunk_stream_aborts_total',
   help:
@@ -841,6 +851,17 @@ export const chunkStreamAbortsTotal = new promClient.Counter({
   labelNames: ['reason'] as const,
 });
 
+/**
+ * Counts invalid zero-length chunks rejected before they can poison the chunk
+ * cache (a persisted empty chunk is served as a hit and stalls consumers).
+ *
+ * @remarks Label `stage` is one of:
+ * - `source_fetch` — a chunk source returned an empty chunk; rejected and not
+ *   cached so the retrieval cascade can fall through.
+ * - `cache_read` — an existing zero-length cache entry was read and treated as
+ *   a miss so it self-heals on the next refetch.
+ * - `cache_write` — a zero-length chunk write was refused, preventing poisoning.
+ */
 export const chunkZeroLengthTotal = new promClient.Counter({
   name: 'chunk_zero_length_total',
   help:

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -841,6 +841,14 @@ export const chunkStreamAbortsTotal = new promClient.Counter({
   labelNames: ['reason'] as const,
 });
 
+export const chunkZeroLengthTotal = new promClient.Counter({
+  name: 'chunk_zero_length_total',
+  help:
+    'Count of invalid zero-length chunks rejected, by pipeline stage ' +
+    '(source_fetch, cache_read, cache_write)',
+  labelNames: ['stage'] as const,
+});
+
 //
 // Negative data cache metrics
 //

--- a/src/store/fs-chunk-data-store.test.ts
+++ b/src/store/fs-chunk-data-store.test.ts
@@ -268,7 +268,7 @@ describe('FsChunkDataStore', () => {
       assert.deepEqual(retrieved.chunk, chunkData.chunk);
     });
 
-    it('should handle empty chunk data', async () => {
+    it('should refuse to cache zero-length chunk data', async () => {
       const dataRoot = 'tne4Fh9gC2AYX_ZUO5fV_ppKe0pwCwjOK4uTtg1OIjk';
       const relativeOffset = 0;
       const chunkData: ChunkData = {
@@ -276,11 +276,30 @@ describe('FsChunkDataStore', () => {
         hash: crypto.createHash('sha256').update(Buffer.alloc(0)).digest(),
       };
 
+      // A zero-length chunk is invalid and would poison the cache, so set()
+      // must drop it rather than persist it.
       await store.set(dataRoot, relativeOffset, chunkData);
-      const retrieved = await store.get(dataRoot, relativeOffset);
 
-      assert.ok(retrieved);
-      assert.strictEqual(retrieved.chunk.length, 0);
+      assert.strictEqual(await store.has(dataRoot, relativeOffset), false);
+      assert.strictEqual(await store.get(dataRoot, relativeOffset), undefined);
+    });
+
+    it('should treat a pre-existing zero-length chunk file as a miss', async () => {
+      // Simulates a cache entry poisoned before this guard existed: a 0-byte
+      // file on disk must self-heal by reading as a miss (so the caller
+      // refetches and overwrites it) rather than a valid empty chunk.
+      const dataRoot = 'Pois0nedZZZ2nHYgKhhI25MzveuYvH7rCd8J0WIVp4EVs';
+      const relativeOffset = 0;
+
+      const fs = await import('node:fs');
+      const dir = join(tempDir, 'data', 'by-dataroot', 'Po', 'is', dataRoot);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(join(dir, '0'), Buffer.alloc(0));
+
+      // has() still reports the file exists...
+      assert.strictEqual(await store.has(dataRoot, relativeOffset), true);
+      // ...but get() must not serve the empty chunk.
+      assert.strictEqual(await store.get(dataRoot, relativeOffset), undefined);
     });
   });
 

--- a/src/store/fs-chunk-data-store.test.ts
+++ b/src/store/fs-chunk-data-store.test.ts
@@ -301,6 +301,50 @@ describe('FsChunkDataStore', () => {
       // ...but get() must not serve the empty chunk.
       assert.strictEqual(await store.get(dataRoot, relativeOffset), undefined);
     });
+
+    it('should treat a pre-existing zero-length absolute-offset entry as a miss', async () => {
+      // A 0-byte file reachable via the by-absolute-offset index must also
+      // self-heal as a miss rather than returning an empty chunk.
+      const absoluteOffset = 51530681327863;
+      // by-absolute-offset/{floor(abs/1e12)}/{floor(abs/1e9)%1000}/{abs}
+      const fs = await import('node:fs');
+      const dir = join(tempDir, 'data', 'by-absolute-offset', '51', '530');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(join(dir, String(absoluteOffset)), Buffer.alloc(0));
+
+      assert.strictEqual(
+        await store.getByAbsoluteOffset(absoluteOffset),
+        undefined,
+      );
+    });
+
+    it('should not create an absolute-offset index for a zero-length chunk', async () => {
+      const dataRoot = 'zeroAbsIdxZZ2nHYgKhhI25MzveuYvH7rCd8J0WIVp4EVs';
+      const relativeOffset = 0;
+      const absoluteOffset = 51530681327863;
+      const chunkData: ChunkData = {
+        chunk: Buffer.alloc(0),
+        hash: crypto.createHash('sha256').update(Buffer.alloc(0)).digest(),
+      };
+
+      // set() refuses the zero-length write before any index is created.
+      await store.set(dataRoot, relativeOffset, chunkData, absoluteOffset);
+
+      const fs = await import('node:fs');
+      const indexPath = join(
+        tempDir,
+        'data',
+        'by-absolute-offset',
+        '51',
+        '530',
+        String(absoluteOffset),
+      );
+      assert.strictEqual(fs.existsSync(indexPath), false);
+      assert.strictEqual(
+        await store.getByAbsoluteOffset(absoluteOffset),
+        undefined,
+      );
+    });
   });
 
   describe('error handling', () => {

--- a/src/store/fs-chunk-data-store.ts
+++ b/src/store/fs-chunk-data-store.ts
@@ -10,6 +10,7 @@ import path from 'node:path';
 import winston from 'winston';
 
 import { ChunkData, ChunkDataStore } from '../types.js';
+import * as metrics from '../metrics.js';
 
 export class FsChunkDataStore implements ChunkDataStore {
   private log: winston.Logger;
@@ -62,6 +63,20 @@ export class FsChunkDataStore implements ChunkDataStore {
       if (await this.has(dataRoot, relativeOffset)) {
         const chunkPath = this.chunkDataRootPath(dataRoot, relativeOffset);
         const chunk = await fs.promises.readFile(chunkPath);
+
+        // Self-heal poisoned cache entries: a zero-length chunk file is never
+        // valid and, if served, would stall consumers that advance by chunk
+        // length (re-requesting the same offset forever). Treat it as a miss
+        // so the caller refetches and overwrites it.
+        if (chunk.length === 0) {
+          metrics.chunkZeroLengthTotal.inc({ stage: 'cache_read' });
+          this.log.warn('Ignoring zero-length cached chunk; treating as miss', {
+            dataRoot,
+            relativeOffset,
+          });
+          return undefined;
+        }
+
         const hash = crypto.createHash('sha256').update(chunk).digest();
 
         return {
@@ -87,6 +102,18 @@ export class FsChunkDataStore implements ChunkDataStore {
     try {
       const symlinkPath = this.absoluteOffsetIndexPath(absoluteOffset);
       const chunk = await fs.promises.readFile(symlinkPath); // Follows symlink
+
+      // Self-heal poisoned entries (see get()): treat a zero-length chunk as a
+      // miss so the caller refetches rather than serving invalid empty data.
+      if (chunk.length === 0) {
+        metrics.chunkZeroLengthTotal.inc({ stage: 'cache_read' });
+        this.log.warn(
+          'Ignoring zero-length cached chunk by absolute offset; treating as miss',
+          { absoluteOffset },
+        );
+        return undefined;
+      }
+
       const hash = crypto.createHash('sha256').update(chunk).digest();
 
       return {
@@ -127,6 +154,19 @@ export class FsChunkDataStore implements ChunkDataStore {
     chunkData: ChunkData,
     absoluteOffset?: number,
   ): Promise<void> {
+    // Never persist a zero-length chunk: it is invalid data and poisons the
+    // cache, since has() would report a hit and get() would return an empty
+    // buffer that stalls chunk-streaming consumers.
+    if (chunkData.chunk.length === 0) {
+      metrics.chunkZeroLengthTotal.inc({ stage: 'cache_write' });
+      this.log.warn('Refusing to cache zero-length chunk', {
+        dataRoot,
+        relativeOffset,
+        absoluteOffset,
+      });
+      return;
+    }
+
     try {
       const chunkDataRootDir = this.chunkDataRootDir(dataRoot);
       await fs.promises.mkdir(chunkDataRootDir, { recursive: true });


### PR DESCRIPTION
## Problem

A data request served from chunks produced a Honeycomb trace with **5.1M spans** — `RawDataHandler.handle` → `ReadThroughDataCache.getData` → a seemingly endless waterfall of `ReadThroughChunkDataCache.getChunkDataByAny`, all at the **same relative offset** and almost all sub-millisecond cache hits. The request ran until the 15s HTTP timeout.

The transaction was a **2805-byte, single-chunk L1 tx** — it should be served in one chunk and stop.

## Root cause

`TxChunksDataSource`'s full-stream read loop terminates only on byte accounting (`bytes < size`), advancing by `chunkData.chunk.length`. A **zero-length chunk** never advances `bytes`, so `bytes < size` stays true forever and the loop re-requests the **same offset** indefinitely.

The zero-length chunk came from a **poisoned cache entry**: `FsChunkDataStore` wrote chunk bytes with no length validation, so a source that returned an empty chunk once was persisted as a **0-byte file**. Thereafter `has()` reports a hit on that file and `get()` serves an empty buffer — re-poisoning every subsequent read of that offset. The first span in the trace confirmed the very first read was already a `source: cache` hit returning empty.

## Fix — defense in depth across every layer

- **`FsChunkDataStore.set`** — refuse to persist a zero-length chunk (also guards the `/chunk` ingest path).
- **`FsChunkDataStore.get` / `getByAbsoluteOffset`** — treat an existing 0-byte file as a **miss**, so already-poisoned entries **self-heal**: the caller refetches and overwrites the entry on next access.
- **`ReadThroughChunkDataCache`** — reject a zero-length chunk returned by the source (never cache it; throw so the retrieval cascade falls through to another source).
- **`TxChunksDataSource`** — forward-progress guards in the stream loop: abort on a non-advancing (zero-length) chunk, and abort on a chunk-count overrun (`> ceil(size / MAX_CHUNK_SIZE) + 1`) as a backstop against pathological tx geometry. Gated on `size > 0`.

## Observability

New metric `chunk_zero_length_total{stage}` counts rejected zero-length chunks by pipeline stage (`source_fetch` / `cache_read` / `cache_write`). `TxChunksDataSource` aborts increment `chunk_stream_aborts_total{reason}`.

## Notes

- Existing poisoned cache entries self-heal on next access; no manual eviction required.
- Updated a prior `FsChunkDataStore` test that asserted empty chunks round-trip — that was effectively the poison contract.
- **Not addressed here (follow-up):** the per-chunk span instrumentation emits one span (plus children) per chunk read with no per-request cap or sampling, which is what let a runaway loop produce a multi-million-span trace. The guards prevent the runaway, but large legitimate files still create large traces.

## Testing

- `src/store/fs-chunk-data-store.test.ts`, `src/data/read-through-chunk-data-cache.test.ts`, `src/data/tx-chunks-data-source.test.ts` — added coverage for set-rejection, read self-heal, source-rejection, the zero-length guard, and the count cap. All pass.
- `yarn lint:check` and `yarn build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)