### PR TITLE
fix(store): key chunk metadata cache by full data root (PE-9129)

### DIFF
--- a/src/store/fs-chunk-metadata-store.test.ts
+++ b/src/store/fs-chunk-metadata-store.test.ts
@@ -1,0 +1,165 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { strict as assert } from 'node:assert';
+import {
+  existsSync,
+  mkdtempSync,
+  promises as fsPromises,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, before, beforeEach, describe, it } from 'node:test';
+
+import { fromB64Url, toMsgpack } from '../lib/encoding.js';
+import { FsChunkMetadataStore } from './fs-chunk-metadata-store.js';
+import { ChunkMetadata } from '../types.js';
+import { createTestLogger } from '../../test/test-logger.js';
+
+// Two distinct data roots sharing the same 4-character prefix ('wRq6') —
+// under prefix-only bucketing these collide onto the same metadata slot.
+const DATA_ROOT_A = 'wRq6f05oRupfTW_M5dcYBtwK5P8rSNYu20vC6D_o-M4';
+const DATA_ROOT_B = 'wRq63Q4N4df6jD6pPsS8PBmeGRbQUVwKVS91BB8rR90';
+
+function makeChunkMetadata({
+  dataRoot,
+  offset = 0,
+  dataPathFill = 1,
+}: {
+  dataRoot: string;
+  offset?: number;
+  dataPathFill?: number;
+}): ChunkMetadata {
+  return {
+    data_root: fromB64Url(dataRoot),
+    data_size: 30474,
+    data_path: Buffer.alloc(64, dataPathFill),
+    offset,
+    hash: Buffer.alloc(32, dataPathFill),
+    chunk_size: 30474,
+  };
+}
+
+describe('FsChunkMetadataStore', () => {
+  let log: ReturnType<typeof createTestLogger>;
+  let tempDir: string;
+  let store: FsChunkMetadataStore;
+
+  before(() => {
+    log = createTestLogger({ suite: 'FsChunkMetadataStore' });
+  });
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'fs-chunk-metadata-store-test-'));
+    store = new FsChunkMetadataStore({ log, baseDir: tempDir });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('set and get', () => {
+    it('should round-trip chunk metadata keyed by the full data root', async () => {
+      const metadata = makeChunkMetadata({ dataRoot: DATA_ROOT_A });
+
+      await store.set(metadata);
+
+      const expectedPath = join(
+        tempDir,
+        'wR',
+        'q6',
+        DATA_ROOT_A,
+        'metadata',
+        '0',
+      );
+      assert.ok(existsSync(expectedPath));
+
+      const retrieved = await store.get(DATA_ROOT_A, 0);
+      assert.ok(retrieved !== undefined);
+      assert.ok(retrieved.data_root.equals(metadata.data_root));
+      assert.ok(retrieved.data_path.equals(metadata.data_path));
+      assert.equal(retrieved.data_size, metadata.data_size);
+    });
+
+    it('should not collide for data roots sharing a 4-character prefix', async () => {
+      const metadataA = makeChunkMetadata({
+        dataRoot: DATA_ROOT_A,
+        dataPathFill: 1,
+      });
+      const metadataB = makeChunkMetadata({
+        dataRoot: DATA_ROOT_B,
+        dataPathFill: 2,
+      });
+
+      await store.set(metadataA);
+      await store.set(metadataB);
+
+      const retrievedA = await store.get(DATA_ROOT_A, 0);
+      const retrievedB = await store.get(DATA_ROOT_B, 0);
+
+      assert.ok(retrievedA !== undefined);
+      assert.ok(retrievedB !== undefined);
+      assert.ok(retrievedA.data_root.equals(fromB64Url(DATA_ROOT_A)));
+      assert.ok(retrievedB.data_root.equals(fromB64Url(DATA_ROOT_B)));
+      assert.ok(retrievedA.data_path.equals(Buffer.alloc(64, 1)));
+      assert.ok(retrievedB.data_path.equals(Buffer.alloc(64, 2)));
+    });
+
+    it('should return undefined for a missing entry', async () => {
+      assert.equal(await store.get(DATA_ROOT_A, 0), undefined);
+    });
+  });
+
+  describe('get with mismatched cached data root', () => {
+    it('should treat a foreign entry as a miss and remove it', async () => {
+      // Simulate a poisoned cache entry: metadata for data root B stored
+      // under data root A's path (as prefix-only bucketing used to allow).
+      const foreign = makeChunkMetadata({ dataRoot: DATA_ROOT_B });
+      const poisonedDir = join(tempDir, 'wR', 'q6', DATA_ROOT_A, 'metadata');
+      await fsPromises.mkdir(poisonedDir, { recursive: true });
+      const poisonedPath = join(poisonedDir, '0');
+      await fsPromises.writeFile(poisonedPath, toMsgpack(foreign));
+
+      const retrieved = await store.get(DATA_ROOT_A, 0);
+
+      assert.equal(retrieved, undefined);
+      assert.ok(!existsSync(poisonedPath));
+    });
+  });
+
+  describe('getByAbsoluteOffset', () => {
+    it('should resolve metadata through the absolute offset symlink', async () => {
+      const absoluteOffset = 388149830525175;
+      const metadata = makeChunkMetadata({ dataRoot: DATA_ROOT_A });
+
+      await store.set(metadata, absoluteOffset);
+
+      const retrieved = await store.getByAbsoluteOffset(absoluteOffset);
+      assert.ok(retrieved !== undefined);
+      assert.ok(retrieved.data_root.equals(metadata.data_root));
+    });
+
+    it('should return undefined when no symlink exists', async () => {
+      assert.equal(await store.getByAbsoluteOffset(12345), undefined);
+    });
+  });
+
+  describe('has and del', () => {
+    it('should report presence and support deletion', async () => {
+      const metadata = makeChunkMetadata({ dataRoot: DATA_ROOT_A });
+      await store.set(metadata);
+
+      assert.equal(await store.has(DATA_ROOT_A, 0), true);
+      await store.del(DATA_ROOT_A, 0);
+      assert.equal(await store.has(DATA_ROOT_A, 0), false);
+    });
+
+    it('should not throw when deleting a missing entry', async () => {
+      await assert.doesNotReject(store.del(DATA_ROOT_A, 0));
+    });
+  });
+});

--- a/src/store/fs-chunk-metadata-store.test.ts
+++ b/src/store/fs-chunk-metadata-store.test.ts
@@ -25,6 +25,11 @@ import { createTestLogger } from '../../test/test-logger.js';
 const DATA_ROOT_A = 'wRq6f05oRupfTW_M5dcYBtwK5P8rSNYu20vC6D_o-M4';
 const DATA_ROOT_B = 'wRq63Q4N4df6jD6pPsS8PBmeGRbQUVwKVS91BB8rR90';
 
+/**
+ * Builds a ChunkMetadata fixture for the given data root. `dataPathFill`
+ * seeds the data_path and hash buffers so entries for different data roots
+ * are distinguishable in assertions.
+ */
 function makeChunkMetadata({
   dataRoot,
   offset = 0,
@@ -128,6 +133,21 @@ describe('FsChunkMetadataStore', () => {
 
       assert.equal(retrieved, undefined);
       assert.ok(!existsSync(poisonedPath));
+    });
+
+    it('should discard a corrupt entry missing data_root', async () => {
+      const corruptDir = join(tempDir, 'wR', 'q6', DATA_ROOT_A, 'metadata');
+      await fsPromises.mkdir(corruptDir, { recursive: true });
+      const corruptPath = join(corruptDir, '0');
+      await fsPromises.writeFile(
+        corruptPath,
+        toMsgpack({ unexpected: 'shape' }),
+      );
+
+      const retrieved = await store.get(DATA_ROOT_A, 0);
+
+      assert.equal(retrieved, undefined);
+      assert.ok(!existsSync(corruptPath));
     });
   });
 

--- a/src/store/fs-chunk-metadata-store.ts
+++ b/src/store/fs-chunk-metadata-store.ts
@@ -20,10 +20,14 @@ export class FsChunkMetadataStore implements ChunkMetadataStore {
     this.baseDir = baseDir;
   }
 
-  // The full data root MUST be part of the path (not just its prefix) —
-  // different data roots sharing a 4-character prefix would otherwise share
-  // metadata slots and serve each other's merkle proofs, which fail
-  // validation downstream. Mirrors the FsChunkDataStore by-dataroot layout.
+  /**
+   * Returns the directory that holds cached metadata for a data root.
+   *
+   * The full data root MUST be part of the path (not just its prefix) —
+   * different data roots sharing a 4-character prefix would otherwise share
+   * metadata slots and serve each other's merkle proofs, which fail
+   * validation downstream. Mirrors the FsChunkDataStore by-dataroot layout.
+   */
   private chunkMetadataDir(dataRoot: string) {
     const dataRootPrefix = `${dataRoot.substring(0, 2)}/${dataRoot.substring(
       2,
@@ -68,16 +72,20 @@ export class FsChunkMetadataStore implements ChunkMetadataStore {
           this.chunkMetadataPath(dataRoot, relativeOffset),
         );
         const chunkMetadata = fromMsgpack(msgpack) as ChunkMetadata;
-        // Never serve metadata whose data root doesn't match the request — a
-        // mismatch means the entry is corrupt or was written under another
-        // transaction's key, and its data_path would fail proof validation.
-        // Drop it and treat the read as a miss so it gets refetched.
-        if (toB64Url(chunkMetadata.data_root) !== dataRoot) {
+        // Never serve metadata whose data root is absent or doesn't match the
+        // request — a mismatch means the entry is corrupt or was written
+        // under another transaction's key, and its data_path would fail proof
+        // validation. Drop it and treat the read as a miss so it gets
+        // refetched.
+        const cachedDataRoot = Buffer.isBuffer(chunkMetadata?.data_root)
+          ? toB64Url(chunkMetadata.data_root)
+          : undefined;
+        if (cachedDataRoot !== dataRoot) {
           this.log.warn(
             'Cached chunk metadata data root mismatch, discarding entry',
             {
               dataRoot,
-              cachedDataRoot: toB64Url(chunkMetadata.data_root),
+              cachedDataRoot,
               relativeOffset,
             },
           );

--- a/src/store/fs-chunk-metadata-store.ts
+++ b/src/store/fs-chunk-metadata-store.ts
@@ -20,12 +20,16 @@ export class FsChunkMetadataStore implements ChunkMetadataStore {
     this.baseDir = baseDir;
   }
 
+  // The full data root MUST be part of the path (not just its prefix) —
+  // different data roots sharing a 4-character prefix would otherwise share
+  // metadata slots and serve each other's merkle proofs, which fail
+  // validation downstream. Mirrors the FsChunkDataStore by-dataroot layout.
   private chunkMetadataDir(dataRoot: string) {
     const dataRootPrefix = `${dataRoot.substring(0, 2)}/${dataRoot.substring(
       2,
       4,
     )}`;
-    return `${this.baseDir}/${dataRootPrefix}/metadata/`;
+    return `${this.baseDir}/${dataRootPrefix}/${dataRoot}/metadata`;
   }
 
   private chunkMetadataPath(dataRoot: string, relativeOffset: number) {
@@ -63,7 +67,24 @@ export class FsChunkMetadataStore implements ChunkMetadataStore {
         const msgpack = await fs.promises.readFile(
           this.chunkMetadataPath(dataRoot, relativeOffset),
         );
-        return fromMsgpack(msgpack) as ChunkMetadata;
+        const chunkMetadata = fromMsgpack(msgpack) as ChunkMetadata;
+        // Never serve metadata whose data root doesn't match the request — a
+        // mismatch means the entry is corrupt or was written under another
+        // transaction's key, and its data_path would fail proof validation.
+        // Drop it and treat the read as a miss so it gets refetched.
+        if (toB64Url(chunkMetadata.data_root) !== dataRoot) {
+          this.log.warn(
+            'Cached chunk metadata data root mismatch, discarding entry',
+            {
+              dataRoot,
+              cachedDataRoot: toB64Url(chunkMetadata.data_root),
+              relativeOffset,
+            },
+          );
+          await this.del(dataRoot, relativeOffset);
+          return undefined;
+        }
+        return chunkMetadata;
       }
     } catch (error: any) {
       this.log.error('Failed to fetch chunk data from cache', {


### PR DESCRIPTION
## Summary

`FsChunkMetadataStore` keyed cached chunk metadata by only the first 4 base64url characters of the dataRoot plus the relative offset:

```
<baseDir>/<dataRoot[0:2]>/<dataRoot[2:4]>/metadata/<relativeOffset>
```

The full dataRoot never appeared in the path, so any two transactions whose dataRoots share a 4-character prefix (16.7M buckets vs a cache of ~1M entries per node) shared metadata slots — and relative offset 0 collides constantly because every transaction has a chunk there. The read path did not compare the stored `data_root` against the requested one, so a collision served another transaction's `data_path`, and merkle validation failed with `Failed to parse data_path: invalid proof` **deterministically, on every request**, until the foreign cache entry was removed by hand.

Observed in production on the canary gateways: a ~30 KB single-chunk bundle was permanently unretrievable because its dataRoot shares a 4-character prefix with a ~78 MB transaction cached two days earlier; the cached 928-byte proof was served for the 30 KB transaction's chunk at offset 0. Chunk *data* on disk was byte-identical to the network's (sha256-verified) — only the metadata slot was poisoned. Deleting the colliding file immediately restored retrieval. The chunk data store already avoids this by including the full dataRoot in its `by-dataroot` layout; the metadata store never got the same treatment.

## Changes

- Include the full dataRoot in the chunk metadata path, mirroring `FsChunkDataStore`:
  `<baseDir>/<prefix>/<full dataRoot>/metadata/<relativeOffset>`
- Defense in depth: on read, verify the decoded `data_root` is present and matches the requested dataRoot; on mismatch or a corrupt entry missing `data_root`, log, delete the entry, and treat it as a cache miss so it is refetched.
- Regression tests: prefix-colliding dataRoots round-trip independently; a foreign entry planted at another dataRoot's path is discarded rather than served; absolute-offset symlink resolution still works under the new layout.

## Migration

None required. Entries under the old layout become unreachable orphans; the existing fs cleanup worker (`ENABLE_CHUNK_DATA_CACHE_CLEANUP`, default on) ages them out, and the dead-symlink cleanup worker removes their `by-absolute-offset` links. The metadata cache goes effectively cold once and re-warms from normal retrieval traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
