### PR TITLE
feat(moderation): add unblock-data admin endpoint

### DIFF
--- a/src/database/sql/moderation/block.sql
+++ b/src/database/sql/moderation/block.sql
@@ -26,3 +26,11 @@ ON CONFLICT DO NOTHING
 -- deleteBlockedName
 DELETE FROM blocked_names
 WHERE name = @name;
+
+-- deleteBlockedId
+DELETE FROM blocked_ids
+WHERE id = @id;
+
+-- deleteBlockedHash
+DELETE FROM blocked_hashes
+WHERE hash = @hash;

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -2993,6 +2993,17 @@ export class StandaloneSqliteDatabaseWorker {
     this.stmts.moderation.deleteBlockedName.run({ name });
   }
 
+  unblockData({ id, hash }: { id?: string; hash?: string }) {
+    // Remove both the id- and hash-keyed block if present so content blocked
+    // by either key is fully released. DELETE of a missing row is a no-op.
+    if (id !== undefined) {
+      this.stmts.moderation.deleteBlockedId.run({ id: fromB64Url(id) });
+    }
+    if (hash !== undefined) {
+      this.stmts.moderation.deleteBlockedHash.run({ hash: fromB64Url(hash) });
+    }
+  }
+
   async saveNestedDataId({
     id,
     parentId,
@@ -4119,6 +4130,16 @@ export class StandaloneSqliteDatabase
     return this.queueWrite('moderation', 'unblockName', [{ name }]);
   }
 
+  async unblockData({
+    id,
+    hash,
+  }: {
+    id?: string;
+    hash?: string;
+  }): Promise<void> {
+    return this.queueWrite('moderation', 'unblockData', [{ id, hash }]);
+  }
+
   async saveNestedDataId({
     id,
     parentId,
@@ -4448,6 +4469,10 @@ if (!isMainThread) {
           break;
         case 'unblockName':
           worker.unblockName(args[0]);
+          parentPort?.postMessage(null);
+          break;
+        case 'unblockData':
+          worker.unblockData(args[0]);
           parentPort?.postMessage(null);
           break;
         case 'saveNestedDataId':

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -311,6 +311,21 @@ arIoRouter.put('/ar-io/admin/block-data', express.json(), async (req, res) => {
   }
 });
 
+// Unblock previously blocked data by id or hash
+arIoRouter.put('/ar-io/admin/unblock-data', express.json(), async (req, res) => {
+  try {
+    const { id, hash } = req.body;
+    if (id === undefined && hash === undefined) {
+      res.status(400).send("Must provide 'id' or 'hash'");
+      return;
+    }
+    await system.db.unblockData({ id, hash });
+    res.json({ message: 'Content unblocked' });
+  } catch (error: any) {
+    res.status(500).send(error?.message);
+  }
+});
+
 // Block resolution of ArNS name
 arIoRouter.put('/ar-io/admin/block-name', express.json(), async (req, res) => {
   try {

--- a/src/routes/ar-io.ts
+++ b/src/routes/ar-io.ts
@@ -312,19 +312,30 @@ arIoRouter.put('/ar-io/admin/block-data', express.json(), async (req, res) => {
 });
 
 // Unblock previously blocked data by id or hash
-arIoRouter.put('/ar-io/admin/unblock-data', express.json(), async (req, res) => {
-  try {
-    const { id, hash } = req.body;
-    if (id === undefined && hash === undefined) {
-      res.status(400).send("Must provide 'id' or 'hash'");
-      return;
+arIoRouter.put(
+  '/ar-io/admin/unblock-data',
+  express.json(),
+  async (req, res) => {
+    try {
+      const { id, hash } = req.body;
+      if (id === undefined && hash === undefined) {
+        res.status(400).send("Must provide 'id' or 'hash'");
+        return;
+      }
+      if (
+        (id !== undefined && typeof id !== 'string') ||
+        (hash !== undefined && typeof hash !== 'string')
+      ) {
+        res.status(400).send("'id' and 'hash' must be strings");
+        return;
+      }
+      await system.db.unblockData({ id, hash });
+      res.json({ message: 'Content unblocked' });
+    } catch (error: any) {
+      res.status(500).send(error?.message);
     }
-    await system.db.unblockData({ id, hash });
-    res.json({ message: 'Content unblocked' });
-  } catch (error: any) {
-    res.status(500).send(error?.message);
-  }
-});
+  },
+);
 
 // Block resolution of ArNS name
 arIoRouter.put('/ar-io/admin/block-name', express.json(), async (req, res) => {

--- a/test/end-to-end/moderation.test.ts
+++ b/test/end-to-end/moderation.test.ts
@@ -183,5 +183,63 @@ describe('Moderation', function () {
         `Expected 404 or 451, got ${res.status}`,
       );
     });
+
+    it('Should return unauthorized if the api key is incorrect for /ar-io/admin/unblock-data', async function () {
+      const res = await axios.put(
+        'http://localhost:4000/ar-io/admin/unblock-data',
+        { id: txId },
+        {
+          headers: {
+            Authorization: `Bearer incorrect-api-key`,
+            'Content-Type': 'application/json',
+          },
+          validateStatus: () => true,
+        },
+      );
+      assert.strictEqual(res.status, 401);
+    });
+
+    it('Should unblock a previously blocked transaction', async function () {
+      // Ensure the tx is blocked first.
+      await axios.put(
+        'http://localhost:4000/ar-io/admin/block-data',
+        { id: txId, source: 'Public Block list' },
+        {
+          headers: {
+            Authorization: `Bearer ${adminApiKey}`,
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+
+      const unblockRes = await axios.put(
+        'http://localhost:4000/ar-io/admin/unblock-data',
+        { id: txId },
+        {
+          headers: {
+            Authorization: `Bearer ${adminApiKey}`,
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+      assert.strictEqual(unblockRes.status, 200);
+
+      // wait for the cache to be refreshed
+      await wait(500);
+
+      const res = await axios.get(`http://localhost:4000/${txId}`, {
+        headers: {
+          Host: 'sw3yqmkl5ajki5vl5jflcpqy43opvgtpngs6tel3eltuhq73l2jq.ar-io.localhost',
+        },
+        validateStatus: () => true,
+      });
+      // The block is lifted: the tx is no longer forbidden (may 200 if the
+      // data is available, or 404 if not, but never 451).
+      assert.notStrictEqual(
+        res.status,
+        451,
+        `Expected content to be unblocked (not 451), got ${res.status}`,
+      );
+    });
   });
 });


### PR DESCRIPTION
Content blocked via PUT /ar-io/admin/block-data could not be reversed through the API — moderation had block-data, block-name, and unblock-name, but no unblock-data. Lifting a data block required deleting rows from moderation.db by hand.

Adds PUT /ar-io/admin/unblock-data {id?, hash?}, mirroring unblock-name:
- deleteBlockedId / deleteBlockedHash statements (sql/moderation/block.sql)
- StandaloneSqlite.unblockData worker method + queue wrapper + worker case
- removes both the id- and hash-keyed block when present; deleting a missing row is a no-op (idempotent).

Blocked data is checked per-request (isIdBlocked/isHashBlocked, not cached like names), so an unblock takes effect immediately with no reload. Adds e2e coverage (auth + unblock lifts the 451) in test/end-to-end/moderation.test.ts.


Claude-Session: https://claude.ai/code/session_015da5KpSkqBeC8JvMHDrBJN