### PR TITLE
feat(monitoring): chunk fan-out placement panels in default dashboard

### DIFF
--- a/monitoring/grafana/dashboards/default.json
+++ b/monitoring/grafana/dashboards/default.json
@@ -59,7 +59,9 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -1023,6 +1025,365 @@
       ],
       "title": "I/O Utilization",
       "type": "timeseries"
+    },
+    {
+      "id": 14,
+      "type": "row",
+      "title": "Chunk Fan-out Seeding (placement)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "panels": []
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "Distinct fault domains per chunk POST",
+      "description": "Independent operators (IP /24·/48) a chunk landed on per POST. p10 is the seeding-risk tail: low p10 = a meaningful slice of chunks are landing on few fault domains.",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "axisPlacement": "auto",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "sum(rate(chunk_post_distinct_domains_sum[$__rate_interval]))/sum(rate(chunk_post_distinct_domains_count[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "avg",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(chunk_post_distinct_domains_bucket[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.1, sum by (le) (rate(chunk_post_distinct_domains_bucket[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "p10 (thinnest 10%)",
+          "range": true,
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Preferred (tip) shortfall rate",
+      "description": "POSTs where the preferred (tip) success count fell short. tips_unavailable = the tip /24 was down/over-queue (the SPOF the soft-preferred fallback covers); tips_failed = tips reachable but did not ack. Emitted even when the fallback still made the POST succeed.",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "axisPlacement": "auto",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "sum(rate(chunk_post_preferred_shortfall_total[$__rate_interval])) by (reason)",
+          "instant": false,
+          "legendFormat": "{{reason}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "Distinct-domain target shortfall rate",
+      "description": "Only when CHUNK_POST_MIN_DISTINCT_DOMAINS>0. unmet = target achievable but not reached; degraded = eligible peer set could not supply the target (soft-capped, POST not failed on scarcity).",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "axisPlacement": "auto",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "sum(rate(chunk_post_domain_shortfall_total[$__rate_interval])) by (reason)",
+          "instant": false,
+          "legendFormat": "{{reason}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Chunk broadcast success rate",
+      "description": "Overall share of chunk broadcasts meeting the quorum verdict. Context for the diversity panels above.",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "axisPlacement": "auto",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "editorMode": "code",
+          "expr": "sum(rate(arweave_chunk_broadcast_total{status=\"success\"}[$__rate_interval]))/clamp_min(sum(rate(arweave_chunk_broadcast_total[$__rate_interval])),0.0001)",
+          "instant": false,
+          "legendFormat": "success ratio",
+          "range": true,
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "auto",


### PR DESCRIPTION
## What

Adds a **"Chunk Fan-out Seeding (placement)"** row to the provisioned Grafana dashboard (`monitoring/grafana/dashboards/default.json`), visualizing the metrics from the fault-domain-aware quorum work (#806):

| Panel | Shows |
|---|---|
| **Distinct fault domains per POST** (avg / p50 / p10) | how many independent operators (IP /24·/48) each chunk lands on. **p10 is the seeding-risk tail** — low p10 = a real slice of chunks landing on few fault domains |
| **Preferred (tip) shortfall rate** by reason | `tips_unavailable` surfaces the tips-`/24` SPOF **even when the soft-preferred fallback still succeeds** |
| **Distinct-domain target shortfall rate** by reason | `unmet` vs `degraded` (soft-capped on scarcity) |
| **Chunk broadcast success rate** | quorum context |

## Notes

- **Additive only** — existing panels are unchanged (verified: 362 insertions, all prior panels intact).
- Panels reference `chunk_post_distinct_domains`, `chunk_post_{preferred,domain}_shortfall_total`, and the existing `arweave_chunk_broadcast_total`. They show **"No data" until #806 merges** and the metrics flow — harmless until then.
- Auto-provisioned via `monitoring/grafana/provisioning/dashboards` (loads on next Grafana start).
- This is the gateway-operator observability surface for the placement work; it is **not** end-user or bundler-facing (see the boundary RFC for the bundler-side proposal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)