### PR TITLE
perf(db): index stable_blocks.block_timestamp to avoid full-table MAX scan (PE-9130)

### DIFF
--- a/migrations/2026.07.17T12.00.00.core.add-stable-blocks-block-timestamp-index.sql
+++ b/migrations/2026.07.17T12.00.00.core.add-stable-blocks-block-timestamp-index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS stable_blocks_block_timestamp_idx
+  ON stable_blocks (block_timestamp);

--- a/migrations/down/2026.07.17T12.00.00.core.add-stable-blocks-block-timestamp-index.sql
+++ b/migrations/down/2026.07.17T12.00.00.core.add-stable-blocks-block-timestamp-index.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS stable_blocks_block_timestamp_idx;

--- a/test/core-schema.sql
+++ b/test/core-schema.sql
@@ -204,3 +204,5 @@ CREATE INDEX new_transactions_owner_address_id_idx ON new_transactions (owner_ad
 CREATE INDEX new_transactions_height_indexed_at_idx ON new_transactions (height, indexed_at);
 CREATE INDEX stable_blocks_weave_size_idx ON stable_blocks (weave_size);
 CREATE INDEX new_blocks_weave_size_idx ON new_blocks (weave_size);
+CREATE INDEX stable_blocks_block_timestamp_idx
+  ON stable_blocks (block_timestamp);


### PR DESCRIPTION
## Summary

`selectMaxStableBlockTimestamp` (`SELECT IFNULL(MAX(block_timestamp), 0) FROM stable_blocks`) has no supporting index, so every call is a full scan of `stable_blocks` — ~2M rows / ~900 MB on a full-history node. It runs on the core read worker during data-item flushes and inline in `saveBlockAndTxs` on the write worker at every stable-flush interval.

When called frequently the scan stays in page cache (~400 ms — already the slowest read on the core worker by ~3 orders of magnitude); when called infrequently the pages are evicted and the scan goes disk-bound. On canary gateways we measured 8–13 s per call in that state, head-of-line blocking all other core reads behind it.

This adds an index on `stable_blocks (block_timestamp)`, turning the query into a covering reverse index seek (verified via `EXPLAIN QUERY PLAN`).

## Cost

- Index size: ~24 MB at current chain height (measured against a production-scale copy); grows ~0.3 MB/month with chain height regardless of operator traffic.
- One-time build for existing operators at next startup (migrations run in the entrypoint): 0.6 s measured warm on a full-history table, ≲15 s worst case cold.
- New operators: built on an empty table, then maintained incrementally — negligible.

## Notes

- Down migration included; round-tripped locally (`db:migrate down` → index gone → `up` → back).
- `test/core-schema.sql` regenerated via `./test/dump-test-schemas`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)