### PR TITLE
perf(chunk-offset): resolve tip offsets locally by querying new_blocks too

### DIFF
--- a/docs/arweave/transaction-and-chunk-offsets.md
+++ b/docs/arweave/transaction-and-chunk-offsets.md
@@ -342,14 +342,26 @@ for (const range of ranges) {
    (the cold-data chunk-by-offset path), the gateway must first find the block
    containing the offset. Rather than walking the chain with ~log₂(height)
    sequential `GET /block/height/{h}` requests, the Arweave client first
-   consults a local index over `stable_blocks.weave_size`
-   (`getBlockByWeaveOffset`, backed by `stable_blocks_weave_size_idx`): the
-   containing block is the lowest block whose cumulative `weave_size` reaches
-   the offset. The local result is only trusted when the immediately-preceding
-   block is also present and ends before the offset (a tight bracket, so no
-   missing block can hide the true container); otherwise — and for offsets in
-   the not-yet-stable chain tip — it falls back to the chain binary search.
-   This only changes how the block is *found*; the block returned is identical.
+   consults a local index over the `weave_size` columns of both `stable_blocks`
+   and the not-yet-stable tip table `new_blocks` (`getBlockByWeaveOffset`, backed
+   by `stable_blocks_weave_size_idx` / `new_blocks_weave_size_idx`): the
+   containing block is the lowest block — in either table — whose cumulative
+   `weave_size` reaches the offset. Spanning both tables means offsets in the
+   recent tip (mined but not yet stable), which are exactly the cold-data
+   requests that used to time out on the chain walk, also resolve locally.
+
+   The local result is only trusted when the immediately-preceding block is also
+   present and ends before the offset (a tight bracket, so no missing block can
+   hide the true container) **and** the candidate block, re-fetched by height, is
+   re-confirmed to still cover the offset. `new_blocks` can transiently hold
+   non-canonical fork blocks (its `weave_size` is not guaranteed unique or
+   monotonic), so this re-validation is the safety net: a stale or forked local
+   hit degrades to a fall-back to the chain binary search, never to a wrong
+   block. The predecessor's `weave_size` is taken as the MAX across any rows at
+   the preceding height, so a fork that overshoots the offset conservatively
+   breaks the bracket and forces the fall-back. Any miss, gap, or error also
+   falls back. This only changes how the block is *found*; the block returned is
+   identical.
 
    Note this resolves offset→**block** only. Resolving offset→**transaction**
    within that block cannot be done from local block/transaction columns,

--- a/migrations/2026.06.29T12.00.00.core.add-new-blocks-weave-size-index.sql
+++ b/migrations/2026.06.29T12.00.00.core.add-new-blocks-weave-size-index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS new_blocks_weave_size_idx ON new_blocks (weave_size);

--- a/migrations/down/2026.06.29T12.00.00.core.add-new-blocks-weave-size-index.sql
+++ b/migrations/down/2026.06.29T12.00.00.core.add-new-blocks-weave-size-index.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS new_blocks_weave_size_idx;

--- a/src/arweave/composite-client-binary-search.test.ts
+++ b/src/arweave/composite-client-binary-search.test.ts
@@ -10,6 +10,16 @@ import * as assert from 'node:assert';
 import { ArweaveCompositeClient } from './composite-client.js';
 import { Arweave } from 'arweave';
 import * as winston from 'winston';
+import * as metrics from '../metrics.js';
+
+// Read the current value of block_offset_resolution_total for a given outcome.
+// The counter is process-global and accumulates across tests, so assertions
+// compare a before/after delta rather than an absolute value.
+const outcomeCount = async (outcome: string): Promise<number> => {
+  const metric = await metrics.blockOffsetResolutionCounter.get();
+  const entry = metric.values.find((v: any) => v.labels.outcome === outcome);
+  return entry?.value ?? 0;
+};
 
 describe('ArweaveCompositeClient Binary Search', () => {
   let client: ArweaveCompositeClient;
@@ -616,6 +626,79 @@ describe('ArweaveCompositeClient Binary Search', () => {
       const result = await client.binarySearchBlocks(targetOffset);
       assert.strictEqual(getHeightMock.mock.calls.length, 1);
       assert.strictEqual(result.height, 60);
+    });
+
+    it('resolves an unstable-tip block via the local index with a single fetch and records the unstable outcome', async () => {
+      client.cleanup();
+
+      const before = await outcomeCount('local_index_hit_unstable');
+
+      const getBlockMock = mock.fn(async (height: number) => ({
+        height,
+        weave_size: '2500',
+        txs: ['tx'],
+      }));
+      client.getBlockByHeight = getBlockMock;
+      const getHeightMock = mock.fn(async () => 100);
+      client.getHeight = getHeightMock;
+
+      // Candidate resolved from new_blocks (the not-yet-stable tip).
+      const indexMock = mock.fn(async () => ({
+        height: 50,
+        weaveSize: 2500,
+        prevWeaveSize: 1000,
+        zone: 'unstable' as const,
+      }));
+      client.blockByOffsetIndex = { getBlockByWeaveOffset: indexMock };
+
+      const result = await client.binarySearchBlocks(targetOffset);
+
+      assert.strictEqual(result.height, 50);
+      // Exactly one block fetched — the single re-validation getBlockByHeight,
+      // not the ~log2(height) chain walk.
+      assert.strictEqual(getBlockMock.mock.calls.length, 1);
+      assert.strictEqual(getBlockMock.mock.calls[0].arguments[0], 50);
+      // The chain binary search (which calls getHeight) is skipped entirely.
+      assert.strictEqual(getHeightMock.mock.calls.length, 0);
+      // The tip resolution is attributed to the distinct unstable outcome.
+      const after = await outcomeCount('local_index_hit_unstable');
+      assert.strictEqual(after - before, 1);
+    });
+
+    it('falls back to the chain search when an unstable candidate no longer covers the offset (forked tip)', async () => {
+      client.cleanup();
+
+      const before = await outcomeCount('fallback_stale');
+
+      // The index bracketed the offset from new_blocks, but the re-fetched
+      // canonical block at that height reports a smaller weave_size (the tip
+      // block was a fork that lost weave under the canonical chain). Must not
+      // trust it — fall back to the chain search and return the correct block,
+      // never wrong bytes.
+      const getBlockMock = mock.fn(async (height: number) => ({
+        height,
+        weave_size: height >= 60 ? '2500' : '1000',
+        txs: [],
+      }));
+      client.getBlockByHeight = getBlockMock;
+      const getHeightMock = mock.fn(async () => 100);
+      client.getHeight = getHeightMock;
+
+      client.blockByOffsetIndex = {
+        getBlockByWeaveOffset: mock.fn(async () => ({
+          height: 50,
+          weaveSize: 2500,
+          prevWeaveSize: 1000,
+          zone: 'unstable' as const,
+        })),
+      };
+
+      const result = await client.binarySearchBlocks(targetOffset);
+      // Re-validation fetched height 50 (weave 1000 < 1500) -> stale -> fall back.
+      assert.strictEqual(getHeightMock.mock.calls.length, 1);
+      assert.strictEqual(result.height, 60);
+      const after = await outcomeCount('fallback_stale');
+      assert.strictEqual(after - before, 1);
     });
   });
 

--- a/src/arweave/composite-client.ts
+++ b/src/arweave/composite-client.ts
@@ -66,16 +66,23 @@ import { BlockOffsetMapping } from './block-offset-mapping.js';
 /**
  * Local index that resolves an absolute weave offset to its containing block
  * without per-block upstream fetches. Implemented by the SQLite database over
- * the indexed `stable_blocks.weave_size` column and injected post-construction
- * (see {@link ArweaveCompositeClient.blockByOffsetIndex} and system.ts). When
- * absent or unable to confidently bracket the offset, the client falls back to
- * the chain binary search, so behavior is unchanged — only the lookup path.
+ * the indexed `weave_size` columns of `stable_blocks` and `new_blocks` and
+ * injected post-construction (see {@link ArweaveCompositeClient.blockByOffsetIndex}
+ * and system.ts). Querying both tables means offsets in the not-yet-stable tip
+ * resolve locally too, not just stable offsets. When absent or unable to
+ * confidently bracket the offset, the client falls back to the chain binary
+ * search, so behavior is unchanged — only the lookup path.
+ *
+ * `zone` reports whether the candidate came from the stable chain or the
+ * unstable tip; it is optional so callers/mocks that predate the tip extension
+ * still satisfy the interface (treated as stable when absent).
  */
 export interface BlockByOffsetIndex {
   getBlockByWeaveOffset(offset: number): Promise<{
     height: number | undefined;
     weaveSize: number | undefined;
     prevWeaveSize: number | undefined;
+    zone?: 'stable' | 'unstable';
   }>;
 }
 
@@ -2247,15 +2254,19 @@ export class ArweaveCompositeClient
       return cached;
     }
 
-    // Fast path: resolve the containing block from the local stable-block index,
+    // Fast path: resolve the containing block from the local block-offset index,
     // collapsing the ~log2(height) sequential upstream block fetches of the
     // chain binary search below into a single indexed lookup plus one block
-    // fetch. Only trusted when the index tightly brackets the offset (the
-    // immediately-preceding block is present and ends before the offset), which
-    // rules out a missing block hiding the true container; the fetched block's
-    // weave_size is re-checked before returning. Any miss, gap, abort-free
-    // error, or offset in the unstable tip falls through to the chain binary
-    // search. This never changes which block is returned, only how it's found.
+    // fetch. The index spans both the stable chain and the not-yet-stable tip
+    // (stable_blocks ∪ new_blocks), so offsets in the unstable tip resolve here
+    // too instead of falling through. Only trusted when the index tightly
+    // brackets the offset (the immediately-preceding block is present and ends
+    // before the offset), which rules out a missing block hiding the true
+    // container; the fetched block's weave_size is re-checked before returning.
+    // The re-fetch by height returns the canonical block, so a stale or forked
+    // tip hit degrades to a fallback, never to a wrong block. Any miss, gap, or
+    // abort-free error falls through to the chain binary search. This never
+    // changes which block is returned, only how it's found.
     if (this.blockByOffsetIndex !== undefined) {
       try {
         const local =
@@ -2274,24 +2285,34 @@ export class ArweaveCompositeClient
             block !== null &&
             parseInt(block.weave_size) >= targetOffset
           ) {
+            // Distinguish tip hits so the win over the chain search is
+            // observable: the unstable tip is where the old slow path used to
+            // 504, so this outcome should absorb the former fallback_miss
+            // volume.
             metrics.blockOffsetResolutionCounter.inc({
-              outcome: 'local_index_hit',
+              outcome:
+                local.zone === 'unstable'
+                  ? 'local_index_hit_unstable'
+                  : 'local_index_hit',
             });
             this.blockCache.set(cacheKey, block);
             this.log.debug('Resolved block for offset via local index', {
               targetOffset,
               height: local.height,
               blockOffset: block.weave_size,
+              zone: local.zone,
             });
             return block;
           }
           // Index bracketed the offset but the fetched header no longer covers
-          // it (e.g. a reorg under the stable boundary) — don't trust it.
+          // it (e.g. a reorg, or a forked tip block that lost weave under the
+          // canonical chain) — don't trust it.
           metrics.blockOffsetResolutionCounter.inc({
             outcome: 'fallback_stale',
           });
         } else if (local.height === undefined) {
-          // No stable block reaches the offset (e.g. the unstable chain tip).
+          // No block reaches the offset at all (the offset is beyond the
+          // current chain tip).
           metrics.blockOffsetResolutionCounter.inc({
             outcome: 'fallback_miss',
           });

--- a/src/database/sql/core/offsets.sql
+++ b/src/database/sql/core/offsets.sql
@@ -9,16 +9,57 @@ ORDER BY offset ASC
 LIMIT 1;
 
 -- selectBlockHeightByWeaveOffset
--- Resolve an absolute weave offset to its containing stable block: the lowest
--- block whose cumulative weave_size reaches the offset. prev_weave_size is the
--- preceding block's cumulative weave_size, used by the caller to confirm the
--- offset is tightly bracketed (no missing block between) before trusting the
--- local result. Backed by stable_blocks_weave_size_idx.
-SELECT b.height AS height,
-  b.weave_size AS weave_size,
-  p.weave_size AS prev_weave_size
-FROM stable_blocks b
-LEFT JOIN stable_blocks p ON p.height = b.height - 1
-WHERE b.weave_size >= @offset
-ORDER BY b.weave_size ASC, b.height ASC
+-- Resolve an absolute weave offset to its containing block: the lowest block
+-- whose cumulative weave_size reaches the offset, considering BOTH the stable
+-- chain (stable_blocks) and the not-yet-stable tip (new_blocks). Extending the
+-- search into new_blocks lets tip offsets resolve from the local index instead
+-- of falling through to the slow chain binary search.
+--
+-- Each table is probed independently through its own weave_size index (a single
+-- indexed LIMIT 1 lookup, no full scan of either table), then the two candidates
+-- are merged and the lower one chosen. is_unstable flags whether the winning row
+-- came from new_blocks (1) or stable_blocks (0); ties prefer the stable row so a
+-- block that has just stabilized is reported as stable. The caller uses it to
+-- attribute the resolution to the stable vs unstable zone in metrics.
+--
+-- prev_weave_size is the immediately-preceding block's cumulative weave_size --
+-- the MAX across any rows at height-1 in either table. Taking the MAX is the
+-- conservative choice under tip forks (new_blocks can transiently hold
+-- non-canonical blocks, so weave_size is not guaranteed unique/monotonic there):
+-- if any block at height-1 already reaches the offset the bracket is not tight
+-- and the caller falls back rather than risk a wrong block. The caller confirms
+-- prev_weave_size < offset <= weave_size (a tight bracket, no missing block
+-- between) and re-fetches + re-verifies the candidate block before trusting it,
+-- so a stale or forked local hit degrades to a fallback, never to wrong bytes.
+-- Backed by stable_blocks_weave_size_idx / new_blocks_weave_size_idx.
+WITH candidate AS (
+  SELECT height, weave_size, 0 AS is_unstable FROM (
+    SELECT height, weave_size
+    FROM stable_blocks
+    WHERE weave_size >= @offset
+    ORDER BY weave_size ASC, height ASC
+    LIMIT 1
+  )
+  UNION ALL
+  SELECT height, weave_size, 1 AS is_unstable FROM (
+    SELECT height, weave_size
+    FROM new_blocks
+    WHERE weave_size >= @offset
+    ORDER BY weave_size ASC, height ASC
+    LIMIT 1
+  )
+)
+SELECT c.height AS height,
+  c.weave_size AS weave_size,
+  c.is_unstable AS is_unstable,
+  (
+    SELECT MAX(p.weave_size)
+    FROM (
+      SELECT weave_size FROM stable_blocks WHERE height = c.height - 1
+      UNION ALL
+      SELECT weave_size FROM new_blocks WHERE height = c.height - 1
+    ) AS p
+  ) AS prev_weave_size
+FROM candidate c
+ORDER BY c.weave_size ASC, c.height ASC, c.is_unstable ASC
 LIMIT 1;

--- a/src/database/standalone-sqlite.test.ts
+++ b/src/database/standalone-sqlite.test.ts
@@ -399,6 +399,99 @@ describe('StandaloneSqliteDatabase', () => {
       assert.equal(beyond.weaveSize, undefined);
       assert.equal(beyond.prevWeaveSize, undefined);
     });
+
+    it('resolves offsets in the not-yet-stable tip (new_blocks) across the stable boundary', async () => {
+      const insertStableBlock = (height: number, weaveSize: number) =>
+        coreDb
+          .prepare(
+            `INSERT INTO stable_blocks (
+               height, nonce, hash, block_timestamp, diff, last_retarget,
+               reward_pool, block_size, weave_size, tx_count, missing_tx_count
+             ) VALUES (
+               @height, @nonce, @hash, 0, '0', '0',
+               '0', 1, @weave_size, 0, 0
+             )`,
+          )
+          .run({
+            height,
+            nonce: Buffer.alloc(1),
+            hash: Buffer.alloc(1),
+            weave_size: weaveSize,
+          });
+
+      const insertNewBlock = (
+        height: number,
+        weaveSize: number,
+        indepHashByte: number,
+      ) =>
+        coreDb
+          .prepare(
+            `INSERT INTO new_blocks (
+               indep_hash, height, nonce, hash, block_timestamp, diff,
+               last_retarget, reward_pool, block_size, weave_size, tx_count,
+               missing_tx_count
+             ) VALUES (
+               @indep_hash, @height, @nonce, @hash, 0, '0',
+               '0', '0', 1, @weave_size, 0, 0
+             )`,
+          )
+          .run({
+            indep_hash: Buffer.from([indepHashByte]),
+            height,
+            nonce: Buffer.alloc(1),
+            hash: Buffer.alloc(1),
+            weave_size: weaveSize,
+          });
+
+      // Use a high, isolated offset range so the rows inserted by the previous
+      // test (heights 10–22, weave_size ≤ 1200) can never become candidates.
+      // Stable chain ends at height 1003; the tip lives in new_blocks.
+      insertStableBlock(1000, 10_000);
+      insertStableBlock(1001, 20_000);
+      insertStableBlock(1002, 20_000); // empty block, same cumulative weave_size
+      insertStableBlock(1003, 35_000); // last stable block
+      insertNewBlock(1004, 50_000, 0xa1); // first unstable block
+      insertNewBlock(1005, 60_000, 0xa2);
+
+      // Offset still inside the stable chain resolves as before, tagged stable.
+      // 15_000 falls in block 1001 (10_000 < 15_000 <= 20_000).
+      const stableHit = await db.getBlockByWeaveOffset(15_000);
+      assert.equal(stableHit.height, 1001);
+      assert.equal(stableHit.weaveSize, 20_000);
+      assert.equal(stableHit.prevWeaveSize, 10_000); // from stable_blocks(1000)
+      assert.equal(stableHit.zone, 'stable');
+
+      // Boundary case: the FIRST new block (1004). Its predecessor is the last
+      // STABLE block (1003), so prev_weave_size must come across the UNION.
+      const firstTip = await db.getBlockByWeaveOffset(45_000);
+      assert.equal(firstTip.height, 1004);
+      assert.equal(firstTip.weaveSize, 50_000);
+      assert.equal(firstTip.prevWeaveSize, 35_000); // from stable_blocks(1003)
+      assert.equal(firstTip.zone, 'unstable');
+
+      // A deeper tip offset resolves entirely within new_blocks.
+      const deeperTip = await db.getBlockByWeaveOffset(55_000);
+      assert.equal(deeperTip.height, 1005);
+      assert.equal(deeperTip.weaveSize, 60_000);
+      assert.equal(deeperTip.prevWeaveSize, 50_000); // from new_blocks(1004)
+      assert.equal(deeperTip.zone, 'unstable');
+
+      // Reorg safety: new_blocks can transiently hold a non-canonical fork at a
+      // height already occupied. Add a fork of the predecessor height (1004)
+      // claiming an inflated cumulative weave_size that overshoots the offset.
+      // prev_weave_size takes the MAX across rows at height-1, so the bracket is
+      // no longer tight (prev >= offset) and the caller must fall back rather
+      // than risk trusting a forked tip — the conservative direction.
+      insertNewBlock(1004, 70_000, 0xb1); // fork at height 1004
+      const forked = await db.getBlockByWeaveOffset(55_000);
+      assert.equal(forked.height, 1005);
+      assert.equal(forked.weaveSize, 60_000);
+      assert.equal(forked.prevWeaveSize, 70_000); // MAX(50_000, 70_000) at 1004
+      assert.ok(
+        forked.prevWeaveSize !== undefined && forked.prevWeaveSize >= 55_000,
+        'forked predecessor breaks the tight bracket so the caller falls back',
+      );
+    });
   });
 
   describe('getTransactionAttributes', () => {

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -90,9 +90,10 @@ interface TxByOffsetResult {
 }
 
 /**
- * Result of resolving an absolute weave offset to its containing stable block.
+ * Result of resolving an absolute weave offset to its containing block.
  *
- * `height`/`weaveSize` describe the lowest stable block whose cumulative
+ * `height`/`weaveSize` describe the lowest block — across the stable chain
+ * (`stable_blocks`) and the not-yet-stable tip (`new_blocks`) — whose cumulative
  * `weave_size` reaches the requested offset (the candidate container).
  * `prevWeaveSize` is the immediately-preceding block's cumulative `weave_size`,
  * present only when that predecessor is itself indexed. Callers use it to
@@ -100,15 +101,21 @@ interface TxByOffsetResult {
  * weaveSize`) — i.e. no missing block sits between the predecessor and the
  * candidate — before trusting the local result.
  *
- * All fields are `undefined` when no stable block reaches the offset (e.g. the
- * offset lies in the not-yet-stable chain tip); `prevWeaveSize` alone is
- * `undefined` when the predecessor is absent (a gap or the genesis block), in
- * which case the caller must not trust the bracket and should fall back.
+ * `zone` reports whether the candidate came from the stable chain (`'stable'`)
+ * or the unstable tip (`'unstable'`), letting the caller attribute the
+ * resolution to the right zone in metrics. A block present in both tables (just
+ * stabilized) is reported as `'stable'`.
+ *
+ * All fields are `undefined` when no block reaches the offset (an offset beyond
+ * the chain tip); `prevWeaveSize` alone is `undefined` when the predecessor is
+ * absent (a gap or the genesis block), in which case the caller must not trust
+ * the bracket and should fall back.
  */
 interface BlockByWeaveOffsetResult {
   height: number | undefined;
   weaveSize: number | undefined;
   prevWeaveSize: number | undefined;
+  zone: 'stable' | 'unstable' | undefined;
 }
 
 export function encodeTransactionGqlCursor({
@@ -1134,12 +1141,13 @@ export class StandaloneSqliteDatabaseWorker {
   }
 
   /**
-   * Resolve an absolute weave `offset` to its containing stable block via the
-   * indexed `stable_blocks.weave_size` column, avoiding the chain binary
-   * search's sequential per-block fetches. Returns the candidate block plus its
-   * predecessor's weave size for bracket validation; see
-   * {@link BlockByWeaveOffsetResult} for the `undefined` semantics. Resolves
-   * offset→block only — not offset→transaction.
+   * Resolve an absolute weave `offset` to its containing block via the indexed
+   * `weave_size` columns of `stable_blocks` and `new_blocks`, avoiding the chain
+   * binary search's sequential per-block fetches. Querying both tables lets
+   * offsets in the not-yet-stable tip resolve locally too. Returns the candidate
+   * block plus its predecessor's weave size for bracket validation and the zone
+   * it was found in; see {@link BlockByWeaveOffsetResult} for the `undefined`
+   * semantics. Resolves offset→block only — not offset→transaction.
    */
   getBlockByWeaveOffset(offset: number): BlockByWeaveOffsetResult {
     const result = this.stmts.core.selectBlockHeightByWeaveOffset.get({
@@ -1150,12 +1158,14 @@ export class StandaloneSqliteDatabaseWorker {
         height: undefined,
         weaveSize: undefined,
         prevWeaveSize: undefined,
+        zone: undefined,
       };
     }
     return {
       height: result.height ?? undefined,
       weaveSize: result.weave_size ?? undefined,
       prevWeaveSize: result.prev_weave_size ?? undefined,
+      zone: result.is_unstable ? 'unstable' : 'stable',
     };
   }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -87,21 +87,24 @@ export const chunkServeDeadlineExceededCounter = new promClient.Counter({
 });
 
 // Outcome of resolving an absolute weave offset to its containing block in
-// ArweaveCompositeClient.binarySearchBlocks. `local_index_hit` means the local
-// stable_blocks index resolved and verified the block with no chain walk; every
-// other `outcome` value falls through to the chain binary search. During soak,
-// hit_rate = local_index_hit / (sum of all outcomes except cache_hit); the
+// ArweaveCompositeClient.binarySearchBlocks. The `local_index_hit*` outcomes
+// mean the local index (stable_blocks ∪ new_blocks) resolved and verified the
+// block with no chain walk; every other `outcome` value falls through to the
+// chain binary search. During soak, hit_rate = (local_index_hit +
+// local_index_hit_unstable) / (sum of all outcomes except cache_hit); the
 // fallback_* labels explain why the fast path was not taken.
 //   - cache_hit: returned from the in-memory block cache before either path
-//   - local_index_hit: local index bracketed + fetched block re-verified
-//   - fallback_miss: no stable block reaches the offset (e.g. unstable tip)
+//   - local_index_hit: stable-zone index bracketed + fetched block re-verified
+//   - local_index_hit_unstable: as above, candidate from the not-yet-stable tip
+//     (new_blocks) — absorbs offsets that previously fell to fallback_miss
+//   - fallback_miss: no block reaches the offset (beyond the current chain tip)
 //   - fallback_untight: candidate found but predecessor missing/not below offset
 //   - fallback_stale: fetched block no longer covers the offset (e.g. reorg)
 //   - fallback_error: index lookup failed (non-abort)
 //   - fallback_no_index: no local index wired (should not occur in production)
 export const blockOffsetResolutionCounter = new promClient.Counter({
   name: 'block_offset_resolution_total',
-  help: 'Count of offset->block resolutions by outcome of the local stable_blocks fast path',
+  help: 'Count of offset->block resolutions by outcome of the local block-offset fast path',
   labelNames: ['outcome'],
 });
 

--- a/test/core-schema.sql
+++ b/test/core-schema.sql
@@ -203,3 +203,4 @@ CREATE INDEX new_transactions_target_id_idx ON new_transactions (target, id);
 CREATE INDEX new_transactions_owner_address_id_idx ON new_transactions (owner_address, id);
 CREATE INDEX new_transactions_height_indexed_at_idx ON new_transactions (height, indexed_at);
 CREATE INDEX stable_blocks_weave_size_idx ON stable_blocks (weave_size);
+CREATE INDEX new_blocks_weave_size_idx ON new_blocks (weave_size);


### PR DESCRIPTION
## Summary

Extends the local offset→block fast path from **#801** to cover the **unstable/tip zone**.

#801 added a local fast path in `ArweaveCompositeClient.binarySearchBlocks` that resolves an absolute weave offset → containing block from the SQLite index, collapsing the chain binary search's `~log₂(height)` sequential `GET /block/height/{h}` upstream requests into a single indexed lookup plus one block fetch. It queried **`stable_blocks` only**, so any offset in the unstable tip (mined but not yet stable, living in `new_blocks`) *"fell through to the chain binary search"* — the slow path it was meant to kill.

The tip zone (most recent ~20 blocks) is exactly where cold-data retrieval is slow on production: those requests take the full chain binary search → gateway timeouts (504), ~280s p99, then a slow public-gateway fallback. The node already **has** those blocks locally in `new_blocks` (synced to tip) — they were just not in the queried table.

### Production evidence (develop node, rev `55ef9235`)

```
block_offset_resolution_total{outcome="local_index_hit"} = 1,236
block_offset_resolution_total{outcome="cache_hit"}       = 7,564
block_offset_resolution_total{outcome="fallback_miss"}   = 10,274   <-- dominant; the tip gap
```

`fallback_miss` (10,274) dominates and is almost entirely the tip gap. This PR moves that volume onto the local index.

## The change

- **SQL** (`src/database/sql/core/offsets.sql`): `selectBlockHeightByWeaveOffset` now considers `stable_blocks ∪ new_blocks`. Each table is probed through its own `weave_size` index (an indexed `LIMIT 1` lookup — **no full scan**, verified via `EXPLAIN QUERY PLAN`) and the lower candidate is chosen. `prev_weave_size` spans the boundary (the first new block's predecessor is the last stable block) and is the **MAX** across any rows at `height-1`. An `is_unstable` flag reports which zone the candidate came from (ties prefer stable).
- **Migration**: adds `new_blocks_weave_size_idx ON new_blocks(weave_size)` (+ matching down migration). `stable_blocks_weave_size_idx` already exists from #801.
- **Plumbing**: this reuses #801's existing `getBlockByWeaveOffset` DB method end to end. The return shape gains an optional `zone` field; SQL, `StandaloneSqlite` worker impl, the queue wrapper, and the worker message-handler case all still line up (the queue/case pass the object through unchanged). The `BlockByOffsetIndex` interface's `zone` is **optional**, so pre-existing callers/mocks still satisfy it.
- **Metric**: new distinct outcome `local_index_hit_unstable` on `block_offset_resolution_total` so the win is observable; it should absorb the former `fallback_miss` volume. `fallback_miss` now means strictly "offset beyond the chain tip."

## ⚠️ Reorg / unstable safety

`new_blocks` can transiently hold **non-canonical fork blocks**, so `weave_size` is **not guaranteed unique/monotonic** there, and a block can move new→stable between lookup and fetch. Two backstops make a wrong/forked local hit **safe — worst case a fall-back, never a wrong offset / wrong bytes**:

1. **#801's re-validation guard is retained unchanged.** After the local index returns a candidate, the block is re-fetched by height (returning the **canonical** block) and its `weave_size` is re-checked against the offset before it is trusted. On mismatch → `fallback_stale` → chain binary search. This guard is **not removed or weakened**.
2. **Conservative MAX predecessor.** `prev_weave_size` takes the MAX across rows at `height-1`, so a fork that overshoots the offset breaks the tight bracket (`prev ≥ offset`) and forces a fall-back rather than risk it.

The block returned is identical to the chain search — only *how* it is found changes.

## Tests

- `composite-client-binary-search.test.ts`: an unstable-tip candidate resolves via the local index with **a single re-validation `getBlockByHeight`** and **no chain walk** (`getHeight` never called), asserting the new `local_index_hit_unstable` outcome; plus a forked-tip case where the re-fetched block no longer covers the offset → falls back cleanly and returns the **correct** block.
- `standalone-sqlite.test.ts`: stable∪new resolution, the **boundary case** (first new block whose `prev_weave_size` comes from `stable_blocks` across the UNION), `zone` reporting, and a fork at the predecessor height breaking the bracket (conservative MAX).
- Migration applied and `test/core-schema.sql` regenerated (single added index line).
- Auto-verify re-checked: index-only change, no projected-column drift → no-op. ClickHouse is not in this path.
- `yarn lint:check` clean; touched test files green.

Tight extension of #801 — closes the tip gap that `fallback_miss=10,274` represents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
