### PR TITLE
ci(test-core): typecheck test files in CI

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -25,6 +25,10 @@ jobs:
       - run: yarn --immutable --immutable-cache
       - run: yarn build
       - run: yarn lint:check
+      # Typecheck including test files. `yarn build` uses tsconfig.prod.json,
+      # which excludes **/*.test.ts, and `yarn test` runs via a type-stripping
+      # loader — so without this, type errors in test code reach no CI gate.
+      - run: yarn typecheck
       - run: yarn test:ci
       - name: Build core Docker image
         if: matrix.os == 'ubuntu-latest'

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "test:auto-verify:indexing": "node --no-deprecation --import ./register.js src/tests/auto-verify/run.ts",
     "lint:check": "eslint src test",
     "lint:fix": "eslint --fix src test",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "duplicate:check": "jscpd src",
     "duplicate:report": "jscpd src --reporters html,console",
     "duplicate:ci": "jscpd src --reporters console --exitCode 1",


### PR DESCRIPTION
## What

Adds a `typecheck` script (`tsc --noEmit -p tsconfig.json`) and runs it in `test-core.yml` between `lint:check` and `test:ci`.

## Why

**Test code currently has no type gate.** Two facts combine into a blind spot:
- `yarn build` typechecks with `tsconfig.prod.json`, which **excludes `**/*.test.ts`**.
- `yarn test` runs through a **type-stripping loader** (no typecheck).

So a type error in a `.test.ts` — e.g. a mock object missing a newly-**required** interface field — passes every PR check and only surfaces if someone runs the test-inclusive `tsc` by hand. This was hit for real while developing the chunk-fanout work: extending `BroadcastChunkResult` silently broke 5 typed mocks in `rebroadcasting-chunk-source.test.ts`, green across all of CI.

## Scope

Pure gate addition — **the current tree already passes `yarn typecheck` with 0 errors**, so there's no cleanup tail. `yarn build` still owns emit; this is a fast no-emit check that simply *includes* tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)