### PR TITLE
perf(root-tx): short-circuit composite lookup on actionable results (PE-9134)

### DIFF
--- a/docs/cdb64.md
+++ b/docs/cdb64.md
@@ -1,24 +1,30 @@
 # CDB64 Root Transaction Index
 
-CDB64 is the AR.IO Gateway's solution for fast, offline lookups of data item to root transaction mappings. It enables O(1) retrieval of nested bundle data without external API dependencies.
+CDB64 is the AR.IO Gateway's solution for fast, offline lookups of data item to
+root transaction mappings. It enables O(1) retrieval of nested bundle data
+without external API dependencies.
 
 ## Why CDB64?
 
-When a client requests a data item nested inside an ANS-104 bundle, the gateway needs to know which root transaction contains it and where within that transaction the data resides. CDB64 indexes provide:
+When a client requests a data item nested inside an ANS-104 bundle, the gateway
+needs to know which root transaction contains it and where within that
+transaction the data resides. CDB64 indexes provide:
 
 - **Instant lookups**: Hash-based O(1) access, no database queries
 - **Offline operation**: No external API calls for indexed items
-- **Flexible deployment**: Local files, HTTP endpoints, or Arweave-stored indexes
+- **Flexible deployment**: Local files, HTTP endpoints, or Arweave-stored
+  indexes
 - **Hot reloading**: Add/remove indexes without gateway restart
-- **Scalability**: Partitioned indexes for datasets exceeding billions of records
+- **Scalability**: Partitioned indexes for datasets exceeding billions of
+  records
 
 ## Documentation
 
-| Document | Audience | Description |
-|----------|----------|-------------|
-| **[Operator Guide](cdb64-guide.md)** | Gateway operators | Configuration, deployment, performance tuning, troubleshooting |
-| **[Tools Reference](cdb64-tools.md)** | Developers | CLI tools for creating and managing CDB64 indexes |
-| **[Format Specification](cdb64-format.md)** | Implementers | Technical specification of the CDB64 file format |
+| Document                                    | Audience          | Description                                                    |
+| ------------------------------------------- | ----------------- | -------------------------------------------------------------- |
+| **[Operator Guide](cdb64-guide.md)**        | Gateway operators | Configuration, deployment, performance tuning, troubleshooting |
+| **[Tools Reference](cdb64-tools.md)**       | Developers        | CLI tools for creating and managing CDB64 indexes              |
+| **[Format Specification](cdb64-format.md)** | Implementers      | Technical specification of the CDB64 file format               |
 
 ## Quick Start
 
@@ -100,12 +106,12 @@ CDB64 root TX index initialized { sourceCount: 1, readerCount: 3, watching: true
 
 Each data item ID maps to information about its location:
 
-| Field | Description |
-|-------|-------------|
-| `rootTxId` | The L1 Arweave transaction containing the data |
-| `rootOffset` | Byte offset of the data item header within the root TX |
-| `rootDataOffset` | Byte offset of the data payload within the root TX |
-| `path` | Bundle traversal path for nested bundles |
+| Field            | Description                                            |
+| ---------------- | ------------------------------------------------------ |
+| `rootTxId`       | The L1 Arweave transaction containing the data         |
+| `rootOffset`     | Byte offset of the data item header within the root TX |
+| `rootDataOffset` | Byte offset of the data payload within the root TX     |
+| `path`           | Bundle traversal path for nested bundles               |
 
 ### Source Priority
 
@@ -118,24 +124,41 @@ CDB64_ROOT_TX_INDEX_SOURCES=/local/indexes/,https://cdn.example.com/index.cdb,Ar
 
 ### Lookup Short-Circuiting
 
-The composite root TX index (`ROOT_TX_LOOKUP_ORDER`) stops probing sources as soon as one returns an **actionable** result, so a CDB64 hit early in the order avoids the remaining (often remote and expensive) sources such as GraphQL. A result is actionable when the caller can proceed without further lookups:
+The composite root TX index (`ROOT_TX_LOOKUP_ORDER`) stops probing sources as
+soon as one returns an **actionable** result, so a CDB64 hit early in the order
+avoids the remaining (often remote and expensive) sources such as GraphQL. A
+result is actionable when the caller can proceed without further lookups:
 
-| Exit reason | Condition | Notes |
-|-------------|-----------|-------|
-| `complete_offsets` | `rootOffset` + `rootDataOffset` + `size` + `dataSize` | Full offsets; no header parse needed |
-| `l1_root` | `rootTxId === id` | Definitive L1 root; passthrough |
-| `offsets` | `rootOffset` + `rootDataOffset` present | The CDB64 case; size is read from the item header |
-| `path` | non-empty `path` | Enables path-guided bundle navigation |
+| Exit reason        | Condition                                             | Notes                                             |
+| ------------------ | ----------------------------------------------------- | ------------------------------------------------- |
+| `complete_offsets` | `rootOffset` + `rootDataOffset` + `size` + `dataSize` | Full offsets; no header parse needed              |
+| `l1_root`          | `rootTxId === id`                                     | Definitive L1 root; passthrough                   |
+| `offsets`          | `rootOffset` + `rootDataOffset` present               | The CDB64 case; size is read from the item header |
+| `path`             | non-empty `path`                                      | Enables path-guided bundle navigation             |
 
-A bare `rootTxId` with no path or offsets is **not** actionable — it is saved as a fallback and the search continues, so a later source (e.g. CDB64) can supply a path or offsets. If no source is actionable, the saved fallback is returned (`fallback`), or `undefined` if nothing resolved (`not_found`).
+A caller may override this decision by passing an `accept` predicate to
+`getRootTx` (short-circuiting on whatever it deems sufficient — e.g. any
+`rootTxId` it will resolve offsets from locally); such short-circuits are
+recorded with the `caller_accept` exit reason.
 
-CDB64 values carry offsets (`rootOffset`/`rootDataOffset`) but not `size`, so CDB64 hits terminate with the `offsets` (or `path`) reason rather than `complete_offsets`.
+A bare `rootTxId` with no path or offsets is **not** actionable — it is saved as
+a fallback and the search continues, so a later source (e.g. CDB64) can supply a
+path or offsets. If no source is actionable, the saved fallback is returned
+(`fallback`), or `undefined` if nothing resolved (`not_found`).
+
+CDB64 values carry offsets (`rootOffset`/`rootDataOffset`) but not `size`, so
+CDB64 hits terminate with the `offsets` (or `path`) reason rather than
+`complete_offsets`.
 
 Observability (per-node Prometheus metrics):
 
-- `composite_root_tx_exit_reason_total{reason,winning_source}` — one increment per lookup, labelled with the exit reason above. A healthy CDB64 deployment shows most CDB64-won lookups exiting on `offsets`/`path`.
-- `composite_root_tx_sources_probed` — summary of how many sources were queried before returning. Effective short-circuiting keeps this low.
-- `root_tx_lookup_total{source="graphql"}` — total GraphQL probes; falls sharply once early local sources (db/cdb) short-circuit.
+- `composite_root_tx_exit_reason_total{reason,winning_source}` — one increment
+  per lookup, labelled with the exit reason above. A healthy CDB64 deployment
+  shows most CDB64-won lookups exiting on `offsets`/`path`.
+- `composite_root_tx_sources_probed` — summary of how many sources were queried
+  before returning. Effective short-circuiting keeps this low.
+- `root_tx_lookup_total{source="graphql"}` — total GraphQL probes; falls sharply
+  once early local sources (db/cdb) short-circuit.
 
 ### Partitioned Indexes
 

--- a/docs/cdb64.md
+++ b/docs/cdb64.md
@@ -135,6 +135,7 @@ result is actionable when the caller can proceed without further lookups:
 | `l1_root`          | `rootTxId === id`                                     | Definitive L1 root; passthrough                   |
 | `offsets`          | `rootOffset` + `rootDataOffset` present               | The CDB64 case; size is read from the item header |
 | `path`             | non-empty `path`                                      | Enables path-guided bundle navigation             |
+| `caller_accept`    | `opts.accept(result) === true`                        | Caller-provided predicate accepted the result     |
 
 A caller may override this decision by passing an `accept` predicate to
 `getRootTx` (short-circuiting on whatever it deems sufficient — e.g. any

--- a/docs/cdb64.md
+++ b/docs/cdb64.md
@@ -116,6 +116,27 @@ Multiple CDB64 sources are searched in configuration order. First match wins:
 CDB64_ROOT_TX_INDEX_SOURCES=/local/indexes/,https://cdn.example.com/index.cdb,ArweaveTxId
 ```
 
+### Lookup Short-Circuiting
+
+The composite root TX index (`ROOT_TX_LOOKUP_ORDER`) stops probing sources as soon as one returns an **actionable** result, so a CDB64 hit early in the order avoids the remaining (often remote and expensive) sources such as GraphQL. A result is actionable when the caller can proceed without further lookups:
+
+| Exit reason | Condition | Notes |
+|-------------|-----------|-------|
+| `complete_offsets` | `rootOffset` + `rootDataOffset` + `size` + `dataSize` | Full offsets; no header parse needed |
+| `l1_root` | `rootTxId === id` | Definitive L1 root; passthrough |
+| `offsets` | `rootOffset` + `rootDataOffset` present | The CDB64 case; size is read from the item header |
+| `path` | non-empty `path` | Enables path-guided bundle navigation |
+
+A bare `rootTxId` with no path or offsets is **not** actionable — it is saved as a fallback and the search continues, so a later source (e.g. CDB64) can supply a path or offsets. If no source is actionable, the saved fallback is returned (`fallback`), or `undefined` if nothing resolved (`not_found`).
+
+CDB64 values carry offsets (`rootOffset`/`rootDataOffset`) but not `size`, so CDB64 hits terminate with the `offsets` (or `path`) reason rather than `complete_offsets`.
+
+Observability (per-node Prometheus metrics):
+
+- `composite_root_tx_exit_reason_total{reason,winning_source}` — one increment per lookup, labelled with the exit reason above. A healthy CDB64 deployment shows most CDB64-won lookups exiting on `offsets`/`path`.
+- `composite_root_tx_sources_probed` — summary of how many sources were queried before returning. Effective short-circuiting keeps this low.
+- `root_tx_lookup_total{source="graphql"}` — total GraphQL probes; falls sharply once early local sources (db/cdb) short-circuit.
+
 ### Partitioned Indexes
 
 For large datasets, indexes can be split into 256 partitions by key prefix:

--- a/src/data/root-parent-data-source.test.ts
+++ b/src/data/root-parent-data-source.test.ts
@@ -17,6 +17,17 @@ import {
   DataItemRootIndex,
 } from '../types.js';
 import { createTestLogger } from '../../test/test-logger.js';
+import * as metrics from '../metrics.js';
+
+// Reads the current value of root_tx_local_resolve_total for a given outcome
+// label so tests can assert the increment (the counter is process-global, so
+// assert deltas rather than absolute values).
+async function readLocalResolve(outcome: string): Promise<number> {
+  const metric = await metrics.rootTxLocalResolveTotal.get();
+  return (
+    metric.values.find((v: any) => v.labels.outcome === outcome)?.value ?? 0
+  );
+}
 
 describe('RootParentDataSource', () => {
   let log: winston.Logger;
@@ -2362,7 +2373,9 @@ describe('RootParentDataSource', () => {
         cached: false,
       }));
 
+      const before = await readLocalResolve('local');
       await rootParentDataSource.getData({ id: dataItemId });
+      assert.strictEqual((await readLocalResolve('local')) - before, 1);
 
       // Exactly one root-tx lookup: the local scan succeeded, so no remote
       // fallback lookup was issued.
@@ -2418,7 +2431,12 @@ describe('RootParentDataSource', () => {
         cached: false,
       }));
 
+      const before = await readLocalResolve('remote_fallback');
       await rootParentDataSource.getData({ id: dataItemId });
+      assert.strictEqual(
+        (await readLocalResolve('remote_fallback')) - before,
+        1,
+      );
 
       // Two lookups: local-first, then the remote fallback after the miss.
       assert.strictEqual(
@@ -2443,6 +2461,102 @@ describe('RootParentDataSource', () => {
           .arguments[1],
         [rootTxId, 'parent-nested'],
       );
+    });
+
+    it('resolves via direct offsets when the fallback lookup has no path', async () => {
+      const dataItemId = 'nested-offsets-item';
+      const rootTxId = 'root-tx-offsets';
+      (ans104OffsetSource as any).getDataItemOffsetWithPath = mock.fn();
+
+      (dataAttributesStore.getDataAttributes as any).mock.mockImplementation(
+        async () => null,
+      );
+      // First lookup: bare rootTxId. Fallback: direct offsets, no path.
+      let call = 0;
+      (dataItemRootTxIndex.getRootTx as any).mock.mockImplementation(
+        async () => {
+          call += 1;
+          return call === 1
+            ? { rootTxId }
+            : {
+                rootTxId,
+                rootOffset: 900,
+                rootDataOffset: 1000,
+                size: 600,
+                dataSize: 500,
+                contentType: 'text/plain',
+              };
+        },
+      );
+      // Local scan misses.
+      (ans104OffsetSource.getDataItemOffset as any).mock.mockImplementation(
+        async () => null,
+      );
+      (dataSource.getData as any).mock.mockImplementation(async () => ({
+        stream: Readable.from([Buffer.from('x')]),
+        size: 500,
+        verified: true,
+        trusted: true,
+        cached: false,
+      }));
+
+      const before = await readLocalResolve('remote_fallback');
+      await rootParentDataSource.getData({ id: dataItemId });
+      assert.strictEqual(
+        (await readLocalResolve('remote_fallback')) - before,
+        1,
+      );
+
+      // Resolved from the fallback's direct offsets — no path navigation.
+      assert.strictEqual(
+        (dataItemRootTxIndex.getRootTx as any).mock.calls.length,
+        2,
+      );
+      assert.strictEqual(
+        (ans104OffsetSource.getDataItemOffsetWithPath as any).mock.calls.length,
+        0,
+      );
+      // Data was served using the recovered offsets (dataOffset 1000).
+      assert.strictEqual(
+        (dataSource.getData as any).mock.calls[0].arguments[0].region.offset,
+        1000,
+      );
+    });
+
+    it('records unresolved when both the local scan and the fallback miss', async () => {
+      const dataItemId = 'truly-missing-item';
+      const rootTxId = 'root-tx-missing';
+      (ans104OffsetSource as any).getDataItemOffsetWithPath = mock.fn();
+
+      (dataAttributesStore.getDataAttributes as any).mock.mockImplementation(
+        async () => null,
+      );
+      // Both lookups return a bare rootTxId (no path/offsets).
+      (dataItemRootTxIndex.getRootTx as any).mock.mockImplementation(
+        async () => ({ rootTxId }),
+      );
+      // Local scan misses; the fallback lookup also yields nothing usable.
+      (ans104OffsetSource.getDataItemOffset as any).mock.mockImplementation(
+        async () => null,
+      );
+
+      const before = await readLocalResolve('unresolved');
+      await assert.rejects(
+        async () => {
+          await rootParentDataSource.getData({ id: dataItemId });
+        },
+        {
+          message: `Data item ${dataItemId} not found in root bundle ${rootTxId}`,
+        },
+      );
+      assert.strictEqual((await readLocalResolve('unresolved')) - before, 1);
+
+      // No path navigation and no data fetch on a genuine miss.
+      assert.strictEqual(
+        (ans104OffsetSource.getDataItemOffsetWithPath as any).mock.calls.length,
+        0,
+      );
+      assert.strictEqual((dataSource.getData as any).mock.calls.length, 0);
     });
   });
 });

--- a/src/data/root-parent-data-source.test.ts
+++ b/src/data/root-parent-data-source.test.ts
@@ -403,9 +403,12 @@ describe('RootParentDataSource', () => {
         },
       );
 
+      // Two root-tx lookups: the local-first lookup (bare rootTxId), then the
+      // remote fallback after the local scan misses — which also can't resolve
+      // it here, so the not-found error is thrown.
       assert.strictEqual(
         (dataItemRootTxIndex.getRootTx as any).mock.calls.length,
-        1,
+        2,
       );
       assert.strictEqual(
         (ans104OffsetSource.getDataItemOffset as any).mock.calls.length,
@@ -2325,6 +2328,120 @@ describe('RootParentDataSource', () => {
       assert.strictEqual(
         (ans104OffsetSource.getDataItemOffset as any).mock.calls.length,
         1,
+      );
+    });
+  });
+
+  describe('local-first offset resolution', () => {
+    it('resolves a bare rootTxId via local scan without a second (remote) lookup', async () => {
+      const dataItemId = 'local-first-item';
+      const rootTxId = 'root-tx-local';
+
+      (dataAttributesStore.getDataAttributes as any).mock.mockImplementation(
+        async () => null,
+      );
+      // Bare rootTxId only (no path/offsets) — the CDB case.
+      (dataItemRootTxIndex.getRootTx as any).mock.mockImplementation(
+        async () => ({ rootTxId }),
+      );
+      // Local header scan resolves it (shallow item).
+      (ans104OffsetSource.getDataItemOffset as any).mock.mockImplementation(
+        async () => ({
+          itemOffset: 900,
+          dataOffset: 1000,
+          itemSize: 600,
+          dataSize: 500,
+          contentType: 'text/plain',
+        }),
+      );
+      (dataSource.getData as any).mock.mockImplementation(async () => ({
+        stream: Readable.from([Buffer.from('x')]),
+        size: 500,
+        verified: true,
+        trusted: true,
+        cached: false,
+      }));
+
+      await rootParentDataSource.getData({ id: dataItemId });
+
+      // Exactly one root-tx lookup: the local scan succeeded, so no remote
+      // fallback lookup was issued.
+      assert.strictEqual(
+        (dataItemRootTxIndex.getRootTx as any).mock.calls.length,
+        1,
+      );
+      // The lookup opted into rootId-only acceptance.
+      const accept = (dataItemRootTxIndex.getRootTx as any).mock.calls[0]
+        .arguments[1]?.accept;
+      assert.strictEqual(typeof accept, 'function');
+      assert.strictEqual(accept({ rootTxId: 'anything' }), true);
+      assert.strictEqual(accept({}), false);
+    });
+
+    it('falls back to a path lookup when the local scan misses', async () => {
+      const dataItemId = 'nested-item';
+      const rootTxId = 'root-tx-nested';
+      (ans104OffsetSource as any).getDataItemOffsetWithPath = mock.fn();
+
+      (dataAttributesStore.getDataAttributes as any).mock.mockImplementation(
+        async () => null,
+      );
+      // First lookup: bare rootTxId. Second lookup (fallback): supplies a path.
+      let call = 0;
+      (dataItemRootTxIndex.getRootTx as any).mock.mockImplementation(
+        async () => {
+          call += 1;
+          return call === 1
+            ? { rootTxId }
+            : { rootTxId, path: [rootTxId, 'parent-nested'] };
+        },
+      );
+      // Local scan misses (nested item).
+      (ans104OffsetSource.getDataItemOffset as any).mock.mockImplementation(
+        async () => null,
+      );
+      // Path-guided navigation resolves it.
+      (
+        ans104OffsetSource.getDataItemOffsetWithPath as any
+      ).mock.mockImplementation(async () => ({
+        itemOffset: 10,
+        dataOffset: 20,
+        itemSize: 60,
+        dataSize: 50,
+        contentType: 'text/plain',
+      }));
+      (dataSource.getData as any).mock.mockImplementation(async () => ({
+        stream: Readable.from([Buffer.from('x')]),
+        size: 50,
+        verified: true,
+        trusted: true,
+        cached: false,
+      }));
+
+      await rootParentDataSource.getData({ id: dataItemId });
+
+      // Two lookups: local-first, then the remote fallback after the miss.
+      assert.strictEqual(
+        (dataItemRootTxIndex.getRootTx as any).mock.calls.length,
+        2,
+      );
+      // The fallback lookup used the default (no accept override).
+      assert.strictEqual(
+        (dataItemRootTxIndex.getRootTx as any).mock.calls[1].arguments[1],
+        undefined,
+      );
+      assert.strictEqual(
+        (ans104OffsetSource.getDataItemOffset as any).mock.calls.length,
+        1,
+      );
+      assert.strictEqual(
+        (ans104OffsetSource.getDataItemOffsetWithPath as any).mock.calls.length,
+        1,
+      );
+      assert.deepStrictEqual(
+        (ans104OffsetSource.getDataItemOffsetWithPath as any).mock.calls[0]
+          .arguments[1],
+        [rootTxId, 'parent-nested'],
       );
     });
   });

--- a/src/data/root-parent-data-source.ts
+++ b/src/data/root-parent-data-source.ts
@@ -19,6 +19,7 @@ import {
 import { startChildSpan } from '../tracing.js';
 import { Ans104OffsetSource } from './ans104-offset-source.js';
 import { MAX_BUNDLE_NESTING_DEPTH } from '../arweave/constants.js';
+import * as metrics from '../metrics.js';
 
 /**
  * Data source that resolves data items to their root bundles before fetching data.
@@ -670,7 +671,14 @@ export class RootParentDataSource implements ContiguousDataSource {
       let rootTxId: string | undefined;
       let rootResult: any;
       try {
-        rootResult = await this.dataItemRootTxIndex.getRootTx(id);
+        // Local-first: accept any result carrying a rootTxId so the lookup
+        // short-circuits on a local source (db/cdb) instead of probing remote
+        // sources (e.g. GraphQL) for a path shortcut. Offsets are resolved
+        // below from the bundle header — bytes we must read to serve the item
+        // anyway — and a path lookup is only issued if that local scan misses.
+        rootResult = await this.dataItemRootTxIndex.getRootTx(id, {
+          accept: (r) => r.rootTxId != null,
+        });
         rootTxId = rootResult?.rootTxId;
         rootTxLookupSpan.setAttributes({
           'root.tx_id': rootTxId ?? 'not_found',
@@ -821,15 +829,66 @@ export class RootParentDataSource implements ContiguousDataSource {
               'offset.path_length': rootResult.path.length,
             });
           } else {
-            // Fallback to linear search when path is not available
+            // No path from the local-first lookup: try a cheap linear scan of
+            // the root bundle header, which resolves shallow items (direct
+            // children of the root bundle) with no remote lookup.
             bundleParseResult = await this.ans104OffsetSource.getDataItemOffset(
               id,
               rootTxId,
               signal,
             );
-            offsetParseSpan.setAttributes({
-              'offset.method': 'linear_search',
-            });
+
+            if (bundleParseResult !== null) {
+              metrics.rootTxLocalResolveTotal.inc({ outcome: 'local' });
+              offsetParseSpan.setAttributes({
+                'offset.method': 'linear_search',
+              });
+            } else {
+              // Local scan missed — the item is nested beyond the root bundle's
+              // direct children. Recover the richer result the local-first
+              // lookup skipped by re-querying with the default actionable
+              // acceptance (which may consult remote sources such as GraphQL),
+              // then retry with its path or direct offsets.
+              const actionable = await this.dataItemRootTxIndex.getRootTx(id);
+              if (actionable?.path && actionable.path.length > 0) {
+                bundleParseResult =
+                  await this.ans104OffsetSource.getDataItemOffsetWithPath(
+                    id,
+                    actionable.path,
+                    signal,
+                  );
+                offsetParseSpan.setAttributes({
+                  'offset.method': 'linear_then_path_fallback',
+                  'offset.path_length': actionable.path.length,
+                });
+              } else if (
+                actionable?.rootOffset !== undefined &&
+                actionable?.rootDataOffset !== undefined &&
+                actionable?.dataSize !== undefined
+              ) {
+                // A source supplied direct offsets (absolute within the root
+                // TX), which serve regardless of nesting.
+                bundleParseResult = {
+                  itemOffset: actionable.rootOffset,
+                  dataOffset: actionable.rootDataOffset,
+                  itemSize: actionable.size ?? actionable.dataSize,
+                  dataSize: actionable.dataSize,
+                  contentType: actionable.contentType,
+                };
+                offsetParseSpan.setAttributes({
+                  'offset.method': 'linear_then_offsets_fallback',
+                });
+              } else {
+                offsetParseSpan.setAttributes({
+                  'offset.method': 'linear_search',
+                });
+              }
+
+              metrics.rootTxLocalResolveTotal.inc({
+                outcome:
+                  bundleParseResult !== null ? 'remote_fallback' : 'unresolved',
+              });
+            }
           }
           offsetParseSpan.setAttributes({
             'offset.found': bundleParseResult !== null,

--- a/src/data/root-parent-data-source.ts
+++ b/src/data/root-parent-data-source.ts
@@ -105,6 +105,85 @@ export class RootParentDataSource implements ContiguousDataSource {
   }
 
   /**
+   * Recovers a data item's offset after the local bundle-header scan missed
+   * (the item is nested beyond the root bundle's direct children). Re-queries
+   * the root index with the default actionable acceptance — which may consult
+   * remote sources such as GraphQL — and derives the offset from its path or
+   * direct offsets. Runs under its own span so this slow path's latency is
+   * visible in traces, separate from the cheap local scan.
+   *
+   * @returns The resolved offset (or `null` if unresolved) and the method used.
+   */
+  private async resolveRemoteFallbackOffset(
+    id: string,
+    parentSpan: Span,
+    signal?: AbortSignal,
+  ): Promise<{
+    result: {
+      itemOffset: number;
+      dataOffset: number;
+      itemSize: number;
+      dataSize: number;
+      contentType?: string;
+    } | null;
+    method:
+      | 'linear_then_path_fallback'
+      | 'linear_then_offsets_fallback'
+      | 'linear_search';
+  }> {
+    const span = startChildSpan(
+      'RootParentDataSource.remoteFallbackOffset',
+      { attributes: { 'data.id': id } },
+      parentSpan,
+    );
+    try {
+      const actionable = await this.dataItemRootTxIndex.getRootTx(id);
+
+      if (actionable?.path && actionable.path.length > 0) {
+        const result = await this.ans104OffsetSource.getDataItemOffsetWithPath(
+          id,
+          actionable.path,
+          signal,
+        );
+        span.setAttributes({
+          'offset.method': 'linear_then_path_fallback',
+          'offset.path_length': actionable.path.length,
+          'offset.found': result !== null,
+        });
+        return { result, method: 'linear_then_path_fallback' };
+      }
+
+      if (
+        actionable?.rootOffset !== undefined &&
+        actionable?.rootDataOffset !== undefined &&
+        actionable?.dataSize !== undefined
+      ) {
+        // Direct offsets are absolute within the root TX, so they serve
+        // regardless of nesting.
+        span.setAttributes({ 'offset.method': 'linear_then_offsets_fallback' });
+        return {
+          result: {
+            itemOffset: actionable.rootOffset,
+            dataOffset: actionable.rootDataOffset,
+            itemSize: actionable.size ?? actionable.dataSize,
+            dataSize: actionable.dataSize,
+            contentType: actionable.contentType,
+          },
+          method: 'linear_then_offsets_fallback',
+        };
+      }
+
+      span.setAttributes({
+        'offset.method': 'linear_search',
+        'offset.found': false,
+      });
+      return { result: null, method: 'linear_search' };
+    } finally {
+      span.end();
+    }
+  }
+
+  /**
    * Attempts to cache data attributes, logging a warning on failure.
    * Never throws — storage failures should not block data retrieval.
    */
@@ -844,46 +923,18 @@ export class RootParentDataSource implements ContiguousDataSource {
                 'offset.method': 'linear_search',
               });
             } else {
-              // Local scan missed — the item is nested beyond the root bundle's
-              // direct children. Recover the richer result the local-first
-              // lookup skipped by re-querying with the default actionable
-              // acceptance (which may consult remote sources such as GraphQL),
-              // then retry with its path or direct offsets.
-              const actionable = await this.dataItemRootTxIndex.getRootTx(id);
-              if (actionable?.path && actionable.path.length > 0) {
-                bundleParseResult =
-                  await this.ans104OffsetSource.getDataItemOffsetWithPath(
-                    id,
-                    actionable.path,
-                    signal,
-                  );
-                offsetParseSpan.setAttributes({
-                  'offset.method': 'linear_then_path_fallback',
-                  'offset.path_length': actionable.path.length,
-                });
-              } else if (
-                actionable?.rootOffset !== undefined &&
-                actionable?.rootDataOffset !== undefined &&
-                actionable?.dataSize !== undefined
-              ) {
-                // A source supplied direct offsets (absolute within the root
-                // TX), which serve regardless of nesting.
-                bundleParseResult = {
-                  itemOffset: actionable.rootOffset,
-                  dataOffset: actionable.rootDataOffset,
-                  itemSize: actionable.size ?? actionable.dataSize,
-                  dataSize: actionable.dataSize,
-                  contentType: actionable.contentType,
-                };
-                offsetParseSpan.setAttributes({
-                  'offset.method': 'linear_then_offsets_fallback',
-                });
-              } else {
-                offsetParseSpan.setAttributes({
-                  'offset.method': 'linear_search',
-                });
-              }
-
+              // Local scan missed — the item is nested beyond the root
+              // bundle's direct children. Recover via a full lookup (which may
+              // consult remote sources such as GraphQL).
+              const fallback = await this.resolveRemoteFallbackOffset(
+                id,
+                span,
+                signal,
+              );
+              bundleParseResult = fallback.result;
+              offsetParseSpan.setAttributes({
+                'offset.method': fallback.method,
+              });
               metrics.rootTxLocalResolveTotal.inc({
                 outcome:
                   bundleParseResult !== null ? 'remote_fallback' : 'unresolved',

--- a/src/discovery/composite-root-tx-index.test.ts
+++ b/src/discovery/composite-root-tx-index.test.ts
@@ -266,4 +266,29 @@ describe('CompositeRootTxIndex', () => {
     assert.equal(db.calls, 1);
     assert.equal(cdb.calls, 1);
   });
+
+  it('propagates exceptions from opts.accept instead of swallowing them as a source error', async () => {
+    const db = makeIndex('StandaloneSqlite', { rootTxId: 'root-9' });
+    const cdb = makeIndex('Cdb64RootTxIndex', { rootTxId: 'root-9' });
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [db, cdb],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    await assert.rejects(
+      () =>
+        composite.getRootTx(ID, {
+          accept: () => {
+            throw new Error('predicate boom');
+          },
+        }),
+      /predicate boom/,
+    );
+    // The predicate throws on db's result; the error must surface immediately,
+    // not be misattributed to db and cause cdb to be probed as a fallback.
+    assert.equal(db.calls, 1);
+    assert.equal(cdb.calls, 0);
+  });
 });

--- a/src/discovery/composite-root-tx-index.test.ts
+++ b/src/discovery/composite-root-tx-index.test.ts
@@ -25,9 +25,14 @@ const stableBreakerOptions = {
   rollingCountTimeout: 5000,
 };
 
-// Builds a DataItemRootIndex stub with a distinct constructor name (the
-// composite keys its per-source circuit breakers on constructor.name, so each
-// source must be uniquely named) and a call counter.
+/**
+ * Builds a `DataItemRootIndex` stub with a distinct constructor name and a call
+ * counter. The composite keys its per-source circuit breakers on
+ * `constructor.name`, so each stub must be uniquely named to avoid collisions.
+ *
+ * @param name - unique class name for the stub (drives the breaker key).
+ * @param result - the value (or async factory) returned by `getRootTx`.
+ */
 function makeIndex(
   name: string,
   result: RootTxResult | (() => Promise<RootTxResult>),

--- a/src/discovery/composite-root-tx-index.test.ts
+++ b/src/discovery/composite-root-tx-index.test.ts
@@ -1,0 +1,190 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { CompositeRootTxIndex } from './composite-root-tx-index.js';
+import { DataItemRootIndex } from '../types.js';
+import { createTestLogger } from '../../test/test-logger.js';
+
+const log = createTestLogger({ suite: 'CompositeRootTxIndex' });
+
+type RootTxResult = Awaited<ReturnType<DataItemRootIndex['getRootTx']>>;
+
+// Circuit-breaker options that never trip and never time out so tests exercise
+// only the composite's own control flow.
+const stableBreakerOptions = {
+  timeout: 5000,
+  errorThresholdPercentage: 100,
+  resetTimeout: 1000,
+  rollingCountTimeout: 5000,
+};
+
+// Builds a DataItemRootIndex stub with a distinct constructor name (the
+// composite keys its per-source circuit breakers on constructor.name, so each
+// source must be uniquely named) and a call counter.
+function makeIndex(
+  name: string,
+  result: RootTxResult | (() => Promise<RootTxResult>),
+): DataItemRootIndex & { calls: number } {
+  const holder = {
+    [name]: class {
+      calls = 0;
+      async getRootTx(): Promise<RootTxResult> {
+        this.calls++;
+        return typeof result === 'function' ? result() : result;
+      }
+    },
+  };
+  return new holder[name]() as DataItemRootIndex & { calls: number };
+}
+
+const ID = 'a'.repeat(43); // stand-in data item / tx id
+
+describe('CompositeRootTxIndex', () => {
+  it('short-circuits on complete offsets without probing later sources', async () => {
+    const first = makeIndex('TurboRootTxIndex', {
+      rootTxId: 'root-1',
+      rootOffset: 10,
+      rootDataOffset: 20,
+      size: 100,
+      dataSize: 90,
+    });
+    const second = makeIndex('GraphQLRootTxIndex', { rootTxId: 'should-not' });
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [first, second],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    const result = await composite.getRootTx(ID);
+    assert.equal(result?.rootTxId, 'root-1');
+    assert.equal(first.calls, 1);
+    assert.equal(second.calls, 0, 'later source must not be probed');
+  });
+
+  it('short-circuits on a CDB-style result (offsets but no size)', async () => {
+    // This is the regression this change targets: prior to the fix a size-less
+    // offset result did not satisfy the gate, so GraphQL was probed anyway.
+    const cdb = makeIndex('Cdb64RootTxIndex', {
+      rootTxId: 'root-2',
+      rootOffset: 10,
+      rootDataOffset: 20,
+    });
+    const graphql = makeIndex('GraphQLRootTxIndex', {
+      rootTxId: 'root-2',
+      dataSize: 90,
+    });
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [cdb, graphql],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    const result = await composite.getRootTx(ID);
+    assert.equal(result?.rootTxId, 'root-2');
+    assert.equal(result?.rootOffset, 10);
+    assert.equal(
+      graphql.calls,
+      0,
+      'GraphQL must not be probed after a CDB hit',
+    );
+  });
+
+  it('short-circuits on a definitive L1 root (rootTxId === id)', async () => {
+    const db = makeIndex('StandaloneSqlite', { rootTxId: ID });
+    const graphql = makeIndex('GraphQLRootTxIndex', { rootTxId: ID });
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [db, graphql],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    const result = await composite.getRootTx(ID);
+    assert.equal(result?.rootTxId, ID);
+    assert.equal(graphql.calls, 0, 'L1 root is authoritative; stop probing');
+  });
+
+  it('short-circuits on a path-only result', async () => {
+    const cdb = makeIndex('Cdb64RootTxIndex', {
+      rootTxId: 'root-3',
+      path: ['root-3', 'parent-3'],
+    });
+    const graphql = makeIndex('GraphQLRootTxIndex', { rootTxId: 'root-3' });
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [cdb, graphql],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    const result = await composite.getRootTx(ID);
+    assert.deepEqual(result?.path, ['root-3', 'parent-3']);
+    assert.equal(graphql.calls, 0);
+  });
+
+  it('keeps probing past a bare rootTxId and prefers a later actionable result', async () => {
+    // db returns a thin result (nested item, no path/offsets) -> not actionable.
+    const db = makeIndex('StandaloneSqlite', { rootTxId: 'root-4' });
+    const cdb = makeIndex('Cdb64RootTxIndex', {
+      rootTxId: 'root-4',
+      rootOffset: 5,
+      rootDataOffset: 15,
+    });
+    const graphql = makeIndex('GraphQLRootTxIndex', { rootTxId: 'root-4' });
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [db, cdb, graphql],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    const result = await composite.getRootTx(ID);
+    assert.equal(db.calls, 1);
+    assert.equal(cdb.calls, 1);
+    assert.equal(result?.rootOffset, 5, 'should return the richer CDB result');
+    assert.equal(graphql.calls, 0, 'CDB was actionable; GraphQL not probed');
+  });
+
+  it('returns the saved fallback when no source is actionable', async () => {
+    const db = makeIndex('StandaloneSqlite', { rootTxId: 'root-5' }); // bare
+    const graphql = makeIndex('GraphQLRootTxIndex', undefined); // miss
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [db, graphql],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    const result = await composite.getRootTx(ID);
+    assert.equal(
+      result?.rootTxId,
+      'root-5',
+      'bare rootTxId returned as fallback',
+    );
+    assert.equal(db.calls, 1);
+    assert.equal(graphql.calls, 1, 'no actionable hit; full chain is probed');
+  });
+
+  it('returns undefined when every source misses', async () => {
+    const db = makeIndex('StandaloneSqlite', undefined);
+    const cdb = makeIndex('Cdb64RootTxIndex', undefined);
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [db, cdb],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    const result = await composite.getRootTx(ID);
+    assert.equal(result, undefined);
+  });
+});

--- a/src/discovery/composite-root-tx-index.test.ts
+++ b/src/discovery/composite-root-tx-index.test.ts
@@ -192,4 +192,78 @@ describe('CompositeRootTxIndex', () => {
     const result = await composite.getRootTx(ID);
     assert.equal(result, undefined);
   });
+
+  it('opts.accept short-circuits on a bare rootTxId the default would reject', async () => {
+    // db misses; cdb returns a bare rootTxId (no path/offsets, not an L1 root).
+    // Default acceptance would keep probing GraphQL; a rootTxId-only predicate
+    // stops at cdb.
+    const db = makeIndex('StandaloneSqlite', undefined);
+    const cdb = makeIndex('Cdb64RootTxIndex', { rootTxId: 'root-6' });
+    const graphql = makeIndex('GraphQLRootTxIndex', {
+      rootTxId: 'root-6',
+      path: ['root-6', 'parent-6'],
+    });
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [db, cdb, graphql],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    const result = await composite.getRootTx(ID, {
+      accept: (r) => r.rootTxId !== undefined,
+    });
+    assert.equal(result?.rootTxId, 'root-6');
+    assert.equal(cdb.calls, 1);
+    assert.equal(
+      graphql.calls,
+      0,
+      'predicate satisfied at cdb; GraphQL skipped',
+    );
+  });
+
+  it('opts.accept returning false keeps probing until satisfied', async () => {
+    // A stricter predicate (require a path) rejects the bare db/cdb results and
+    // forces the search to reach GraphQL, which supplies the path.
+    const db = makeIndex('StandaloneSqlite', { rootTxId: 'root-7' });
+    const cdb = makeIndex('Cdb64RootTxIndex', { rootTxId: 'root-7' });
+    const graphql = makeIndex('GraphQLRootTxIndex', {
+      rootTxId: 'root-7',
+      path: ['root-7', 'parent-7'],
+    });
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [db, cdb, graphql],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    const result = await composite.getRootTx(ID, {
+      accept: (r) => (r.path?.length ?? 0) > 0,
+    });
+    assert.deepEqual(result?.path, ['root-7', 'parent-7']);
+    assert.equal(db.calls, 1);
+    assert.equal(cdb.calls, 1);
+    assert.equal(graphql.calls, 1);
+  });
+
+  it('opts.accept falls back to the first result when nothing is accepted', async () => {
+    // No source satisfies the predicate -> the saved fallback (first result) is
+    // returned, matching default fallback semantics.
+    const db = makeIndex('StandaloneSqlite', { rootTxId: 'root-8' });
+    const cdb = makeIndex('Cdb64RootTxIndex', { rootTxId: 'root-8' });
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [db, cdb],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    const result = await composite.getRootTx(ID, {
+      accept: (r) => (r.path?.length ?? 0) > 0,
+    });
+    assert.equal(result?.rootTxId, 'root-8');
+    assert.equal(db.calls, 1);
+    assert.equal(cdb.calls, 1);
+  });
 });

--- a/src/discovery/composite-root-tx-index.ts
+++ b/src/discovery/composite-root-tx-index.ts
@@ -97,6 +97,22 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
     }
   }
 
+  /**
+   * Resolves a data item ID to its root transaction, probing the configured
+   * indexes in order and returning the first *actionable* result — one the
+   * caller can proceed on without consulting the remaining (often remote and
+   * expensive) sources. A result is actionable when it has complete offsets,
+   * is a definitive L1 root (`rootTxId === id`), carries `rootOffset` +
+   * `rootDataOffset`, or carries a non-empty traversal path.
+   *
+   * A bare `rootTxId` (no path/offsets, not an L1 root) is not actionable: it
+   * is retained as a fallback while later indexes are probed for something
+   * richer. If no source is actionable, the saved fallback is returned, or
+   * `undefined` when nothing resolved.
+   *
+   * @param id - base64url data item / transaction ID to resolve.
+   * @returns The root transaction info, or `undefined` if unresolved.
+   */
   async getRootTx(id: string): Promise<
     | {
         rootTxId: string;

--- a/src/discovery/composite-root-tx-index.ts
+++ b/src/discovery/composite-root-tx-index.ts
@@ -6,7 +6,11 @@
  */
 import winston from 'winston';
 import CircuitBreaker from 'opossum';
-import { DataItemRootIndex, GetRootTxOptions } from '../types.js';
+import {
+  DataItemRootIndex,
+  GetRootTxOptions,
+  RootTxLookupResult,
+} from '../types.js';
 import * as config from '../config.js';
 import * as metrics from '../metrics.js';
 
@@ -180,6 +184,7 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
       }
 
       const lookupStartTime = Date.now();
+      let result: RootTxLookupResult | undefined;
       try {
         log.debug('Trying index', {
           indexNumber: i + 1,
@@ -190,121 +195,7 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
 
         // Execute with circuit breaker protection
         probedCount++;
-        const result = await circuitBreaker.fire(id);
-        const lookupDuration = Date.now() - lookupStartTime;
-        metrics.rootTxLookupDurationSummary.observe(
-          { source: sourceName },
-          lookupDuration,
-        );
-
-        if (result !== undefined) {
-          // Check if result has complete offset information
-          const hasCompleteOffsets =
-            result.rootOffset !== undefined &&
-            result.rootDataOffset !== undefined &&
-            result.size !== undefined &&
-            result.dataSize !== undefined;
-
-          metrics.rootTxLookupTotal.inc({
-            source: sourceName,
-            status: 'found',
-            has_offsets: hasCompleteOffsets ? 'true' : 'false',
-          });
-
-          // Decide whether this result is sufficient to stop the search.
-          //
-          // When the caller supplies opts.accept, it fully governs the
-          // decision (exit reason `caller_accept`) — e.g. "any rootTxId is
-          // enough, I'll resolve offsets locally" avoids probing remote
-          // sources. Otherwise the default "actionable" acceptance applies:
-          // requiring all four offset fields (hasCompleteOffsets) is too
-          // strict — no locally-configured source (db, cdb) ever supplies
-          // `size`, so the search never short-circuited and every lookup fell
-          // through to the expensive downstream sources (e.g. GraphQL) even
-          // when db/cdb had already answered. A result is actionable when the
-          // caller can proceed without probing the remaining sources:
-          //   - complete_offsets: full offsets + size (skip even a header parse)
-          //   - l1_root: rootTxId === id, a definitive L1 root (passthrough)
-          //   - offsets: rootOffset + rootDataOffset present (serve via a cheap
-          //     header parse for size; the CDB case)
-          //   - path: a bundle traversal path (path-guided navigation)
-          let exitReason:
-            | 'complete_offsets'
-            | 'l1_root'
-            | 'offsets'
-            | 'path'
-            | 'caller_accept'
-            | undefined;
-          if (opts?.accept !== undefined) {
-            if (opts.accept(result)) {
-              exitReason = 'caller_accept';
-            }
-          } else if (hasCompleteOffsets) {
-            exitReason = 'complete_offsets';
-          } else if (result.rootTxId === id) {
-            exitReason = 'l1_root';
-          } else if (
-            result.rootOffset !== undefined &&
-            result.rootDataOffset !== undefined
-          ) {
-            exitReason = 'offsets';
-          } else if (result.path !== undefined && result.path.length > 0) {
-            exitReason = 'path';
-          }
-
-          if (exitReason !== undefined) {
-            winningSourceName = sourceName;
-            log.debug('Found actionable root TX result, short-circuiting', {
-              rootTxId: result.rootTxId,
-              indexNumber: i + 1,
-              indexClass: indexName,
-              exitReason,
-              sourcesProbed: probedCount,
-              sourcesSkipped: this.indexes.length - i - 1,
-            });
-
-            metrics.compositeRootTxLookupTotal.inc({
-              status: 'found',
-              winning_source: winningSourceName,
-              has_complete_offsets: hasCompleteOffsets ? 'true' : 'false',
-            });
-            metrics.compositeRootTxExitReasonTotal.inc({
-              reason: exitReason,
-              winning_source: winningSourceName,
-            });
-            metrics.compositeRootTxSourcesProbedSummary.observe(probedCount);
-            metrics.compositeRootTxLookupDurationSummary.observe(
-              Date.now() - compositeStartTime,
-            );
-
-            return result;
-          }
-
-          // Not actionable (bare rootTxId: no path, no offsets, not an L1 root).
-          // Save as a fallback and keep probing for something better.
-          if (fallbackResult === undefined) {
-            fallbackResult = result;
-            fallbackSourceName = sourceName;
-            log.debug(
-              'Found root TX ID but not actionable, saving as fallback',
-              {
-                rootTxId: result.rootTxId,
-                indexNumber: i + 1,
-                indexClass: indexName,
-              },
-            );
-          }
-        } else {
-          metrics.rootTxLookupTotal.inc({
-            source: sourceName,
-            status: 'not_found',
-            has_offsets: 'false',
-          });
-          log.debug('Index returned undefined', {
-            indexNumber: i + 1,
-            indexClass: indexName,
-          });
-        }
+        result = await circuitBreaker.fire(id);
       } catch (error: any) {
         const lookupDuration = Date.now() - lookupStartTime;
         metrics.rootTxLookupDurationSummary.observe(
@@ -323,6 +214,124 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
           circuitState: circuitBreaker.opened ? 'OPEN' : 'CLOSED',
         });
         // Continue to next index
+        continue;
+      }
+
+      // Result classification runs OUTSIDE the source-lookup try/catch above so
+      // that an exception thrown by a caller-supplied opts.accept predicate
+      // propagates to the caller instead of being misattributed as a source
+      // failure — which would swallow the bug and silently return a fallback or
+      // later result.
+      const lookupDuration = Date.now() - lookupStartTime;
+      metrics.rootTxLookupDurationSummary.observe(
+        { source: sourceName },
+        lookupDuration,
+      );
+
+      if (result !== undefined) {
+        // Check if result has complete offset information
+        const hasCompleteOffsets =
+          result.rootOffset !== undefined &&
+          result.rootDataOffset !== undefined &&
+          result.size !== undefined &&
+          result.dataSize !== undefined;
+
+        metrics.rootTxLookupTotal.inc({
+          source: sourceName,
+          status: 'found',
+          has_offsets: hasCompleteOffsets ? 'true' : 'false',
+        });
+
+        // Decide whether this result is sufficient to stop the search.
+        //
+        // When the caller supplies opts.accept, it fully governs the decision
+        // (exit reason `caller_accept`) — e.g. "any rootTxId is enough, I'll
+        // resolve offsets locally" avoids probing remote sources. Otherwise the
+        // default "actionable" acceptance applies: requiring all four offset
+        // fields (hasCompleteOffsets) is too strict — no locally-configured
+        // source (db, cdb) ever supplies `size`, so the search never
+        // short-circuited and every lookup fell through to the expensive
+        // downstream sources (e.g. GraphQL) even when db/cdb had already
+        // answered. A result is actionable when the caller can proceed without
+        // probing the remaining sources:
+        //   - complete_offsets: full offsets + size (skip even a header parse)
+        //   - l1_root: rootTxId === id, a definitive L1 root (passthrough)
+        //   - offsets: rootOffset + rootDataOffset present (serve via a cheap
+        //     header parse for size; the CDB case)
+        //   - path: a bundle traversal path (path-guided navigation)
+        let exitReason:
+          | 'complete_offsets'
+          | 'l1_root'
+          | 'offsets'
+          | 'path'
+          | 'caller_accept'
+          | undefined;
+        if (opts?.accept !== undefined) {
+          if (opts.accept(result)) {
+            exitReason = 'caller_accept';
+          }
+        } else if (hasCompleteOffsets) {
+          exitReason = 'complete_offsets';
+        } else if (result.rootTxId === id) {
+          exitReason = 'l1_root';
+        } else if (
+          result.rootOffset !== undefined &&
+          result.rootDataOffset !== undefined
+        ) {
+          exitReason = 'offsets';
+        } else if (result.path !== undefined && result.path.length > 0) {
+          exitReason = 'path';
+        }
+
+        if (exitReason !== undefined) {
+          winningSourceName = sourceName;
+          log.debug('Found actionable root TX result, short-circuiting', {
+            rootTxId: result.rootTxId,
+            indexNumber: i + 1,
+            indexClass: indexName,
+            exitReason,
+            sourcesProbed: probedCount,
+            sourcesSkipped: this.indexes.length - i - 1,
+          });
+
+          metrics.compositeRootTxLookupTotal.inc({
+            status: 'found',
+            winning_source: winningSourceName,
+            has_complete_offsets: hasCompleteOffsets ? 'true' : 'false',
+          });
+          metrics.compositeRootTxExitReasonTotal.inc({
+            reason: exitReason,
+            winning_source: winningSourceName,
+          });
+          metrics.compositeRootTxSourcesProbedSummary.observe(probedCount);
+          metrics.compositeRootTxLookupDurationSummary.observe(
+            Date.now() - compositeStartTime,
+          );
+
+          return result;
+        }
+
+        // Not actionable (bare rootTxId: no path, no offsets, not an L1 root).
+        // Save as a fallback and keep probing for something better.
+        if (fallbackResult === undefined) {
+          fallbackResult = result;
+          fallbackSourceName = sourceName;
+          log.debug('Found root TX ID but not actionable, saving as fallback', {
+            rootTxId: result.rootTxId,
+            indexNumber: i + 1,
+            indexClass: indexName,
+          });
+        }
+      } else {
+        metrics.rootTxLookupTotal.inc({
+          source: sourceName,
+          status: 'not_found',
+          has_offsets: 'false',
+        });
+        log.debug('Index returned undefined', {
+          indexNumber: i + 1,
+          indexClass: indexName,
+        });
       }
     }
 

--- a/src/discovery/composite-root-tx-index.ts
+++ b/src/discovery/composite-root-tx-index.ts
@@ -126,6 +126,10 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
       | undefined;
     let fallbackSourceName: string | undefined;
     let winningSourceName: string | undefined;
+    // Number of sources actually queried (circuit-open sources are skipped and
+    // do not count). Emitted so we can measure how much of the chain a
+    // short-circuit avoids.
+    let probedCount = 0;
 
     for (let i = 0; i < this.indexes.length; i++) {
       const index = this.indexes[i];
@@ -158,6 +162,7 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
         });
 
         // Execute with circuit breaker protection
+        probedCount++;
         const result = await circuitBreaker.fire(id);
         const lookupDuration = Date.now() - lookupStartTime;
         metrics.rootTxLookupDurationSummary.observe(
@@ -167,7 +172,6 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
 
         if (result !== undefined) {
           // Check if result has complete offset information
-          // If offsets are missing, try next index (e.g., Turbo) for complete data
           const hasCompleteOffsets =
             result.rootOffset !== undefined &&
             result.rootDataOffset !== undefined &&
@@ -180,44 +184,78 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
             has_offsets: hasCompleteOffsets ? 'true' : 'false',
           });
 
+          // Decide whether this result is actionable enough to stop the search.
+          // Requiring all four offset fields (hasCompleteOffsets) is too strict:
+          // no locally-configured source (db, cdb) ever supplies `size`, so the
+          // search never short-circuited and every lookup fell through to the
+          // expensive downstream sources (e.g. GraphQL) even when db/cdb had
+          // already answered. A result is actionable when the caller can proceed
+          // without probing the remaining sources:
+          //   - complete_offsets: full offsets + size (skip even a header parse)
+          //   - l1_root: rootTxId === id, a definitive L1 root (passthrough)
+          //   - offsets: rootOffset + rootDataOffset present (serve via a cheap
+          //     header parse for size; the CDB case)
+          //   - path: a bundle traversal path (path-guided navigation)
+          let exitReason:
+            | 'complete_offsets'
+            | 'l1_root'
+            | 'offsets'
+            | 'path'
+            | undefined;
           if (hasCompleteOffsets) {
-            log.debug('Found root TX ID with complete offsets', {
+            exitReason = 'complete_offsets';
+          } else if (result.rootTxId === id) {
+            exitReason = 'l1_root';
+          } else if (
+            result.rootOffset !== undefined &&
+            result.rootDataOffset !== undefined
+          ) {
+            exitReason = 'offsets';
+          } else if (result.path !== undefined && result.path.length > 0) {
+            exitReason = 'path';
+          }
+
+          if (exitReason !== undefined) {
+            winningSourceName = sourceName;
+            log.debug('Found actionable root TX result, short-circuiting', {
               rootTxId: result.rootTxId,
               indexNumber: i + 1,
               indexClass: indexName,
+              exitReason,
+              sourcesProbed: probedCount,
+              sourcesSkipped: this.indexes.length - i - 1,
             });
-            winningSourceName = sourceName;
 
-            // Record composite lookup metrics
             metrics.compositeRootTxLookupTotal.inc({
               status: 'found',
               winning_source: winningSourceName,
-              has_complete_offsets: 'true',
+              has_complete_offsets: hasCompleteOffsets ? 'true' : 'false',
             });
+            metrics.compositeRootTxExitReasonTotal.inc({
+              reason: exitReason,
+              winning_source: winningSourceName,
+            });
+            metrics.compositeRootTxSourcesProbedSummary.observe(probedCount);
             metrics.compositeRootTxLookupDurationSummary.observe(
               Date.now() - compositeStartTime,
             );
 
             return result;
-          } else {
-            // Save as fallback if we don't have one yet
-            if (fallbackResult === undefined) {
-              fallbackResult = result;
-              fallbackSourceName = sourceName;
-              log.debug(
-                'Found root TX ID but missing offsets, saving as fallback',
-                {
-                  rootTxId: result.rootTxId,
-                  indexNumber: i + 1,
-                  indexClass: indexName,
-                  hasRootOffset: result.rootOffset !== undefined,
-                  hasRootDataOffset: result.rootDataOffset !== undefined,
-                  hasSize: result.size !== undefined,
-                  hasDataSize: result.dataSize !== undefined,
-                },
-              );
-            }
-            // Continue to next index for complete data
+          }
+
+          // Not actionable (bare rootTxId: no path, no offsets, not an L1 root).
+          // Save as a fallback and keep probing for something better.
+          if (fallbackResult === undefined) {
+            fallbackResult = result;
+            fallbackSourceName = sourceName;
+            log.debug(
+              'Found root TX ID but not actionable, saving as fallback',
+              {
+                rootTxId: result.rootTxId,
+                indexNumber: i + 1,
+                indexClass: indexName,
+              },
+            );
           }
         } else {
           metrics.rootTxLookupTotal.inc({
@@ -266,6 +304,11 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
         winning_source: fallbackSourceName ?? 'fallback',
         has_complete_offsets: 'false',
       });
+      metrics.compositeRootTxExitReasonTotal.inc({
+        reason: 'fallback',
+        winning_source: fallbackSourceName ?? 'fallback',
+      });
+      metrics.compositeRootTxSourcesProbedSummary.observe(probedCount);
       metrics.compositeRootTxLookupDurationSummary.observe(
         Date.now() - compositeStartTime,
       );
@@ -284,6 +327,11 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
       winning_source: 'none',
       has_complete_offsets: 'false',
     });
+    metrics.compositeRootTxExitReasonTotal.inc({
+      reason: 'not_found',
+      winning_source: 'none',
+    });
+    metrics.compositeRootTxSourcesProbedSummary.observe(probedCount);
     metrics.compositeRootTxLookupDurationSummary.observe(
       Date.now() - compositeStartTime,
     );

--- a/src/discovery/composite-root-tx-index.ts
+++ b/src/discovery/composite-root-tx-index.ts
@@ -6,7 +6,7 @@
  */
 import winston from 'winston';
 import CircuitBreaker from 'opossum';
-import { DataItemRootIndex } from '../types.js';
+import { DataItemRootIndex, GetRootTxOptions } from '../types.js';
 import * as config from '../config.js';
 import * as metrics from '../metrics.js';
 
@@ -110,10 +110,21 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
    * richer. If no source is actionable, the saved fallback is returned, or
    * `undefined` when nothing resolved.
    *
+   * Callers can override the acceptance decision via `opts.accept` — a
+   * predicate that returns `true` to short-circuit on a given result. This
+   * lets a caller that only needs (say) a `rootTxId` stop as soon as any
+   * source supplies one, rather than probing remote sources for richer
+   * metadata it will derive locally. When omitted, the default actionable
+   * acceptance above applies.
+   *
    * @param id - base64url data item / transaction ID to resolve.
+   * @param opts - optional lookup options; see {@link GetRootTxOptions}.
    * @returns The root transaction info, or `undefined` if unresolved.
    */
-  async getRootTx(id: string): Promise<
+  async getRootTx(
+    id: string,
+    opts?: GetRootTxOptions,
+  ): Promise<
     | {
         rootTxId: string;
         path?: string[];
@@ -200,13 +211,18 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
             has_offsets: hasCompleteOffsets ? 'true' : 'false',
           });
 
-          // Decide whether this result is actionable enough to stop the search.
-          // Requiring all four offset fields (hasCompleteOffsets) is too strict:
-          // no locally-configured source (db, cdb) ever supplies `size`, so the
-          // search never short-circuited and every lookup fell through to the
-          // expensive downstream sources (e.g. GraphQL) even when db/cdb had
-          // already answered. A result is actionable when the caller can proceed
-          // without probing the remaining sources:
+          // Decide whether this result is sufficient to stop the search.
+          //
+          // When the caller supplies opts.accept, it fully governs the
+          // decision (exit reason `caller_accept`) — e.g. "any rootTxId is
+          // enough, I'll resolve offsets locally" avoids probing remote
+          // sources. Otherwise the default "actionable" acceptance applies:
+          // requiring all four offset fields (hasCompleteOffsets) is too
+          // strict — no locally-configured source (db, cdb) ever supplies
+          // `size`, so the search never short-circuited and every lookup fell
+          // through to the expensive downstream sources (e.g. GraphQL) even
+          // when db/cdb had already answered. A result is actionable when the
+          // caller can proceed without probing the remaining sources:
           //   - complete_offsets: full offsets + size (skip even a header parse)
           //   - l1_root: rootTxId === id, a definitive L1 root (passthrough)
           //   - offsets: rootOffset + rootDataOffset present (serve via a cheap
@@ -217,8 +233,13 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
             | 'l1_root'
             | 'offsets'
             | 'path'
+            | 'caller_accept'
             | undefined;
-          if (hasCompleteOffsets) {
+          if (opts?.accept !== undefined) {
+            if (opts.accept(result)) {
+              exitReason = 'caller_accept';
+            }
+          } else if (hasCompleteOffsets) {
             exitReason = 'complete_offsets';
           } else if (result.rootTxId === id) {
             exitReason = 'l1_root';

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1466,16 +1466,9 @@ export const compositeRootTxSourcesProbedSummary = new promClient.Summary({
   help: 'Number of sources queried per composite root TX lookup before returning',
 });
 
-// Outcome of the local-first data item offset resolution in RootParentDataSource
-// (only counted for bare-rootTxId results, where the optimization applies):
-//   - local: resolved to an offset by a local bundle-header scan, avoiding a
-//     remote path/offsets lookup (e.g. GraphQL)
-//   - remote_fallback: the local scan missed (nested item) and a full lookup
-//     (possibly remote) recovered a path or direct offsets
-//   - unresolved: neither the local scan nor the fallback lookup found the item
 export const rootTxLocalResolveTotal = new promClient.Counter({
   name: 'root_tx_local_resolve_total',
-  help: 'Outcome of local-first data item offset resolution by RootParentDataSource',
+  help: 'Outcome of RootParentDataSource local-first offset resolution for bare-rootTxId results: local (resolved by a local bundle-header scan, remote lookup avoided), remote_fallback (local scan missed and a full lookup recovered a path or direct offsets), or unresolved (neither found the item)',
   labelNames: ['outcome'] as const,
 });
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1448,6 +1448,24 @@ export const compositeRootTxLookupDurationSummary = new promClient.Summary({
   help: 'Total duration of composite root TX lookups',
 });
 
+// Records why the composite stopped probing: which condition let it return
+// early ('complete_offsets', 'l1_root', 'offsets', 'path') vs. exhausting the
+// chain ('fallback' = returned a saved incomplete result, 'not_found' = no
+// source resolved). Proves the short-circuit gate is firing and by what reason.
+export const compositeRootTxExitReasonTotal = new promClient.Counter({
+  name: 'composite_root_tx_exit_reason_total',
+  help: 'Composite root TX lookups by termination reason',
+  labelNames: ['reason', 'winning_source'] as const,
+});
+
+// Number of sources actually queried (circuit fired) before the composite
+// returned. Lower is better: a short-circuit avoids probing the remaining
+// (often expensive, e.g. GraphQL) sources in the chain.
+export const compositeRootTxSourcesProbedSummary = new promClient.Summary({
+  name: 'composite_root_tx_sources_probed',
+  help: 'Number of sources queried per composite root TX lookup before returning',
+});
+
 //
 // Root TX Semaphore metrics
 //

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1466,6 +1466,19 @@ export const compositeRootTxSourcesProbedSummary = new promClient.Summary({
   help: 'Number of sources queried per composite root TX lookup before returning',
 });
 
+// Outcome of the local-first data item offset resolution in RootParentDataSource
+// (only counted for bare-rootTxId results, where the optimization applies):
+//   - local: resolved to an offset by a local bundle-header scan, avoiding a
+//     remote path/offsets lookup (e.g. GraphQL)
+//   - remote_fallback: the local scan missed (nested item) and a full lookup
+//     (possibly remote) recovered a path or direct offsets
+//   - unresolved: neither the local scan nor the fallback lookup found the item
+export const rootTxLocalResolveTotal = new promClient.Counter({
+  name: 'root_tx_local_resolve_total',
+  help: 'Outcome of local-first data item offset resolution by RootParentDataSource',
+  labelNames: ['outcome'] as const,
+});
+
 //
 // Root TX Semaphore metrics
 //

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1186,14 +1186,30 @@ export interface ContiguousDataIndex {
   saveVerificationPriority(id: string, priority: number): Promise<void>;
 }
 
+/**
+ * Root transaction location for a data item, as resolved by a
+ * {@link DataItemRootIndex}. All offsets and sizes are byte values relative to
+ * the root L1 transaction's data. Fields beyond `rootTxId` are best-effort:
+ * different sources populate different subsets, and consumers derive whatever
+ * is missing (e.g. by parsing the bundle header).
+ */
 export interface RootTxLookupResult {
+  /** base64url ID of the root L1 transaction containing the data item. */
   rootTxId: string;
-  /** Path from root TX to immediate parent bundle [root, ..., parent] */
+  /**
+   * Bundle traversal path from root to the immediate parent bundle
+   * `[root, ..., parent]`; omitted when the path is unknown.
+   */
   path?: string[];
+  /** Byte offset of the data item header within the root TX data. */
   rootOffset?: number;
+  /** Byte offset of the data item's payload within the root TX data. */
   rootDataOffset?: number;
+  /** Content type of the data item, when known to the source. */
   contentType?: string;
+  /** Total size of the data item in bytes, including its header. */
   size?: number;
+  /** Size of the data item's payload in bytes, excluding its header. */
   dataSize?: number;
 }
 
@@ -1212,7 +1228,19 @@ export interface GetRootTxOptions {
   accept?: (result: RootTxLookupResult) => boolean;
 }
 
+/**
+ * A source that resolves a data item ID to its root transaction location.
+ * Implemented by individual index backends (local DB, CDB64, gateways,
+ * GraphQL, etc.) and by the composite that probes them in order.
+ */
 export interface DataItemRootIndex {
+  /**
+   * Resolves `id` to its root transaction location, or `undefined` if the
+   * source cannot resolve it.
+   *
+   * @param id - base64url data item / transaction ID to resolve.
+   * @param opts - optional lookup options; see {@link GetRootTxOptions}.
+   */
   getRootTx(
     id: string,
     opts?: GetRootTxOptions,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1186,20 +1186,37 @@ export interface ContiguousDataIndex {
   saveVerificationPriority(id: string, priority: number): Promise<void>;
 }
 
+export interface RootTxLookupResult {
+  rootTxId: string;
+  /** Path from root TX to immediate parent bundle [root, ..., parent] */
+  path?: string[];
+  rootOffset?: number;
+  rootDataOffset?: number;
+  contentType?: string;
+  size?: number;
+  dataSize?: number;
+}
+
+export interface GetRootTxOptions {
+  /**
+   * Predicate deciding whether a source's result is sufficient for the caller,
+   * letting the composite short-circuit as soon as it is satisfied. Return
+   * `true` to accept (stop probing further sources) or `false` to keep probing.
+   *
+   * When omitted, the composite applies its default "actionable" acceptance
+   * (complete offsets, an L1 root, `rootOffset` + `rootDataOffset`, or a
+   * non-empty path). Callers that can proceed from less — e.g. a bare
+   * `rootTxId` they will resolve offsets from locally — can pass a looser
+   * predicate to avoid probing remote sources such as GraphQL.
+   */
+  accept?: (result: RootTxLookupResult) => boolean;
+}
+
 export interface DataItemRootIndex {
-  getRootTx(id: string): Promise<
-    | {
-        rootTxId: string;
-        /** Path from root TX to immediate parent bundle [root, ..., parent] */
-        path?: string[];
-        rootOffset?: number;
-        rootDataOffset?: number;
-        contentType?: string;
-        size?: number;
-        dataSize?: number;
-      }
-    | undefined
-  >;
+  getRootTx(
+    id: string,
+    opts?: GetRootTxOptions,
+  ): Promise<RootTxLookupResult | undefined>;
 }
 
 export interface ContiguousDataSource {


### PR DESCRIPTION
## Problem

`CompositeRootTxIndex.getRootTx` only returned early when a **single source** supplied all four offset fields (`rootOffset` + `rootDataOffset` + `size` + `dataSize`). No locally-configured source ever supplies `size` — the DB returns no offsets, the CDB64 index carries offsets but no size, GraphQL carries neither — so the "complete offsets" fast path was **never satisfied** in practice. Every lookup fell through the *entire* source chain, including the remote, rate-limited GraphQL tier, even when the DB or CDB64 index had already resolved the root in position 1–2.

On canary gateways this showed up as: `composite_root_tx` short-circuiting **0** times across thousands of lookups, GraphQL probed on 100% of lookups (winning ~10%), ~70% of lookups answered locally but still paying the full downstream fan-out, and multi-second average composite latency.

## Change

Relax the exit condition to short-circuit on an **actionable** result — one the caller can proceed on without probing the remaining sources:

| Exit reason | Condition |
|---|---|
| `complete_offsets` | all four fields (unchanged) |
| `l1_root` | `rootTxId === id` (definitive L1 root, passthrough) |
| `offsets` | `rootOffset` + `rootDataOffset` present (the CDB64 case; `size` is read cheaply from the item header) |
| `path` | non-empty traversal path (path-guided navigation) |

A bare `rootTxId` (no path/offsets, not L1) is still saved as a fallback and the search continues, so the returned result is **the same or better than before** — only the wasted downstream probes are removed. No behavioral regression; the returned object for a short-circuited lookup is identical to what the old code would have returned as its fallback.

## Observability (to validate on a canary)

- `composite_root_tx_exit_reason_total{reason,winning_source}` — why each lookup terminated.
- `composite_root_tx_sources_probed` — summary of sources queried per lookup (lower is better).
- Debug log on short-circuit (`exitReason`, `sourcesProbed`, `sourcesSkipped`).

Expected on a patched node vs. an unpatched control under shared traffic: sharp drop in `rate(root_tx_lookup_total{source="graphql"}[10m])`, `composite_root_tx_sources_probed` avg falling toward ~2, exit-reason mix dominated by `offsets`/`l1_root`/`path`, and composite latency p50/p90 collapsing.

## Tests

The composite had no unit tests; this adds `composite-root-tx-index.test.ts` covering each exit reason, fallback accumulation past a bare `rootTxId`, the not-found path, and the key regression: **a size-less CDB64 hit short-circuits and GraphQL is never probed**.

## Docs

`docs/cdb64.md` gains a "Lookup Short-Circuiting" section documenting the exit reasons and the new metrics.

## Follow-up (not in this PR)

Free field-level coalescing: fold complementary fields (`contentType`, `dataSize`) from already-probed sources sharing the same `rootTxId` into the actionable result before returning — no extra probing. Small win (saves a header parse, not a network call); gated on whether the live metrics show a meaningful `db-found + cdb-won` overlap.