### PR TITLE
fix(sqlite): stop getTxByOffset misses from scanning the offset index to the end

### DIFF
--- a/src/database/sql/core/offsets.sql
+++ b/src/database/sql/core/offsets.sql
@@ -1,12 +1,33 @@
 -- selectStableTransactionOffsetById
+-- Resolve an absolute weave offset to the stable format-2 transaction that
+-- spans it. `offset` is the tx's END offset, and tx data regions never overlap,
+-- so the FIRST format-2, data_size > 0 row (by offset ASC) with
+-- offset >= @offset is the only possible spanner: any other tx whose region
+-- ends at or past @offset starts after the spanner's region ends. The inner
+-- query fetches exactly that one row, and only the span predicate is applied
+-- outside. Keeping the span predicate inside the scan (the previous form) made
+-- a MISS -- an offset in a coverage gap (format-1 tx, unpopulated region) --
+-- walk the index from @offset to the end of the table looking for a match that
+-- cannot exist (tens of seconds on a large DB, pinning a core read worker);
+-- with this form a miss costs the same single index probe as a hit and returns
+-- empty.
+--
+-- IMPORTANT: stable_transactions_offset_idx is a PARTIAL index
+-- (WHERE format = 2 AND data_size > 0). Both predicates must stay inside the
+-- inner query verbatim -- SQLite only uses a partial index when the query's
+-- WHERE clause implies the index's WHERE clause; hoisting either predicate out
+-- silently degrades this to a full table scan.
 SELECT id, data_root, offset, data_size
-FROM stable_transactions
-WHERE offset >= @offset
-  AND (offset - data_size) < @offset
-  AND format = 2
-  AND data_size > 0
-ORDER BY offset ASC
-LIMIT 1;
+FROM (
+  SELECT id, data_root, offset, data_size
+  FROM stable_transactions
+  WHERE offset >= @offset
+    AND format = 2
+    AND data_size > 0
+  ORDER BY offset ASC
+  LIMIT 1
+)
+WHERE (offset - data_size) < @offset;
 
 -- selectBlockHeightByWeaveOffset
 -- Resolve an absolute weave offset to its containing block: the lowest block

--- a/src/database/standalone-sqlite.test.ts
+++ b/src/database/standalone-sqlite.test.ts
@@ -33,6 +33,7 @@ import {
 } from '../../test/sqlite-helpers.js';
 import { ArweaveChainSourceStub, stubAns104Bundle } from '../../test/stubs.js';
 import { normalizeAns104DataItem } from '../lib/ans-104.js';
+import loadSql from './sql-loader.js';
 import log from '../log.js';
 import { BundleRecord } from '../types.js';
 import { processBundleStream } from '../lib/bundles.js';
@@ -343,6 +344,99 @@ describe('StandaloneSqliteDatabase', () => {
       // if at 201, it shouldn't return anything
       const txByOffsetResult10 = await db.getTxByOffset(201);
       assert.equal(txByOffsetResult10.id, undefined);
+    });
+
+    it('getTxByOffset misses resolve via a single partial-index probe (no scan past the candidate row)', async () => {
+      // Regression test for the miss-scan pathology: the previous form of
+      // selectStableTransactionOffsetById kept the span predicate
+      // ((offset - data_size) < @offset) inside the index scan, so an offset in
+      // a coverage gap walked stable_transactions_offset_idx from @offset to
+      // the end of the table (tens of seconds on a production-sized DB) before
+      // returning empty. The rewritten statement fetches only the first
+      // candidate row and applies the span check outside. Timing is
+      // meaningless on a tiny test DB, so this asserts the two things that
+      // guarantee the behavior instead: (1) miss semantics stay correct, and
+      // (2) the plan uses the partial index — which requires the inner query
+      // to repeat the index's WHERE predicates (format = 2 AND data_size > 0)
+      // verbatim; hoisting either one out silently degrades to a table scan.
+      const f2id = 'iCXp6wqDLcpdOWJd6oTVz4CTS9QI9wsJp6g6oRVvv0E';
+      const f1id = 'Epr8mLUZDBiTprrN1tyuKu4Ct1nkFrVzL4NBmXtj4jQ';
+
+      const baseValues = {
+        height: 124,
+        block_transaction_index: 0,
+        last_tx: Buffer.alloc(32),
+        owner_address: Buffer.alloc(32),
+        quantity: '0',
+        reward: '0',
+        tag_count: 0,
+      };
+      const insertSql = `
+        INSERT INTO stable_transactions (
+          id, height, block_transaction_index, format, last_tx, owner_address,
+          quantity, reward, tag_count, offset, data_size
+        ) VALUES (
+          @id, @height, @block_transaction_index, @format, @last_tx,
+          @owner_address, @quantity, @reward, @tag_count, @offset, @data_size
+        )
+      `;
+
+      // format-2 tx spanning [451, 500]
+      coreDb.prepare(insertSql).run({
+        ...baseValues,
+        id: fromB64Url(f2id),
+        format: 2,
+        offset: 500,
+        data_size: 50,
+      });
+      // format-1 tx spanning [551, 600]: not in the partial index, must never
+      // be returned, and offsets inside it are misses
+      coreDb.prepare(insertSql).run({
+        ...baseValues,
+        id: fromB64Url(f1id),
+        format: 1,
+        offset: 600,
+        data_size: 50,
+      });
+
+      // Hit within the format-2 tx
+      const hit = await db.getTxByOffset(475);
+      assert.equal(hit.id, f2id);
+
+      // Miss in the gap before the format-2 tx: the first candidate row
+      // (offset 500) fails the span check and the lookup must stop there
+      const gapMiss = await db.getTxByOffset(300);
+      assert.equal(gapMiss.id, undefined);
+
+      // Miss inside the format-1 tx's region: the spanning tx is format-1, so
+      // there is no format-2 spanner and the result is empty
+      const f1Miss = await db.getTxByOffset(575);
+      assert.equal(f1Miss.id, undefined);
+
+      // Miss beyond the highest indexed offset
+      const beyondEndMiss = await db.getTxByOffset(1_000_000);
+      assert.equal(beyondEndMiss.id, undefined);
+
+      // Plan assertion: the statement must probe stable_transactions via the
+      // partial offset index, never scan the table
+      const offsetsSqlDir = new URL('./sql/core', import.meta.url).pathname;
+      const stmt = loadSql(offsetsSqlDir)['selectStableTransactionOffsetById'];
+      assert.ok(
+        stmt !== undefined,
+        'selectStableTransactionOffsetById statement not found',
+      );
+      const plan = coreDb
+        .prepare(`EXPLAIN QUERY PLAN ${stmt}`)
+        .all({ offset: 300 }) as { detail: string }[];
+      const details = plan.map((row) => row.detail).join('\n');
+      assert.ok(
+        details.includes('stable_transactions_offset_idx'),
+        `plan must use stable_transactions_offset_idx, got:\n${details}`,
+      );
+      assert.ok(
+        !/SCAN stable_transactions/.test(details),
+        `plan must not scan stable_transactions, got:\n${details}`,
+      );
     });
 
     it('resolves an absolute weave offset to its containing stable block via getBlockByWeaveOffset', async () => {

--- a/src/database/standalone-sqlite.test.ts
+++ b/src/database/standalone-sqlite.test.ts
@@ -6,6 +6,7 @@
  */
 import { strict as assert } from 'node:assert';
 import { after, before, beforeEach, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 import { ValidationError } from 'apollo-server-express';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
@@ -419,7 +420,9 @@ describe('StandaloneSqliteDatabase', () => {
 
       // Plan assertion: the statement must probe stable_transactions via the
       // partial offset index, never scan the table
-      const offsetsSqlDir = new URL('./sql/core', import.meta.url).pathname;
+      const offsetsSqlDir = fileURLToPath(
+        new URL('./sql/core', import.meta.url),
+      );
       const stmt = loadSql(offsetsSqlDir)['selectStableTransactionOffsetById'];
       assert.ok(
         stmt !== undefined,


### PR DESCRIPTION
## Motivation

The SQLite slow-op log added in #817 captured `getTxByOffset` calls with
`queueWaitMs=0` but `serviceMs` of 23–110 **seconds** on a canary gateway, all
during retrieval-load episodes where peer socket pools pinned at their caps.
Re-running the captured offsets against a production-sized core DB showed every
slow call was a **miss** — an absolute weave offset in a coverage gap (format-1
tx or unpopulated region) — while hits consistently resolved in ~10ms.

Root cause: `selectStableTransactionOffsetById` keeps the span predicate
(`(offset - data_size) < @offset`) inside the index scan. On a hit the first
index row matches immediately. On a miss no row can ever match, so SQLite walks
`stable_transactions_offset_idx` from `@offset` to the end of the table — with a
table-row fetch per entry — before returning empty. Each such miss pins a core
read worker for tens of seconds and holds the requesting peer's socket open,
cascading into outbound socket-pool saturation.

## Fix

Weave data regions never overlap, so the **first** `format = 2, data_size > 0`
row with `offset >= @offset` is the only possible spanner — any other tx whose
region ends at or past `@offset` starts after that row's region ends. The
statement now fetches exactly that row in an inner `LIMIT 1` subquery and
applies the span check outside. A miss costs the same single index probe as a
hit.

**Partial-index caveat (guarded in code + test):** `stable_transactions_offset_idx`
is a partial index (`WHERE format = 2 AND data_size > 0`). SQLite only uses it
when the query's WHERE clause implies the index's WHERE clause, so both
predicates must remain inside the inner query verbatim — hoisting either one out
silently degrades to a full table scan. The SQL comment documents this and the
new test asserts the plan.

## Validation

Against a production-sized core DB (read-only, exact offsets captured by the
slow-op log):

| offset | before | after |
|---|---|---|
| hit (control) | ~10ms | ~10ms, identical row |
| miss (logged 44s / measured 41.8s cold) | 23–110s | **~10ms** |
| miss ×3 more | 23–27s logged | **~10ms** |
| beyond weave end | full remaining scan | **~10ms** |

`EXPLAIN QUERY PLAN` confirms a single
`SEARCH stable_transactions USING INDEX stable_transactions_offset_idx (offset>?)`.

## Tests

New regression test covering: hit, gap miss, format-1-spanned miss, beyond-end
miss, and an `EXPLAIN QUERY PLAN` assertion (statement loaded via `sql-loader`,
not duplicated) that the plan probes `stable_transactions_offset_idx` and never
scans `stable_transactions` — this specifically catches the partial-index
mismatch, which timing on a small test DB cannot. Full
`standalone-sqlite.test.ts` suite: 69/69 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
