### PR TITLE
feat(root-tx): caller accept predicate for composite getRootTx (PE-9134)

### DIFF
--- a/docs/cdb64.md
+++ b/docs/cdb64.md
@@ -1,24 +1,30 @@
 # CDB64 Root Transaction Index
 
-CDB64 is the AR.IO Gateway's solution for fast, offline lookups of data item to root transaction mappings. It enables O(1) retrieval of nested bundle data without external API dependencies.
+CDB64 is the AR.IO Gateway's solution for fast, offline lookups of data item to
+root transaction mappings. It enables O(1) retrieval of nested bundle data
+without external API dependencies.
 
 ## Why CDB64?
 
-When a client requests a data item nested inside an ANS-104 bundle, the gateway needs to know which root transaction contains it and where within that transaction the data resides. CDB64 indexes provide:
+When a client requests a data item nested inside an ANS-104 bundle, the gateway
+needs to know which root transaction contains it and where within that
+transaction the data resides. CDB64 indexes provide:
 
 - **Instant lookups**: Hash-based O(1) access, no database queries
 - **Offline operation**: No external API calls for indexed items
-- **Flexible deployment**: Local files, HTTP endpoints, or Arweave-stored indexes
+- **Flexible deployment**: Local files, HTTP endpoints, or Arweave-stored
+  indexes
 - **Hot reloading**: Add/remove indexes without gateway restart
-- **Scalability**: Partitioned indexes for datasets exceeding billions of records
+- **Scalability**: Partitioned indexes for datasets exceeding billions of
+  records
 
 ## Documentation
 
-| Document | Audience | Description |
-|----------|----------|-------------|
-| **[Operator Guide](cdb64-guide.md)** | Gateway operators | Configuration, deployment, performance tuning, troubleshooting |
-| **[Tools Reference](cdb64-tools.md)** | Developers | CLI tools for creating and managing CDB64 indexes |
-| **[Format Specification](cdb64-format.md)** | Implementers | Technical specification of the CDB64 file format |
+| Document                                    | Audience          | Description                                                    |
+| ------------------------------------------- | ----------------- | -------------------------------------------------------------- |
+| **[Operator Guide](cdb64-guide.md)**        | Gateway operators | Configuration, deployment, performance tuning, troubleshooting |
+| **[Tools Reference](cdb64-tools.md)**       | Developers        | CLI tools for creating and managing CDB64 indexes              |
+| **[Format Specification](cdb64-format.md)** | Implementers      | Technical specification of the CDB64 file format               |
 
 ## Quick Start
 
@@ -100,12 +106,12 @@ CDB64 root TX index initialized { sourceCount: 1, readerCount: 3, watching: true
 
 Each data item ID maps to information about its location:
 
-| Field | Description |
-|-------|-------------|
-| `rootTxId` | The L1 Arweave transaction containing the data |
-| `rootOffset` | Byte offset of the data item header within the root TX |
-| `rootDataOffset` | Byte offset of the data payload within the root TX |
-| `path` | Bundle traversal path for nested bundles |
+| Field            | Description                                            |
+| ---------------- | ------------------------------------------------------ |
+| `rootTxId`       | The L1 Arweave transaction containing the data         |
+| `rootOffset`     | Byte offset of the data item header within the root TX |
+| `rootDataOffset` | Byte offset of the data payload within the root TX     |
+| `path`           | Bundle traversal path for nested bundles               |
 
 ### Source Priority
 
@@ -118,24 +124,41 @@ CDB64_ROOT_TX_INDEX_SOURCES=/local/indexes/,https://cdn.example.com/index.cdb,Ar
 
 ### Lookup Short-Circuiting
 
-The composite root TX index (`ROOT_TX_LOOKUP_ORDER`) stops probing sources as soon as one returns an **actionable** result, so a CDB64 hit early in the order avoids the remaining (often remote and expensive) sources such as GraphQL. A result is actionable when the caller can proceed without further lookups:
+The composite root TX index (`ROOT_TX_LOOKUP_ORDER`) stops probing sources as
+soon as one returns an **actionable** result, so a CDB64 hit early in the order
+avoids the remaining (often remote and expensive) sources such as GraphQL. A
+result is actionable when the caller can proceed without further lookups:
 
-| Exit reason | Condition | Notes |
-|-------------|-----------|-------|
-| `complete_offsets` | `rootOffset` + `rootDataOffset` + `size` + `dataSize` | Full offsets; no header parse needed |
-| `l1_root` | `rootTxId === id` | Definitive L1 root; passthrough |
-| `offsets` | `rootOffset` + `rootDataOffset` present | The CDB64 case; size is read from the item header |
-| `path` | non-empty `path` | Enables path-guided bundle navigation |
+| Exit reason        | Condition                                             | Notes                                             |
+| ------------------ | ----------------------------------------------------- | ------------------------------------------------- |
+| `complete_offsets` | `rootOffset` + `rootDataOffset` + `size` + `dataSize` | Full offsets; no header parse needed              |
+| `l1_root`          | `rootTxId === id`                                     | Definitive L1 root; passthrough                   |
+| `offsets`          | `rootOffset` + `rootDataOffset` present               | The CDB64 case; size is read from the item header |
+| `path`             | non-empty `path`                                      | Enables path-guided bundle navigation             |
 
-A bare `rootTxId` with no path or offsets is **not** actionable — it is saved as a fallback and the search continues, so a later source (e.g. CDB64) can supply a path or offsets. If no source is actionable, the saved fallback is returned (`fallback`), or `undefined` if nothing resolved (`not_found`).
+A caller may override this decision by passing an `accept` predicate to
+`getRootTx` (short-circuiting on whatever it deems sufficient — e.g. any
+`rootTxId` it will resolve offsets from locally); such short-circuits are
+recorded with the `caller_accept` exit reason.
 
-CDB64 values carry offsets (`rootOffset`/`rootDataOffset`) but not `size`, so CDB64 hits terminate with the `offsets` (or `path`) reason rather than `complete_offsets`.
+A bare `rootTxId` with no path or offsets is **not** actionable — it is saved as
+a fallback and the search continues, so a later source (e.g. CDB64) can supply a
+path or offsets. If no source is actionable, the saved fallback is returned
+(`fallback`), or `undefined` if nothing resolved (`not_found`).
+
+CDB64 values carry offsets (`rootOffset`/`rootDataOffset`) but not `size`, so
+CDB64 hits terminate with the `offsets` (or `path`) reason rather than
+`complete_offsets`.
 
 Observability (per-node Prometheus metrics):
 
-- `composite_root_tx_exit_reason_total{reason,winning_source}` — one increment per lookup, labelled with the exit reason above. A healthy CDB64 deployment shows most CDB64-won lookups exiting on `offsets`/`path`.
-- `composite_root_tx_sources_probed` — summary of how many sources were queried before returning. Effective short-circuiting keeps this low.
-- `root_tx_lookup_total{source="graphql"}` — total GraphQL probes; falls sharply once early local sources (db/cdb) short-circuit.
+- `composite_root_tx_exit_reason_total{reason,winning_source}` — one increment
+  per lookup, labelled with the exit reason above. A healthy CDB64 deployment
+  shows most CDB64-won lookups exiting on `offsets`/`path`.
+- `composite_root_tx_sources_probed` — summary of how many sources were queried
+  before returning. Effective short-circuiting keeps this low.
+- `root_tx_lookup_total{source="graphql"}` — total GraphQL probes; falls sharply
+  once early local sources (db/cdb) short-circuit.
 
 ### Partitioned Indexes
 

--- a/docs/cdb64.md
+++ b/docs/cdb64.md
@@ -135,6 +135,7 @@ result is actionable when the caller can proceed without further lookups:
 | `l1_root`          | `rootTxId === id`                                     | Definitive L1 root; passthrough                   |
 | `offsets`          | `rootOffset` + `rootDataOffset` present               | The CDB64 case; size is read from the item header |
 | `path`             | non-empty `path`                                      | Enables path-guided bundle navigation             |
+| `caller_accept`    | `opts.accept(result) === true`                        | Caller-provided predicate accepted the result     |
 
 A caller may override this decision by passing an `accept` predicate to
 `getRootTx` (short-circuiting on whatever it deems sufficient — e.g. any

--- a/src/discovery/composite-root-tx-index.test.ts
+++ b/src/discovery/composite-root-tx-index.test.ts
@@ -266,4 +266,29 @@ describe('CompositeRootTxIndex', () => {
     assert.equal(db.calls, 1);
     assert.equal(cdb.calls, 1);
   });
+
+  it('propagates exceptions from opts.accept instead of swallowing them as a source error', async () => {
+    const db = makeIndex('StandaloneSqlite', { rootTxId: 'root-9' });
+    const cdb = makeIndex('Cdb64RootTxIndex', { rootTxId: 'root-9' });
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [db, cdb],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    await assert.rejects(
+      () =>
+        composite.getRootTx(ID, {
+          accept: () => {
+            throw new Error('predicate boom');
+          },
+        }),
+      /predicate boom/,
+    );
+    // The predicate throws on db's result; the error must surface immediately,
+    // not be misattributed to db and cause cdb to be probed as a fallback.
+    assert.equal(db.calls, 1);
+    assert.equal(cdb.calls, 0);
+  });
 });

--- a/src/discovery/composite-root-tx-index.test.ts
+++ b/src/discovery/composite-root-tx-index.test.ts
@@ -192,4 +192,78 @@ describe('CompositeRootTxIndex', () => {
     const result = await composite.getRootTx(ID);
     assert.equal(result, undefined);
   });
+
+  it('opts.accept short-circuits on a bare rootTxId the default would reject', async () => {
+    // db misses; cdb returns a bare rootTxId (no path/offsets, not an L1 root).
+    // Default acceptance would keep probing GraphQL; a rootTxId-only predicate
+    // stops at cdb.
+    const db = makeIndex('StandaloneSqlite', undefined);
+    const cdb = makeIndex('Cdb64RootTxIndex', { rootTxId: 'root-6' });
+    const graphql = makeIndex('GraphQLRootTxIndex', {
+      rootTxId: 'root-6',
+      path: ['root-6', 'parent-6'],
+    });
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [db, cdb, graphql],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    const result = await composite.getRootTx(ID, {
+      accept: (r) => r.rootTxId !== undefined,
+    });
+    assert.equal(result?.rootTxId, 'root-6');
+    assert.equal(cdb.calls, 1);
+    assert.equal(
+      graphql.calls,
+      0,
+      'predicate satisfied at cdb; GraphQL skipped',
+    );
+  });
+
+  it('opts.accept returning false keeps probing until satisfied', async () => {
+    // A stricter predicate (require a path) rejects the bare db/cdb results and
+    // forces the search to reach GraphQL, which supplies the path.
+    const db = makeIndex('StandaloneSqlite', { rootTxId: 'root-7' });
+    const cdb = makeIndex('Cdb64RootTxIndex', { rootTxId: 'root-7' });
+    const graphql = makeIndex('GraphQLRootTxIndex', {
+      rootTxId: 'root-7',
+      path: ['root-7', 'parent-7'],
+    });
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [db, cdb, graphql],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    const result = await composite.getRootTx(ID, {
+      accept: (r) => (r.path?.length ?? 0) > 0,
+    });
+    assert.deepEqual(result?.path, ['root-7', 'parent-7']);
+    assert.equal(db.calls, 1);
+    assert.equal(cdb.calls, 1);
+    assert.equal(graphql.calls, 1);
+  });
+
+  it('opts.accept falls back to the first result when nothing is accepted', async () => {
+    // No source satisfies the predicate -> the saved fallback (first result) is
+    // returned, matching default fallback semantics.
+    const db = makeIndex('StandaloneSqlite', { rootTxId: 'root-8' });
+    const cdb = makeIndex('Cdb64RootTxIndex', { rootTxId: 'root-8' });
+
+    const composite = new CompositeRootTxIndex({
+      log,
+      indexes: [db, cdb],
+      circuitBreakerOptions: stableBreakerOptions,
+    });
+
+    const result = await composite.getRootTx(ID, {
+      accept: (r) => (r.path?.length ?? 0) > 0,
+    });
+    assert.equal(result?.rootTxId, 'root-8');
+    assert.equal(db.calls, 1);
+    assert.equal(cdb.calls, 1);
+  });
 });

--- a/src/discovery/composite-root-tx-index.ts
+++ b/src/discovery/composite-root-tx-index.ts
@@ -6,7 +6,11 @@
  */
 import winston from 'winston';
 import CircuitBreaker from 'opossum';
-import { DataItemRootIndex, GetRootTxOptions } from '../types.js';
+import {
+  DataItemRootIndex,
+  GetRootTxOptions,
+  RootTxLookupResult,
+} from '../types.js';
 import * as config from '../config.js';
 import * as metrics from '../metrics.js';
 
@@ -180,6 +184,7 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
       }
 
       const lookupStartTime = Date.now();
+      let result: RootTxLookupResult | undefined;
       try {
         log.debug('Trying index', {
           indexNumber: i + 1,
@@ -190,121 +195,7 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
 
         // Execute with circuit breaker protection
         probedCount++;
-        const result = await circuitBreaker.fire(id);
-        const lookupDuration = Date.now() - lookupStartTime;
-        metrics.rootTxLookupDurationSummary.observe(
-          { source: sourceName },
-          lookupDuration,
-        );
-
-        if (result !== undefined) {
-          // Check if result has complete offset information
-          const hasCompleteOffsets =
-            result.rootOffset !== undefined &&
-            result.rootDataOffset !== undefined &&
-            result.size !== undefined &&
-            result.dataSize !== undefined;
-
-          metrics.rootTxLookupTotal.inc({
-            source: sourceName,
-            status: 'found',
-            has_offsets: hasCompleteOffsets ? 'true' : 'false',
-          });
-
-          // Decide whether this result is sufficient to stop the search.
-          //
-          // When the caller supplies opts.accept, it fully governs the
-          // decision (exit reason `caller_accept`) — e.g. "any rootTxId is
-          // enough, I'll resolve offsets locally" avoids probing remote
-          // sources. Otherwise the default "actionable" acceptance applies:
-          // requiring all four offset fields (hasCompleteOffsets) is too
-          // strict — no locally-configured source (db, cdb) ever supplies
-          // `size`, so the search never short-circuited and every lookup fell
-          // through to the expensive downstream sources (e.g. GraphQL) even
-          // when db/cdb had already answered. A result is actionable when the
-          // caller can proceed without probing the remaining sources:
-          //   - complete_offsets: full offsets + size (skip even a header parse)
-          //   - l1_root: rootTxId === id, a definitive L1 root (passthrough)
-          //   - offsets: rootOffset + rootDataOffset present (serve via a cheap
-          //     header parse for size; the CDB case)
-          //   - path: a bundle traversal path (path-guided navigation)
-          let exitReason:
-            | 'complete_offsets'
-            | 'l1_root'
-            | 'offsets'
-            | 'path'
-            | 'caller_accept'
-            | undefined;
-          if (opts?.accept !== undefined) {
-            if (opts.accept(result)) {
-              exitReason = 'caller_accept';
-            }
-          } else if (hasCompleteOffsets) {
-            exitReason = 'complete_offsets';
-          } else if (result.rootTxId === id) {
-            exitReason = 'l1_root';
-          } else if (
-            result.rootOffset !== undefined &&
-            result.rootDataOffset !== undefined
-          ) {
-            exitReason = 'offsets';
-          } else if (result.path !== undefined && result.path.length > 0) {
-            exitReason = 'path';
-          }
-
-          if (exitReason !== undefined) {
-            winningSourceName = sourceName;
-            log.debug('Found actionable root TX result, short-circuiting', {
-              rootTxId: result.rootTxId,
-              indexNumber: i + 1,
-              indexClass: indexName,
-              exitReason,
-              sourcesProbed: probedCount,
-              sourcesSkipped: this.indexes.length - i - 1,
-            });
-
-            metrics.compositeRootTxLookupTotal.inc({
-              status: 'found',
-              winning_source: winningSourceName,
-              has_complete_offsets: hasCompleteOffsets ? 'true' : 'false',
-            });
-            metrics.compositeRootTxExitReasonTotal.inc({
-              reason: exitReason,
-              winning_source: winningSourceName,
-            });
-            metrics.compositeRootTxSourcesProbedSummary.observe(probedCount);
-            metrics.compositeRootTxLookupDurationSummary.observe(
-              Date.now() - compositeStartTime,
-            );
-
-            return result;
-          }
-
-          // Not actionable (bare rootTxId: no path, no offsets, not an L1 root).
-          // Save as a fallback and keep probing for something better.
-          if (fallbackResult === undefined) {
-            fallbackResult = result;
-            fallbackSourceName = sourceName;
-            log.debug(
-              'Found root TX ID but not actionable, saving as fallback',
-              {
-                rootTxId: result.rootTxId,
-                indexNumber: i + 1,
-                indexClass: indexName,
-              },
-            );
-          }
-        } else {
-          metrics.rootTxLookupTotal.inc({
-            source: sourceName,
-            status: 'not_found',
-            has_offsets: 'false',
-          });
-          log.debug('Index returned undefined', {
-            indexNumber: i + 1,
-            indexClass: indexName,
-          });
-        }
+        result = await circuitBreaker.fire(id);
       } catch (error: any) {
         const lookupDuration = Date.now() - lookupStartTime;
         metrics.rootTxLookupDurationSummary.observe(
@@ -323,6 +214,124 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
           circuitState: circuitBreaker.opened ? 'OPEN' : 'CLOSED',
         });
         // Continue to next index
+        continue;
+      }
+
+      // Result classification runs OUTSIDE the source-lookup try/catch above so
+      // that an exception thrown by a caller-supplied opts.accept predicate
+      // propagates to the caller instead of being misattributed as a source
+      // failure — which would swallow the bug and silently return a fallback or
+      // later result.
+      const lookupDuration = Date.now() - lookupStartTime;
+      metrics.rootTxLookupDurationSummary.observe(
+        { source: sourceName },
+        lookupDuration,
+      );
+
+      if (result !== undefined) {
+        // Check if result has complete offset information
+        const hasCompleteOffsets =
+          result.rootOffset !== undefined &&
+          result.rootDataOffset !== undefined &&
+          result.size !== undefined &&
+          result.dataSize !== undefined;
+
+        metrics.rootTxLookupTotal.inc({
+          source: sourceName,
+          status: 'found',
+          has_offsets: hasCompleteOffsets ? 'true' : 'false',
+        });
+
+        // Decide whether this result is sufficient to stop the search.
+        //
+        // When the caller supplies opts.accept, it fully governs the decision
+        // (exit reason `caller_accept`) — e.g. "any rootTxId is enough, I'll
+        // resolve offsets locally" avoids probing remote sources. Otherwise the
+        // default "actionable" acceptance applies: requiring all four offset
+        // fields (hasCompleteOffsets) is too strict — no locally-configured
+        // source (db, cdb) ever supplies `size`, so the search never
+        // short-circuited and every lookup fell through to the expensive
+        // downstream sources (e.g. GraphQL) even when db/cdb had already
+        // answered. A result is actionable when the caller can proceed without
+        // probing the remaining sources:
+        //   - complete_offsets: full offsets + size (skip even a header parse)
+        //   - l1_root: rootTxId === id, a definitive L1 root (passthrough)
+        //   - offsets: rootOffset + rootDataOffset present (serve via a cheap
+        //     header parse for size; the CDB case)
+        //   - path: a bundle traversal path (path-guided navigation)
+        let exitReason:
+          | 'complete_offsets'
+          | 'l1_root'
+          | 'offsets'
+          | 'path'
+          | 'caller_accept'
+          | undefined;
+        if (opts?.accept !== undefined) {
+          if (opts.accept(result)) {
+            exitReason = 'caller_accept';
+          }
+        } else if (hasCompleteOffsets) {
+          exitReason = 'complete_offsets';
+        } else if (result.rootTxId === id) {
+          exitReason = 'l1_root';
+        } else if (
+          result.rootOffset !== undefined &&
+          result.rootDataOffset !== undefined
+        ) {
+          exitReason = 'offsets';
+        } else if (result.path !== undefined && result.path.length > 0) {
+          exitReason = 'path';
+        }
+
+        if (exitReason !== undefined) {
+          winningSourceName = sourceName;
+          log.debug('Found actionable root TX result, short-circuiting', {
+            rootTxId: result.rootTxId,
+            indexNumber: i + 1,
+            indexClass: indexName,
+            exitReason,
+            sourcesProbed: probedCount,
+            sourcesSkipped: this.indexes.length - i - 1,
+          });
+
+          metrics.compositeRootTxLookupTotal.inc({
+            status: 'found',
+            winning_source: winningSourceName,
+            has_complete_offsets: hasCompleteOffsets ? 'true' : 'false',
+          });
+          metrics.compositeRootTxExitReasonTotal.inc({
+            reason: exitReason,
+            winning_source: winningSourceName,
+          });
+          metrics.compositeRootTxSourcesProbedSummary.observe(probedCount);
+          metrics.compositeRootTxLookupDurationSummary.observe(
+            Date.now() - compositeStartTime,
+          );
+
+          return result;
+        }
+
+        // Not actionable (bare rootTxId: no path, no offsets, not an L1 root).
+        // Save as a fallback and keep probing for something better.
+        if (fallbackResult === undefined) {
+          fallbackResult = result;
+          fallbackSourceName = sourceName;
+          log.debug('Found root TX ID but not actionable, saving as fallback', {
+            rootTxId: result.rootTxId,
+            indexNumber: i + 1,
+            indexClass: indexName,
+          });
+        }
+      } else {
+        metrics.rootTxLookupTotal.inc({
+          source: sourceName,
+          status: 'not_found',
+          has_offsets: 'false',
+        });
+        log.debug('Index returned undefined', {
+          indexNumber: i + 1,
+          indexClass: indexName,
+        });
       }
     }
 

--- a/src/discovery/composite-root-tx-index.ts
+++ b/src/discovery/composite-root-tx-index.ts
@@ -6,7 +6,7 @@
  */
 import winston from 'winston';
 import CircuitBreaker from 'opossum';
-import { DataItemRootIndex } from '../types.js';
+import { DataItemRootIndex, GetRootTxOptions } from '../types.js';
 import * as config from '../config.js';
 import * as metrics from '../metrics.js';
 
@@ -110,10 +110,21 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
    * richer. If no source is actionable, the saved fallback is returned, or
    * `undefined` when nothing resolved.
    *
+   * Callers can override the acceptance decision via `opts.accept` — a
+   * predicate that returns `true` to short-circuit on a given result. This
+   * lets a caller that only needs (say) a `rootTxId` stop as soon as any
+   * source supplies one, rather than probing remote sources for richer
+   * metadata it will derive locally. When omitted, the default actionable
+   * acceptance above applies.
+   *
    * @param id - base64url data item / transaction ID to resolve.
+   * @param opts - optional lookup options; see {@link GetRootTxOptions}.
    * @returns The root transaction info, or `undefined` if unresolved.
    */
-  async getRootTx(id: string): Promise<
+  async getRootTx(
+    id: string,
+    opts?: GetRootTxOptions,
+  ): Promise<
     | {
         rootTxId: string;
         path?: string[];
@@ -200,13 +211,18 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
             has_offsets: hasCompleteOffsets ? 'true' : 'false',
           });
 
-          // Decide whether this result is actionable enough to stop the search.
-          // Requiring all four offset fields (hasCompleteOffsets) is too strict:
-          // no locally-configured source (db, cdb) ever supplies `size`, so the
-          // search never short-circuited and every lookup fell through to the
-          // expensive downstream sources (e.g. GraphQL) even when db/cdb had
-          // already answered. A result is actionable when the caller can proceed
-          // without probing the remaining sources:
+          // Decide whether this result is sufficient to stop the search.
+          //
+          // When the caller supplies opts.accept, it fully governs the
+          // decision (exit reason `caller_accept`) — e.g. "any rootTxId is
+          // enough, I'll resolve offsets locally" avoids probing remote
+          // sources. Otherwise the default "actionable" acceptance applies:
+          // requiring all four offset fields (hasCompleteOffsets) is too
+          // strict — no locally-configured source (db, cdb) ever supplies
+          // `size`, so the search never short-circuited and every lookup fell
+          // through to the expensive downstream sources (e.g. GraphQL) even
+          // when db/cdb had already answered. A result is actionable when the
+          // caller can proceed without probing the remaining sources:
           //   - complete_offsets: full offsets + size (skip even a header parse)
           //   - l1_root: rootTxId === id, a definitive L1 root (passthrough)
           //   - offsets: rootOffset + rootDataOffset present (serve via a cheap
@@ -217,8 +233,13 @@ export class CompositeRootTxIndex implements DataItemRootIndex {
             | 'l1_root'
             | 'offsets'
             | 'path'
+            | 'caller_accept'
             | undefined;
-          if (hasCompleteOffsets) {
+          if (opts?.accept !== undefined) {
+            if (opts.accept(result)) {
+              exitReason = 'caller_accept';
+            }
+          } else if (hasCompleteOffsets) {
             exitReason = 'complete_offsets';
           } else if (result.rootTxId === id) {
             exitReason = 'l1_root';

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1186,14 +1186,30 @@ export interface ContiguousDataIndex {
   saveVerificationPriority(id: string, priority: number): Promise<void>;
 }
 
+/**
+ * Root transaction location for a data item, as resolved by a
+ * {@link DataItemRootIndex}. All offsets and sizes are byte values relative to
+ * the root L1 transaction's data. Fields beyond `rootTxId` are best-effort:
+ * different sources populate different subsets, and consumers derive whatever
+ * is missing (e.g. by parsing the bundle header).
+ */
 export interface RootTxLookupResult {
+  /** base64url ID of the root L1 transaction containing the data item. */
   rootTxId: string;
-  /** Path from root TX to immediate parent bundle [root, ..., parent] */
+  /**
+   * Bundle traversal path from root to the immediate parent bundle
+   * `[root, ..., parent]`; omitted when the path is unknown.
+   */
   path?: string[];
+  /** Byte offset of the data item header within the root TX data. */
   rootOffset?: number;
+  /** Byte offset of the data item's payload within the root TX data. */
   rootDataOffset?: number;
+  /** Content type of the data item, when known to the source. */
   contentType?: string;
+  /** Total size of the data item in bytes, including its header. */
   size?: number;
+  /** Size of the data item's payload in bytes, excluding its header. */
   dataSize?: number;
 }
 
@@ -1212,7 +1228,19 @@ export interface GetRootTxOptions {
   accept?: (result: RootTxLookupResult) => boolean;
 }
 
+/**
+ * A source that resolves a data item ID to its root transaction location.
+ * Implemented by individual index backends (local DB, CDB64, gateways,
+ * GraphQL, etc.) and by the composite that probes them in order.
+ */
 export interface DataItemRootIndex {
+  /**
+   * Resolves `id` to its root transaction location, or `undefined` if the
+   * source cannot resolve it.
+   *
+   * @param id - base64url data item / transaction ID to resolve.
+   * @param opts - optional lookup options; see {@link GetRootTxOptions}.
+   */
   getRootTx(
     id: string,
     opts?: GetRootTxOptions,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1186,20 +1186,37 @@ export interface ContiguousDataIndex {
   saveVerificationPriority(id: string, priority: number): Promise<void>;
 }
 
+export interface RootTxLookupResult {
+  rootTxId: string;
+  /** Path from root TX to immediate parent bundle [root, ..., parent] */
+  path?: string[];
+  rootOffset?: number;
+  rootDataOffset?: number;
+  contentType?: string;
+  size?: number;
+  dataSize?: number;
+}
+
+export interface GetRootTxOptions {
+  /**
+   * Predicate deciding whether a source's result is sufficient for the caller,
+   * letting the composite short-circuit as soon as it is satisfied. Return
+   * `true` to accept (stop probing further sources) or `false` to keep probing.
+   *
+   * When omitted, the composite applies its default "actionable" acceptance
+   * (complete offsets, an L1 root, `rootOffset` + `rootDataOffset`, or a
+   * non-empty path). Callers that can proceed from less — e.g. a bare
+   * `rootTxId` they will resolve offsets from locally — can pass a looser
+   * predicate to avoid probing remote sources such as GraphQL.
+   */
+  accept?: (result: RootTxLookupResult) => boolean;
+}
+
 export interface DataItemRootIndex {
-  getRootTx(id: string): Promise<
-    | {
-        rootTxId: string;
-        /** Path from root TX to immediate parent bundle [root, ..., parent] */
-        path?: string[];
-        rootOffset?: number;
-        rootDataOffset?: number;
-        contentType?: string;
-        size?: number;
-        dataSize?: number;
-      }
-    | undefined
-  >;
+  getRootTx(
+    id: string,
+    opts?: GetRootTxOptions,
+  ): Promise<RootTxLookupResult | undefined>;
 }
 
 export interface ContiguousDataSource {


### PR DESCRIPTION
**Stacked on #827** (`PE-9134-composite-root-tx-short-circuit`). Base will be retargeted to `develop` once #827 merges. Part 1 of the follow-up discussed on #827; behavior-neutral.

## What

Adds an optional `accept` predicate to `CompositeRootTxIndex.getRootTx` via a new `GetRootTxOptions`:

```ts
getRootTx(id, { accept?: (result) => boolean })
```

When supplied, the predicate fully governs the short-circuit decision (new `caller_accept` exit reason). When omitted, the existing default "actionable" acceptance (`complete_offsets` / `l1_root` / `offsets` / `path`) is unchanged. A result the predicate rejects is still retained as the fallback and the search continues — identical fallback semantics.

## Why

Some callers can proceed from less than a fully actionable result — e.g. they only need a `rootTxId` and will derive offsets locally by streaming the bundle header (work they already do to serve/extract the item). Today those lookups still fall through to remote sources (GraphQL) purely to fetch a path shortcut. The predicate lets such a caller stop as soon as its real need is met.

This is the gateway-only lever for the frozen historical CDB population (bare `{r}` values that can't be re-exported): a `rootTxId`-only predicate will short-circuit on a bare cdb hit and skip GraphQL, with offset resolution moving to a local header scan.

## Scope

**No call site passes `accept` yet**, so this commit changes no runtime behavior — it's pure plumbing + observability. The call-site rewiring (predicate + local-first offset derivation with GraphQL as an on-miss fallback) lands as a separate PR so the predicate can be confirmed as a no-op regression-wise first.

## Tests

Adds cases for: predicate short-circuit on a bare `rootTxId` the default would reject; predicate rejection forcing the search onward to a path-bearing source; and predicate fallback when nothing is accepted. Existing default-behavior tests unchanged. 10/10 pass.

## Docs

`docs/cdb64.md` notes the `accept` override and the `caller_accept` exit reason.