### PR TITLE
perf(chunk-offset): resolve offset→block locally to avoid chain binary search

### DIFF
--- a/docs/arweave/transaction-and-chunk-offsets.md
+++ b/docs/arweave/transaction-and-chunk-offsets.md
@@ -338,6 +338,26 @@ for (const range of ranges) {
 1. **Direct Chunk Access**: Using absolute offsets allows O(1) chunk lookup
 2. **Minimal Data Transfer**: Only fetch chunks containing requested bytes
 3. **Streaming Support**: Process chunks as they arrive without buffering all
+4. **Local offset→block resolution**: When data is retrieved by absolute offset
+   (the cold-data chunk-by-offset path), the gateway must first find the block
+   containing the offset. Rather than walking the chain with ~log₂(height)
+   sequential `GET /block/height/{h}` requests, the Arweave client first
+   consults a local index over `stable_blocks.weave_size`
+   (`getBlockByWeaveOffset`, backed by `stable_blocks_weave_size_idx`): the
+   containing block is the lowest block whose cumulative `weave_size` reaches
+   the offset. The local result is only trusted when the immediately-preceding
+   block is also present and ends before the offset (a tight bracket, so no
+   missing block can hide the true container); otherwise — and for offsets in
+   the not-yet-stable chain tip — it falls back to the chain binary search.
+   This only changes how the block is *found*; the block returned is identical.
+
+   Note this resolves offset→**block** only. Resolving offset→**transaction**
+   within that block cannot be done from local block/transaction columns,
+   because per-transaction offsets follow the block's binary tx-ID sort order
+   (see [Transaction Order vs Offset Order](#transaction-order-vs-offset-order))
+   and a transaction's true weave contribution is not always captured by
+   `data_size` (e.g. v1 inline data). Per-transaction offsets are therefore
+   taken from the chain's authoritative `/tx/{id}/offset` endpoint.
 
 ### Edge Cases
 

--- a/migrations/2026.06.26T12.00.00.core.add-stable-blocks-weave-size-index.sql
+++ b/migrations/2026.06.26T12.00.00.core.add-stable-blocks-weave-size-index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS stable_blocks_weave_size_idx
+  ON stable_blocks (weave_size);

--- a/migrations/down/2026.06.26T12.00.00.core.add-stable-blocks-weave-size-index.sql
+++ b/migrations/down/2026.06.26T12.00.00.core.add-stable-blocks-weave-size-index.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS stable_blocks_weave_size_idx;

--- a/src/arweave/composite-client-binary-search.test.ts
+++ b/src/arweave/composite-client-binary-search.test.ts
@@ -449,6 +449,147 @@ describe('ArweaveCompositeClient Binary Search', () => {
     });
   });
 
+  describe('binarySearchBlocks local index fast path', () => {
+    const targetOffset = 1500;
+
+    it('resolves the containing block via the local index with a single block fetch and no chain walk', async () => {
+      client.cleanup();
+
+      const getBlockMock = mock.fn(async (height: number) => ({
+        height,
+        weave_size: '2500',
+        txs: ['tx'],
+      }));
+      client.getBlockByHeight = getBlockMock;
+      const getHeightMock = mock.fn(async () => 100);
+      client.getHeight = getHeightMock;
+
+      const indexMock = mock.fn(async () => ({
+        height: 50,
+        weaveSize: 2500,
+        prevWeaveSize: 1000,
+      }));
+      client.blockByOffsetIndex = { getBlockByWeaveOffset: indexMock };
+
+      const result = await client.binarySearchBlocks(targetOffset);
+
+      assert.strictEqual(result.height, 50);
+      // Index consulted once with the target offset.
+      assert.strictEqual(indexMock.mock.calls.length, 1);
+      assert.strictEqual(indexMock.mock.calls[0].arguments[0], targetOffset);
+      // Exactly one block fetched (the confirmed block) — no log2(height) walk.
+      assert.strictEqual(getBlockMock.mock.calls.length, 1);
+      assert.strictEqual(getBlockMock.mock.calls[0].arguments[0], 50);
+      // The chain binary search (which calls getHeight) is skipped entirely.
+      assert.strictEqual(getHeightMock.mock.calls.length, 0);
+    });
+
+    it('falls back to the chain binary search when the index misses', async () => {
+      client.cleanup();
+
+      const getBlockMock = mock.fn(async (height: number) => ({
+        height,
+        weave_size: height >= 50 ? '2500' : '1000',
+        txs: [],
+      }));
+      client.getBlockByHeight = getBlockMock;
+      const getHeightMock = mock.fn(async () => 100);
+      client.getHeight = getHeightMock;
+
+      // Index has no row for this offset.
+      client.blockByOffsetIndex = {
+        getBlockByWeaveOffset: mock.fn(async () => ({
+          height: undefined,
+          weaveSize: undefined,
+          prevWeaveSize: undefined,
+        })),
+      };
+
+      const result = await client.binarySearchBlocks(targetOffset);
+
+      assert.strictEqual(result.height, 50);
+      // Fell through to the chain walk: getHeight is consulted there.
+      assert.strictEqual(getHeightMock.mock.calls.length, 1);
+      assert.ok(getBlockMock.mock.calls.length > 1);
+    });
+
+    it('falls back when the offset is not tightly bracketed (possible missing block)', async () => {
+      client.cleanup();
+
+      const getBlockMock = mock.fn(async (height: number) => ({
+        height,
+        weave_size: height >= 50 ? '2500' : '1000',
+        txs: [],
+      }));
+      client.getBlockByHeight = getBlockMock;
+      const getHeightMock = mock.fn(async () => 100);
+      client.getHeight = getHeightMock;
+
+      // Predecessor block absent from the index -> cannot trust the bracket.
+      client.blockByOffsetIndex = {
+        getBlockByWeaveOffset: mock.fn(async () => ({
+          height: 50,
+          weaveSize: 2500,
+          prevWeaveSize: undefined,
+        })),
+      };
+
+      await client.binarySearchBlocks(targetOffset);
+      assert.strictEqual(getHeightMock.mock.calls.length, 1);
+    });
+
+    it('falls back when the index lookup throws, without surfacing the error', async () => {
+      client.cleanup();
+
+      const getBlockMock = mock.fn(async (height: number) => ({
+        height,
+        weave_size: height >= 50 ? '2500' : '1000',
+        txs: [],
+      }));
+      client.getBlockByHeight = getBlockMock;
+      const getHeightMock = mock.fn(async () => 100);
+      client.getHeight = getHeightMock;
+
+      client.blockByOffsetIndex = {
+        getBlockByWeaveOffset: mock.fn(async () => {
+          throw new Error('db unavailable');
+        }),
+      };
+
+      const result = await client.binarySearchBlocks(targetOffset);
+      assert.strictEqual(result.height, 50);
+      assert.strictEqual(getHeightMock.mock.calls.length, 1);
+    });
+
+    it('falls back when the fetched block no longer covers the offset (stale index)', async () => {
+      client.cleanup();
+
+      // Index points at height 50, but the freshly fetched block reports a
+      // smaller weave_size than the index claimed (e.g. a reorg). Must not
+      // trust it; fall through to the chain search.
+      const getBlockMock = mock.fn(async (height: number) => ({
+        height,
+        weave_size: height >= 60 ? '2500' : '1000',
+        txs: [],
+      }));
+      client.getBlockByHeight = getBlockMock;
+      const getHeightMock = mock.fn(async () => 100);
+      client.getHeight = getHeightMock;
+
+      client.blockByOffsetIndex = {
+        getBlockByWeaveOffset: mock.fn(async () => ({
+          height: 50,
+          weaveSize: 2500,
+          prevWeaveSize: 1000,
+        })),
+      };
+
+      const result = await client.binarySearchBlocks(targetOffset);
+      assert.strictEqual(getHeightMock.mock.calls.length, 1);
+      assert.strictEqual(result.height, 60);
+    });
+  });
+
   describe('caching behavior', () => {
     it('should cache transaction offsets', async () => {
       const targetOffset = 1800; // Changed to be within transaction range

--- a/src/arweave/composite-client-binary-search.test.ts
+++ b/src/arweave/composite-client-binary-search.test.ts
@@ -561,6 +561,35 @@ describe('ArweaveCompositeClient Binary Search', () => {
       assert.strictEqual(getHeightMock.mock.calls.length, 1);
     });
 
+    it('rethrows an AbortError from the index lookup instead of falling back', async () => {
+      client.cleanup();
+
+      const getBlockMock = mock.fn(async (height: number) => ({
+        height,
+        weave_size: height >= 50 ? '2500' : '1000',
+        txs: [],
+      }));
+      client.getBlockByHeight = getBlockMock;
+      const getHeightMock = mock.fn(async () => 100);
+      client.getHeight = getHeightMock;
+
+      client.blockByOffsetIndex = {
+        getBlockByWeaveOffset: mock.fn(async () => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          throw err;
+        }),
+      };
+
+      await assert.rejects(
+        async () => client.binarySearchBlocks(targetOffset),
+        /aborted/,
+      );
+      // A cancellation must not silently degrade into a slow chain walk.
+      assert.strictEqual(getHeightMock.mock.calls.length, 0);
+      assert.strictEqual(getBlockMock.mock.calls.length, 0);
+    });
+
     it('falls back when the fetched block no longer covers the offset (stale index)', async () => {
       client.cleanup();
 

--- a/src/arweave/composite-client.ts
+++ b/src/arweave/composite-client.ts
@@ -2238,6 +2238,7 @@ export class ArweaveCompositeClient
     const cacheKey = `block_for_offset_${targetOffset}`;
     const cached = this.blockCache.get(cacheKey);
     if (cached) {
+      metrics.blockOffsetResolutionCounter.inc({ outcome: 'cache_hit' });
       this.log.debug('Block search cache hit', {
         targetOffset,
         cachedBlockHeight: cached.height,
@@ -2273,6 +2274,9 @@ export class ArweaveCompositeClient
             block !== null &&
             parseInt(block.weave_size) >= targetOffset
           ) {
+            metrics.blockOffsetResolutionCounter.inc({
+              outcome: 'local_index_hit',
+            });
             this.blockCache.set(cacheKey, block);
             this.log.debug('Resolved block for offset via local index', {
               targetOffset,
@@ -2281,6 +2285,22 @@ export class ArweaveCompositeClient
             });
             return block;
           }
+          // Index bracketed the offset but the fetched header no longer covers
+          // it (e.g. a reorg under the stable boundary) — don't trust it.
+          metrics.blockOffsetResolutionCounter.inc({
+            outcome: 'fallback_stale',
+          });
+        } else if (local.height === undefined) {
+          // No stable block reaches the offset (e.g. the unstable chain tip).
+          metrics.blockOffsetResolutionCounter.inc({
+            outcome: 'fallback_miss',
+          });
+        } else {
+          // Candidate found but not tightly bracketed (predecessor missing or
+          // not below the offset) — a gap could hide the true container.
+          metrics.blockOffsetResolutionCounter.inc({
+            outcome: 'fallback_untight',
+          });
         }
         this.log.debug(
           'Local block-offset index did not confidently resolve; ' +
@@ -2291,12 +2311,17 @@ export class ArweaveCompositeClient
         if (error?.name === 'AbortError') {
           throw error;
         }
+        metrics.blockOffsetResolutionCounter.inc({ outcome: 'fallback_error' });
         this.log.debug(
           'Local block-offset index lookup failed; ' +
             'falling back to chain binary search',
           { targetOffset, error: error?.message },
         );
       }
+    } else {
+      metrics.blockOffsetResolutionCounter.inc({
+        outcome: 'fallback_no_index',
+      });
     }
 
     try {

--- a/src/arweave/composite-client.ts
+++ b/src/arweave/composite-client.ts
@@ -63,6 +63,22 @@ import {
 import { MAX_FORK_DEPTH } from './constants.js';
 import { BlockOffsetMapping } from './block-offset-mapping.js';
 
+/**
+ * Local index that resolves an absolute weave offset to its containing block
+ * without per-block upstream fetches. Implemented by the SQLite database over
+ * the indexed `stable_blocks.weave_size` column and injected post-construction
+ * (see {@link ArweaveCompositeClient.blockByOffsetIndex} and system.ts). When
+ * absent or unable to confidently bracket the offset, the client falls back to
+ * the chain binary search, so behavior is unchanged — only the lookup path.
+ */
+export interface BlockByOffsetIndex {
+  getBlockByWeaveOffset(offset: number): Promise<{
+    height: number | undefined;
+    weaveSize: number | undefined;
+    prevWeaveSize: number | undefined;
+  }>;
+}
+
 const DEFAULT_REQUEST_TIMEOUT_MS = 15000;
 const DEFAULT_REQUEST_RETRY_COUNT = 5;
 const DEFAULT_MAX_REQUESTS_PER_SECOND = 5;
@@ -184,6 +200,12 @@ export class ArweaveCompositeClient
 
   // Static offset-to-block mapping for optimizing binary search
   private blockOffsetMapping?: BlockOffsetMapping;
+
+  // Optional local index resolving an absolute weave offset to its containing
+  // block, avoiding ~log2(height) sequential upstream block fetches. Set
+  // post-construction in system.ts once the database is available, because the
+  // database is constructed after this client. See binarySearchBlocks.
+  public blockByOffsetIndex?: BlockByOffsetIndex;
 
   // Chunk GET retry settings
   private chunkGetRetryCount: number;
@@ -2222,6 +2244,59 @@ export class ArweaveCompositeClient
         cachedBlockOffset: cached.weave_size,
       });
       return cached;
+    }
+
+    // Fast path: resolve the containing block from the local stable-block index,
+    // collapsing the ~log2(height) sequential upstream block fetches of the
+    // chain binary search below into a single indexed lookup plus one block
+    // fetch. Only trusted when the index tightly brackets the offset (the
+    // immediately-preceding block is present and ends before the offset), which
+    // rules out a missing block hiding the true container; the fetched block's
+    // weave_size is re-checked before returning. Any miss, gap, abort-free
+    // error, or offset in the unstable tip falls through to the chain binary
+    // search. This never changes which block is returned, only how it's found.
+    if (this.blockByOffsetIndex !== undefined) {
+      try {
+        const local =
+          await this.blockByOffsetIndex.getBlockByWeaveOffset(targetOffset);
+        if (
+          local.height !== undefined &&
+          local.weaveSize !== undefined &&
+          local.weaveSize >= targetOffset &&
+          local.prevWeaveSize !== undefined &&
+          local.prevWeaveSize < targetOffset
+        ) {
+          signal?.throwIfAborted();
+          const block = await this.getBlockByHeight(local.height);
+          if (
+            block !== undefined &&
+            block !== null &&
+            parseInt(block.weave_size) >= targetOffset
+          ) {
+            this.blockCache.set(cacheKey, block);
+            this.log.debug('Resolved block for offset via local index', {
+              targetOffset,
+              height: local.height,
+              blockOffset: block.weave_size,
+            });
+            return block;
+          }
+        }
+        this.log.debug(
+          'Local block-offset index did not confidently resolve; ' +
+            'falling back to chain binary search',
+          { targetOffset, local },
+        );
+      } catch (error: any) {
+        if (error?.name === 'AbortError') {
+          throw error;
+        }
+        this.log.debug(
+          'Local block-offset index lookup failed; ' +
+            'falling back to chain binary search',
+          { targetOffset, error: error?.message },
+        );
+      }
     }
 
     try {

--- a/src/database/sql/core/offsets.sql
+++ b/src/database/sql/core/offsets.sql
@@ -20,5 +20,5 @@ SELECT b.height AS height,
 FROM stable_blocks b
 LEFT JOIN stable_blocks p ON p.height = b.height - 1
 WHERE b.weave_size >= @offset
-ORDER BY b.weave_size ASC
+ORDER BY b.weave_size ASC, b.height ASC
 LIMIT 1;

--- a/src/database/sql/core/offsets.sql
+++ b/src/database/sql/core/offsets.sql
@@ -7,3 +7,18 @@ WHERE offset >= @offset
   AND data_size > 0
 ORDER BY offset ASC
 LIMIT 1;
+
+-- selectBlockHeightByWeaveOffset
+-- Resolve an absolute weave offset to its containing stable block: the lowest
+-- block whose cumulative weave_size reaches the offset. prev_weave_size is the
+-- preceding block's cumulative weave_size, used by the caller to confirm the
+-- offset is tightly bracketed (no missing block between) before trusting the
+-- local result. Backed by stable_blocks_weave_size_idx.
+SELECT b.height AS height,
+  b.weave_size AS weave_size,
+  p.weave_size AS prev_weave_size
+FROM stable_blocks b
+LEFT JOIN stable_blocks p ON p.height = b.height - 1
+WHERE b.weave_size >= @offset
+ORDER BY b.weave_size ASC
+LIMIT 1;

--- a/src/database/standalone-sqlite.test.ts
+++ b/src/database/standalone-sqlite.test.ts
@@ -344,6 +344,61 @@ describe('StandaloneSqliteDatabase', () => {
       const txByOffsetResult10 = await db.getTxByOffset(201);
       assert.equal(txByOffsetResult10.id, undefined);
     });
+
+    it('resolves an absolute weave offset to its containing stable block via getBlockByWeaveOffset', async () => {
+      const insertBlock = (height: number, weaveSize: number) =>
+        coreDb
+          .prepare(
+            `INSERT INTO stable_blocks (
+               height, nonce, hash, block_timestamp, diff, last_retarget,
+               reward_pool, block_size, weave_size, tx_count, missing_tx_count
+             ) VALUES (
+               @height, @nonce, @hash, 0, '0', '0',
+               '0', 1, @weave_size, 0, 0
+             )`,
+          )
+          .run({
+            height,
+            nonce: Buffer.alloc(1),
+            hash: Buffer.alloc(1),
+            weave_size: weaveSize,
+          });
+
+      // Contiguous run: weave_size is cumulative-to-end-of-block.
+      insertBlock(10, 100);
+      insertBlock(11, 200);
+      insertBlock(12, 200); // empty block: same cumulative weave_size as 11
+      insertBlock(13, 350);
+
+      // Offset inside block 11 (100 < 150 <= 200): tightly bracketed by block 10.
+      const mid = await db.getBlockByWeaveOffset(150);
+      assert.equal(mid.height, 11);
+      assert.equal(mid.weaveSize, 200);
+      assert.equal(mid.prevWeaveSize, 100);
+
+      // Offset exactly at block 11's end boundary resolves to block 11.
+      const boundary = await db.getBlockByWeaveOffset(200);
+      assert.equal(boundary.height, 11);
+
+      // Just past block 11 lands in block 13 (block 12 added no bytes).
+      const next = await db.getBlockByWeaveOffset(201);
+      assert.equal(next.height, 13);
+      assert.equal(next.prevWeaveSize, 200);
+
+      // Gap guard: predecessor missing -> prevWeaveSize is undefined so the
+      // caller will not trust the local result and falls back to the chain.
+      insertBlock(20, 1000);
+      insertBlock(22, 1200); // height 21 intentionally absent
+      const gapped = await db.getBlockByWeaveOffset(1100);
+      assert.equal(gapped.height, 22);
+      assert.equal(gapped.prevWeaveSize, undefined);
+
+      // Offset beyond the highest indexed block returns no row.
+      const beyond = await db.getBlockByWeaveOffset(99999);
+      assert.equal(beyond.height, undefined);
+      assert.equal(beyond.weaveSize, undefined);
+      assert.equal(beyond.prevWeaveSize, undefined);
+    });
   });
 
   describe('getTransactionAttributes', () => {

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -89,6 +89,12 @@ interface TxByOffsetResult {
   data_size: number | undefined;
 }
 
+interface BlockByWeaveOffsetResult {
+  height: number | undefined;
+  weaveSize: number | undefined;
+  prevWeaveSize: number | undefined;
+}
+
 export function encodeTransactionGqlCursor({
   height,
   blockTransactionIndex,
@@ -1108,6 +1114,24 @@ export class StandaloneSqliteDatabaseWorker {
       id: result.id ? toB64Url(result.id) : undefined,
       offset: result.offset,
       data_size: result.data_size,
+    };
+  }
+
+  getBlockByWeaveOffset(offset: number): BlockByWeaveOffsetResult {
+    const result = this.stmts.core.selectBlockHeightByWeaveOffset.get({
+      offset,
+    });
+    if (result === undefined) {
+      return {
+        height: undefined,
+        weaveSize: undefined,
+        prevWeaveSize: undefined,
+      };
+    }
+    return {
+      height: result.height ?? undefined,
+      weaveSize: result.weave_size ?? undefined,
+      prevWeaveSize: result.prev_weave_size ?? undefined,
     };
   }
 
@@ -3506,6 +3530,10 @@ export class StandaloneSqliteDatabase
     return this.queueRead('core', 'getTxByOffset', [offset]);
   }
 
+  getBlockByWeaveOffset(offset: number): Promise<BlockByWeaveOffsetResult> {
+    return this.queueRead('core', 'getBlockByWeaveOffset', [offset]);
+  }
+
   saveTxOffset(id: string, offset: number) {
     return this.queueWrite('core', 'saveTxOffset', [id, offset]);
   }
@@ -4095,6 +4123,10 @@ if (!isMainThread) {
         case 'getTxByOffset':
           const tx = worker.getTxByOffset(args[0]);
           parentPort?.postMessage(tx);
+          break;
+        case 'getBlockByWeaveOffset':
+          const blockByWeaveOffset = worker.getBlockByWeaveOffset(args[0]);
+          parentPort?.postMessage(blockByWeaveOffset);
           break;
         case 'saveTxOffset':
           worker.saveTxOffset(args[0], args[1]);

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -89,6 +89,22 @@ interface TxByOffsetResult {
   data_size: number | undefined;
 }
 
+/**
+ * Result of resolving an absolute weave offset to its containing stable block.
+ *
+ * `height`/`weaveSize` describe the lowest stable block whose cumulative
+ * `weave_size` reaches the requested offset (the candidate container).
+ * `prevWeaveSize` is the immediately-preceding block's cumulative `weave_size`,
+ * present only when that predecessor is itself indexed. Callers use it to
+ * confirm the offset is tightly bracketed (`prevWeaveSize < offset <=
+ * weaveSize`) — i.e. no missing block sits between the predecessor and the
+ * candidate — before trusting the local result.
+ *
+ * All fields are `undefined` when no stable block reaches the offset (e.g. the
+ * offset lies in the not-yet-stable chain tip); `prevWeaveSize` alone is
+ * `undefined` when the predecessor is absent (a gap or the genesis block), in
+ * which case the caller must not trust the bracket and should fall back.
+ */
 interface BlockByWeaveOffsetResult {
   height: number | undefined;
   weaveSize: number | undefined;
@@ -1117,6 +1133,14 @@ export class StandaloneSqliteDatabaseWorker {
     };
   }
 
+  /**
+   * Resolve an absolute weave `offset` to its containing stable block via the
+   * indexed `stable_blocks.weave_size` column, avoiding the chain binary
+   * search's sequential per-block fetches. Returns the candidate block plus its
+   * predecessor's weave size for bracket validation; see
+   * {@link BlockByWeaveOffsetResult} for the `undefined` semantics. Resolves
+   * offset→block only — not offset→transaction.
+   */
   getBlockByWeaveOffset(offset: number): BlockByWeaveOffsetResult {
     const result = this.stmts.core.selectBlockHeightByWeaveOffset.get({
       offset,
@@ -3530,6 +3554,12 @@ export class StandaloneSqliteDatabase
     return this.queueRead('core', 'getTxByOffset', [offset]);
   }
 
+  /**
+   * Queue-wrapper for the worker's {@link StandaloneSqliteDatabaseWorker.getBlockByWeaveOffset}:
+   * resolve an absolute weave `offset` to its containing stable block (with the
+   * predecessor's weave size for bracket validation). See
+   * {@link BlockByWeaveOffsetResult} for the `undefined` fallback contract.
+   */
   getBlockByWeaveOffset(offset: number): Promise<BlockByWeaveOffsetResult> {
     return this.queueRead('core', 'getBlockByWeaveOffset', [offset]);
   }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -86,6 +86,25 @@ export const chunkServeDeadlineExceededCounter = new promClient.Counter({
   labelNames: ['method'],
 });
 
+// Outcome of resolving an absolute weave offset to its containing block in
+// ArweaveCompositeClient.binarySearchBlocks. `local_index_hit` means the local
+// stable_blocks index resolved and verified the block with no chain walk; every
+// other `outcome` value falls through to the chain binary search. During soak,
+// hit_rate = local_index_hit / (sum of all outcomes except cache_hit); the
+// fallback_* labels explain why the fast path was not taken.
+//   - cache_hit: returned from the in-memory block cache before either path
+//   - local_index_hit: local index bracketed + fetched block re-verified
+//   - fallback_miss: no stable block reaches the offset (e.g. unstable tip)
+//   - fallback_untight: candidate found but predecessor missing/not below offset
+//   - fallback_stale: fetched block no longer covers the offset (e.g. reorg)
+//   - fallback_error: index lookup failed (non-abort)
+//   - fallback_no_index: no local index wired (should not occur in production)
+export const blockOffsetResolutionCounter = new promClient.Counter({
+  name: 'block_offset_resolution_total',
+  help: 'Count of offset->block resolutions by outcome of the local stable_blocks fast path',
+  labelNames: ['outcome'],
+});
+
 //
 // GraphQL root TX lookup batching metrics
 //

--- a/src/system.ts
+++ b/src/system.ts
@@ -288,6 +288,12 @@ export const db = new StandaloneSqliteDatabase({
   tagSelectivity: config.TAG_SELECTIVITY,
 });
 
+// Let the Arweave client resolve chunk offset->block lookups against the local
+// stable-block index instead of sequential upstream block fetches. Wired here
+// (not via the constructor) because the database is constructed after the
+// client. See ArweaveCompositeClient.binarySearchBlocks.
+arweaveClient.blockByOffsetIndex = db;
+
 export const dataAttributesStore: ContiguousDataAttributesStore =
   new CompositeDataAttributesSource({
     log,

--- a/test/core-schema.sql
+++ b/test/core-schema.sql
@@ -202,3 +202,4 @@ CREATE TABLE IF NOT EXISTS "new_transactions" (
 CREATE INDEX new_transactions_target_id_idx ON new_transactions (target, id);
 CREATE INDEX new_transactions_owner_address_id_idx ON new_transactions (owner_address, id);
 CREATE INDEX new_transactions_height_indexed_at_idx ON new_transactions (height, indexed_at);
+CREATE INDEX stable_blocks_weave_size_idx ON stable_blocks (weave_size);


### PR DESCRIPTION
## Problem

Cold data (not in cache / turbo-s3 / trusted-gateways) retrieved by absolute
offset falls to chunk-by-offset retrieval, which must first find the block
containing the offset. `ArweaveCompositeClient.binarySearchBlocks` did this by
walking the chain with ~log₂(height) **sequential** `GET /block/height/{h}`
requests to `TRUSTED_NODE_URL` (~1.5s each ≈ ~27s worst case), routinely
exceeding `CHUNK_SERVE_DEADLINE_MS` (12s) and surfacing as 504s.

## Fix

Add a local index over `stable_blocks.weave_size` and consult it before the
chain walk:

- **Migration** `stable_blocks_weave_size_idx` (+ down).
- **DB method** `getBlockByWeaveOffset` → SQL `selectBlockHeightByWeaveOffset`:
  the containing block is the lowest block whose cumulative `weave_size` reaches
  the offset; a `LEFT JOIN` returns the predecessor's `weave_size` for bracket
  validation.
- **Wiring**: optional `BlockByOffsetIndex` injected into the Arweave client
  post-construction in `system.ts` (the DB is built after the client).
- **`binarySearchBlocks` fast path**: trust the local block **only** when the
  immediately-preceding block is present and ends before the offset (tight
  bracket — no missing block can hide the true container), and re-verify the
  fetched block's `weave_size`. Any gap, stale index, lookup error, or
  unstable-tip offset falls back to the existing chain binary search.

This collapses ~18 sequential upstream block fetches into one indexed local
lookup + one block fetch. **It changes only how the block is found — the block
returned is identical**, so downstream Phase-2 (offset→tx) behavior is unchanged.

## Why offset→block only (and not offset→tx)

Per-transaction offsets are **not** derivable from local columns and remain
chain-authoritative via `/tx/{id}/offset`:

- Per-tx weave offsets follow the block's **binary tx-ID sort order**, not
  `block_transaction_index` (see `docs/arweave/transaction-and-chunk-offsets.md`).
- A transaction's true weave contribution isn't always captured by `data_size`
  (e.g. v1 inline data). Empirically, block 1,100,000 has `missing_tx_count = 0`
  yet ~47 MB of its `block_size` is unaccounted by summed `data_size`.

Computing per-tx offsets locally would silently serve wrong bytes — which is the
intent behind the original per-tx `/tx/{id}/offset` design (PE-2482).

## Tests

- `composite-client-binary-search.test.ts`: 5 new cases — confident local hit
  fetches exactly one block and calls `getHeight` **0×** (no chain walk); plus
  fallback on index miss, untight bracket, lookup error, and stale index.
- `standalone-sqlite.test.ts`: `getBlockByWeaveOffset` — bracket hit, empty-block
  boundary, gap guard (missing predecessor → `prevWeaveSize` undefined), and
  offset-beyond-weave.
- Lint clean, no new `tsc` errors, migration up/down validated on a throwaway DB
  (`EXPLAIN QUERY PLAN` confirms `COVERING INDEX stable_blocks_weave_size_idx`).

## Notes

- Offset→block resolution is only one contributor to chunk-serve timeouts; slow
  peer chunk **data** fetches are a separate source of deadline exceeds and are
  not addressed here.
- Complementary no-rebuild mitigation: point `TRUSTED_NODE_URL` at a fast/local
  node (currently default `arweave.net`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERJ5pSmgZoLj4jEHhweq5B
