### PR TITLE
feat(gql): log + count ClickHouse 158 TOO_MANY_ROWS at the origin

### DIFF
--- a/src/database/composite-clickhouse.test.ts
+++ b/src/database/composite-clickhouse.test.ts
@@ -681,6 +681,19 @@ describe('CompositeClickHouseDatabase', () => {
         1,
         'expected the 158 counter to increment with id_count="3-5"',
       );
+      // The same increment carries filter="ids" from describeGqlFilterShape.
+      const series = (
+        await metrics.clickhouseGqlTooManyRowsTotal.get()
+      ).values.find(
+        (v) =>
+          v.labels.filter === 'ids' &&
+          v.labels.recovery === 'none' &&
+          v.labels.id_count === '3-5',
+      );
+      assert.ok(
+        series !== undefined && series.value >= 1,
+        'expected the 158 counter series to carry filter="ids"',
+      );
     });
 
     it('does not window when the feature is disabled (default)', async () => {

--- a/src/database/composite-clickhouse.test.ts
+++ b/src/database/composite-clickhouse.test.ts
@@ -8,6 +8,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it, beforeEach } from 'node:test';
 
 import { createTestLogger } from '../../test/test-logger.js';
+import * as metrics from '../metrics.js';
 import {
   GqlQueryable,
   GqlTransaction,
@@ -21,6 +22,24 @@ import {
 import { NEW_TRANSACTION_COLUMNS } from '../workers/clickhouse-streamer.js';
 
 const log = createTestLogger({ suite: 'CompositeClickHouseDatabase' });
+
+// Sum of the `clickhouse_gql_too_many_rows_total` counter for a given
+// `recovery` label (optionally narrowed to an `id_count` bucket). Used to
+// assert the 158-audit counter fires with the right recovery outcome and
+// id-count bucket on the windowed and fail-fast paths.
+const tooManyRowsCount = async (
+  recovery: 'windowed' | 'none',
+  idCount?: string,
+): Promise<number> => {
+  const out = await metrics.clickhouseGqlTooManyRowsTotal.get();
+  return out.values
+    .filter(
+      (v) =>
+        v.labels.recovery === recovery &&
+        (idCount === undefined || v.labels.id_count === idCount),
+    )
+    .reduce((sum, v) => sum + v.value, 0);
+};
 
 // Canonicalize a test label into a base64url id that round-trips cleanly
 // through `b64UrlToHex` / `hexToB64Url`. The composite's CH mapper goes
@@ -554,6 +573,7 @@ describe('CompositeClickHouseDatabase', () => {
         },
       };
 
+      const beforeWindowed = await tooManyRowsCount('windowed');
       const result = await composite.getGqlTransactions({
         pageSize: 2,
         owners: [id('owner')],
@@ -561,6 +581,13 @@ describe('CompositeClickHouseDatabase', () => {
         maxHeight: 100_000,
       });
 
+      // The 158 audit counter fires with recovery=windowed for the recovered
+      // (owner-projection) path.
+      assert.equal(
+        (await tooManyRowsCount('windowed')) - beforeWindowed,
+        1,
+        'expected clickhouse_gql_too_many_rows_total{recovery="windowed"} to increment',
+      );
       // The single-shot threw 158, then at least one windowed retry ran.
       assert.ok(
         stableCalls >= 2,
@@ -603,6 +630,7 @@ describe('CompositeClickHouseDatabase', () => {
         },
       };
 
+      const beforeNone = await tooManyRowsCount('none');
       await assert.rejects(
         composite.getGqlTransactions({
           pageSize: 2,
@@ -612,6 +640,47 @@ describe('CompositeClickHouseDatabase', () => {
       );
       // No windowing retries for a tag-only (ownerless) query.
       assert.equal(stableCalls, 1);
+      // The 158 audit counter fires with recovery=none for the fail-fast path,
+      // even though the error still surfaces to the caller.
+      assert.equal(
+        (await tooManyRowsCount('none')) - beforeNone,
+        1,
+        'expected clickhouse_gql_too_many_rows_total{recovery="none"} to increment',
+      );
+    });
+
+    it('buckets id-count on the 158 counter for a multi-id fail-fast query', async () => {
+      const composite = buildComposite({
+        sqlite,
+        ownerProjectionRoutingEnabled: true,
+        chRowsByLeg: {},
+      });
+      (composite as any).clickhouseClient = {
+        async query({ query: sqlStr }: { query: string }) {
+          if (sqlStr.includes('FROM new_transactions')) {
+            return { json: async () => ({ data: [] }) };
+          }
+          const err: any = new Error('Code: 158. TOO_MANY_ROWS');
+          err.code = '158';
+          throw err;
+        },
+      };
+
+      // 4 ids → the `3-5` bucket. Ids-only (no owner) → fail-fast (recovery=none).
+      const before = await tooManyRowsCount('none', '3-5');
+      await assert.rejects(
+        composite.getGqlTransactions({
+          pageSize: 2,
+          ids: [id('a'), id('b'), id('c'), id('d')],
+          tags: [],
+        }),
+        /158|TOO_MANY_ROWS/,
+      );
+      assert.equal(
+        (await tooManyRowsCount('none', '3-5')) - before,
+        1,
+        'expected the 158 counter to increment with id_count="3-5"',
+      );
     });
 
     it('does not window when the feature is disabled (default)', async () => {

--- a/src/database/composite-clickhouse.ts
+++ b/src/database/composite-clickhouse.ts
@@ -157,6 +157,43 @@ function isClickHouseTooManyRowsError(err: unknown): boolean {
   return /\bcode:\s*158\b|TOO_MANY_ROWS/i.test(e.message ?? '');
 }
 
+// Low-cardinality descriptor of which filter families a GQL query used, for
+// the `filter` label on `clickhouse_gql_too_many_rows_total`. Bounded to the
+// 32 combinations of the five filter families (plus `none`), so it's safe as a
+// Prometheus label. The paired warn log carries the concrete filter values.
+function describeGqlFilterShape(args: {
+  ids: string[];
+  owners: string[];
+  recipients: string[];
+  bundledIn?: string[] | null;
+  tags: { name: string; values: string[] }[];
+}): string {
+  const families: string[] = [];
+  if (args.ids.length > 0) families.push('ids');
+  if (args.owners.length > 0) families.push('owners');
+  if (args.recipients.length > 0) families.push('recipients');
+  if (args.bundledIn != null && args.bundledIn.length > 0)
+    families.push('bundledIn');
+  if (args.tags.length > 0) families.push('tags');
+  return families.length > 0 ? families.join('+') : 'none';
+}
+
+// Coarse id-count bucket for the `id_count` label on
+// `clickhouse_gql_too_many_rows_total`. The dominant 158 source is multi-id
+// `transactions(ids:[...])` lookups whose id_bloom scatter scales ~linearly
+// with id count (each id ≈ 1% of granules as false positives), so the number
+// of ids is the load-bearing dimension — but the raw count is too
+// high-cardinality for a label. Buckets chosen around the observed
+// max_rows_to_read boundary (single-id safe, ~2 marginal, 3+ over the cap).
+function bucketIdCount(n: number): string {
+  if (n === 0) return '0';
+  if (n === 1) return '1';
+  if (n === 2) return '2';
+  if (n <= 5) return '3-5';
+  if (n <= 20) return '6-20';
+  return '21+';
+}
+
 // Reactive fallback (hack 5) for owner-filtered GQL queries whose owner
 // footprint is so large it still trips `max_rows_to_read` even via
 // owner_projection (a "whale" owner). When the single-shot stable query throws
@@ -1144,39 +1181,70 @@ export class CompositeClickHouseDatabase implements GqlQueryable {
         const jsonRow = await row.json();
         return jsonRow.data.map((tx: any) => this.mapTransactionRow(tx));
       } catch (err) {
-        // Hack 5: an owner-filtered query that still trips max_rows_to_read
-        // through owner_projection means a whale whose footprint exceeds the
-        // cap. Re-run as an adaptive height-windowed walk instead of failing.
-        //
-        // Restricted to non-id queries: the windowing walk is height-ordered
-        // and relies on the cursor predicate to drain a window, but id queries
-        // carry no ORDER BY or cursor predicate (see addGqlTransactionFilters /
-        // buildTransactionOrderBy), so the walk can't make per-window progress.
-        // owner+ids only reaches the cap for whale owners (>10M footprint) — a
-        // rare case left to surface the 158, no worse than before this feature.
-        if (
-          this.ownerProjectionApplies(owners, ids, tags) &&
-          ids.length === 0 &&
-          isClickHouseTooManyRowsError(err)
-        ) {
-          this.log.warn(
-            'Stable GQL leg tripped max_rows_to_read on an owner-filtered ' +
-              'query; retrying with adaptive height-windowing',
-            { owners, tags, minHeight, maxHeight },
-          );
-          return this.queryStableTransactionsWindowed({
-            pageSize,
-            cursor,
-            sortOrder,
-            ids,
-            recipients,
-            owners,
-            minHeight,
-            maxHeight,
-            bundledIn,
-            tags,
-            encoded: encodedFilters,
+        // Every stable-leg Code 158 (TOO_MANY_ROWS) is recorded here — at the
+        // origin, for both the recovered and the failing path — so operators can
+        // audit which query shapes trip `max_rows_to_read`. The counter carries a
+        // low-cardinality filter descriptor; the warn carries the concrete query
+        // shape needed to reproduce it.
+        if (isClickHouseTooManyRowsError(err)) {
+          // Hack 5: an owner-filtered query that still trips max_rows_to_read
+          // through owner_projection means a whale whose footprint exceeds the
+          // cap. Re-run as an adaptive height-windowed walk instead of failing.
+          //
+          // Restricted to non-id queries: the windowing walk is height-ordered
+          // and relies on the cursor predicate to drain a window, but id queries
+          // carry no ORDER BY or cursor predicate (see addGqlTransactionFilters /
+          // buildTransactionOrderBy), so the walk can't make per-window progress.
+          // owner+ids only reaches the cap for whale owners (>10M footprint) — a
+          // rare case left to surface the 158, no worse than before this feature.
+          const willRetryWindowed =
+            this.ownerProjectionApplies(owners, ids, tags) && ids.length === 0;
+          metrics.clickhouseGqlTooManyRowsTotal.inc({
+            filter: describeGqlFilterShape({
+              ids,
+              owners,
+              recipients,
+              bundledIn,
+              tags,
+            }),
+            recovery: willRetryWindowed ? 'windowed' : 'none',
+            id_count: bucketIdCount(ids.length),
           });
+          this.log.warn(
+            'ClickHouse GQL stable query tripped max_rows_to_read ' +
+              '(Code 158 TOO_MANY_ROWS)',
+            {
+              recovery: willRetryWindowed
+                ? 'adaptive-height-windowing'
+                : 'none',
+              maxRowsToRead: config.CLICKHOUSE_GQL_MAX_ROWS_TO_READ,
+              idCount: ids.length,
+              ids,
+              owners,
+              recipients,
+              bundledIn,
+              tags,
+              minHeight,
+              maxHeight,
+              pageSize,
+              sortOrder,
+            },
+          );
+          if (willRetryWindowed) {
+            return this.queryStableTransactionsWindowed({
+              pageSize,
+              cursor,
+              sortOrder,
+              ids,
+              recipients,
+              owners,
+              minHeight,
+              maxHeight,
+              bundledIn,
+              tags,
+              encoded: encodedFilters,
+            });
+          }
         }
         throw err;
       }

--- a/src/database/composite-clickhouse.ts
+++ b/src/database/composite-clickhouse.ts
@@ -157,10 +157,12 @@ function isClickHouseTooManyRowsError(err: unknown): boolean {
   return /\bcode:\s*158\b|TOO_MANY_ROWS/i.test(e.message ?? '');
 }
 
-// Low-cardinality descriptor of which filter families a GQL query used, for
-// the `filter` label on `clickhouse_gql_too_many_rows_total`. Bounded to the
-// 32 combinations of the five filter families (plus `none`), so it's safe as a
-// Prometheus label. The paired warn log carries the concrete filter values.
+/**
+ * Low-cardinality descriptor of which filter families a GQL query used, for
+ * the `filter` label on `clickhouse_gql_too_many_rows_total`. Bounded to the
+ * 32 combinations of the five filter families (plus `none`), so it's safe as a
+ * Prometheus label. The paired warn log carries the concrete filter values.
+ */
 function describeGqlFilterShape(args: {
   ids: string[];
   owners: string[];
@@ -178,13 +180,15 @@ function describeGqlFilterShape(args: {
   return families.length > 0 ? families.join('+') : 'none';
 }
 
-// Coarse id-count bucket for the `id_count` label on
-// `clickhouse_gql_too_many_rows_total`. The dominant 158 source is multi-id
-// `transactions(ids:[...])` lookups whose id_bloom scatter scales ~linearly
-// with id count (each id ≈ 1% of granules as false positives), so the number
-// of ids is the load-bearing dimension — but the raw count is too
-// high-cardinality for a label. Buckets chosen around the observed
-// max_rows_to_read boundary (single-id safe, ~2 marginal, 3+ over the cap).
+/**
+ * Coarse id-count bucket for the `id_count` label on
+ * `clickhouse_gql_too_many_rows_total`. The dominant 158 source is multi-id
+ * `transactions(ids:[...])` lookups whose id_bloom scatter scales ~linearly
+ * with id count (each id ≈ 1% of granules as false positives), so the number
+ * of ids is the load-bearing dimension — but the raw count is too
+ * high-cardinality for a label. Buckets chosen around the observed
+ * max_rows_to_read boundary (single-id safe, ~2 marginal, 3+ over the cap).
+ */
 function bucketIdCount(n: number): string {
   if (n === 0) return '0';
   if (n === 1) return '1';
@@ -1214,9 +1218,9 @@ export class CompositeClickHouseDatabase implements GqlQueryable {
             'ClickHouse GQL stable query tripped max_rows_to_read ' +
               '(Code 158 TOO_MANY_ROWS)',
             {
-              recovery: willRetryWindowed
-                ? 'adaptive-height-windowing'
-                : 'none',
+              // Same vocabulary as the counter's `recovery` label so logs and
+              // the metric correlate directly (grep `recovery="windowed"`).
+              recovery: willRetryWindowed ? 'windowed' : 'none',
               maxRowsToRead: config.CLICKHOUSE_GQL_MAX_ROWS_TO_READ,
               idCount: ids.length,
               ids,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -673,6 +673,21 @@ export const clickhouseMaxImportedHeight = new promClient.Gauge({
   help: 'Max height present in the ClickHouse `transactions` table (refreshed lazily).',
 });
 
+// Count of GQL stable-leg queries that tripped ClickHouse `max_rows_to_read`
+// (Code 158 TOO_MANY_ROWS). `filter` is a low-cardinality descriptor of which
+// filter families the query used (e.g. `owners+tags`, `ids`, `none`),
+// `recovery` is `windowed` when the owner-projection height-windowing fallback
+// re-ran it or `none` when the 158 surfaced to the caller, and `id_count` is a
+// coarse bucket of the id-list size (`0`,`1`,`2`,`3-5`,`6-20`,`21+`) — the
+// dominant 158 source is multi-id `transactions(ids:[...])` lookups whose
+// id_bloom scatter scales with id count. The paired per-query warn log carries
+// the full query shape for post-hoc audits.
+export const clickhouseGqlTooManyRowsTotal = new promClient.Counter({
+  name: 'clickhouse_gql_too_many_rows_total',
+  help: 'Count of GQL stable queries that tripped ClickHouse max_rows_to_read (Code 158).',
+  labelNames: ['filter', 'recovery', 'id_count'] as const,
+});
+
 //
 // Redis Cache Metrics
 //

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -673,15 +673,17 @@ export const clickhouseMaxImportedHeight = new promClient.Gauge({
   help: 'Max height present in the ClickHouse `transactions` table (refreshed lazily).',
 });
 
-// Count of GQL stable-leg queries that tripped ClickHouse `max_rows_to_read`
-// (Code 158 TOO_MANY_ROWS). `filter` is a low-cardinality descriptor of which
-// filter families the query used (e.g. `owners+tags`, `ids`, `none`),
-// `recovery` is `windowed` when the owner-projection height-windowing fallback
-// re-ran it or `none` when the 158 surfaced to the caller, and `id_count` is a
-// coarse bucket of the id-list size (`0`,`1`,`2`,`3-5`,`6-20`,`21+`) — the
-// dominant 158 source is multi-id `transactions(ids:[...])` lookups whose
-// id_bloom scatter scales with id count. The paired per-query warn log carries
-// the full query shape for post-hoc audits.
+/**
+ * Count of GQL stable-leg queries that tripped ClickHouse `max_rows_to_read`
+ * (Code 158 TOO_MANY_ROWS). `filter` is a low-cardinality descriptor of which
+ * filter families the query used (e.g. `owners+tags`, `ids`, `none`),
+ * `recovery` is `windowed` when the owner-projection height-windowing fallback
+ * re-ran it or `none` when the 158 surfaced to the caller, and `id_count` is a
+ * coarse bucket of the id-list size (`0`,`1`,`2`,`3-5`,`6-20`,`21+`) — the
+ * dominant 158 source is multi-id `transactions(ids:[...])` lookups whose
+ * id_bloom scatter scales with id count. The paired per-query warn log carries
+ * the full query shape for post-hoc audits.
+ */
 export const clickhouseGqlTooManyRowsTotal = new promClient.Counter({
   name: 'clickhouse_gql_too_many_rows_total',
   help: 'Count of GQL stable queries that tripped ClickHouse max_rows_to_read (Code 158).',


### PR DESCRIPTION
## What

GQL stable-leg queries that exceed ClickHouse `max_rows_to_read` throw `Code: 158 TOO_MANY_ROWS`. Today the only origin-side signal is the owner-projection height-windowing warn, which covers owner queries only and is easy to miss — the dominant 158 source (multi-id `transactions(ids:[...])` lookups tripping the `id_bloom` row cap) re-throws with no log or metric, leaving only a generic "Upstream source failed" warn on the fan-out side whose error string has to be substring-matched for `TOO_MANY_ROWS`.

This records **every** 158 at the point it's classified in the composite ClickHouse read path, for both the recovered (owner-projection windowing) and the fail-fast paths:

- **Counter** `clickhouse_gql_too_many_rows_total{filter, recovery, id_count}`
  - `filter` — low-cardinality descriptor of the filter families used (e.g. `ids`, `owners+tags`, `none`)
  - `recovery` — `windowed` when the owner-projection height-windowing fallback re-ran it, `none` when the 158 surfaced to the caller
  - `id_count` — coarse bucket of the id-list size (`0`/`1`/`2`/`3-5`/`6-20`/`21+`). This is the load-bearing dimension: `id_bloom` false-positive scatter scales ~linearly with id count, and the cap is crossed around 2–3 ids.
- **Warn log** carrying the concrete query shape (`idCount`, ids, owners, recipients, bundledIn, tags, height range, page size, sort order) so operators can audit exactly which queries trip the cap without parsing rendered SQL out of `system.query_log`.

The prior owner-projection-only warn is folded into the unified log.

## Why

Investigating 158 load on the canary gateways, the only retrospective source was ClickHouse `system.query_log` (full SQL, ~3-month retention). That's fine for offline audits but there's no live signal — nothing to alert or trend on, and the app logs carried no usable trace at the origin. This adds that live signal with the id-count dimension the audit showed actually matters.

## Risk

Purely additive — a counter increment and a warn log inside an existing `catch` block. No change to query results or control flow. Low log volume (a warn per 158), bounded counter cardinality.

## Tests

New unit coverage asserts the counter fires with the right `recovery` outcome on both the windowed and fail-fast paths, and buckets `id_count` correctly for a multi-id fail-fast query. `tsc`, eslint, prettier, and the `composite-clickhouse` suite all pass.