### PR TITLE
perf(root-tx): local-first offset resolution in RootParentDataSource (PE-9134)

### DIFF
--- a/src/data/root-parent-data-source.test.ts
+++ b/src/data/root-parent-data-source.test.ts
@@ -17,6 +17,17 @@ import {
   DataItemRootIndex,
 } from '../types.js';
 import { createTestLogger } from '../../test/test-logger.js';
+import * as metrics from '../metrics.js';
+
+// Reads the current value of root_tx_local_resolve_total for a given outcome
+// label so tests can assert the increment (the counter is process-global, so
+// assert deltas rather than absolute values).
+async function readLocalResolve(outcome: string): Promise<number> {
+  const metric = await metrics.rootTxLocalResolveTotal.get();
+  return (
+    metric.values.find((v: any) => v.labels.outcome === outcome)?.value ?? 0
+  );
+}
 
 describe('RootParentDataSource', () => {
   let log: winston.Logger;
@@ -2362,7 +2373,9 @@ describe('RootParentDataSource', () => {
         cached: false,
       }));
 
+      const before = await readLocalResolve('local');
       await rootParentDataSource.getData({ id: dataItemId });
+      assert.strictEqual((await readLocalResolve('local')) - before, 1);
 
       // Exactly one root-tx lookup: the local scan succeeded, so no remote
       // fallback lookup was issued.
@@ -2418,7 +2431,12 @@ describe('RootParentDataSource', () => {
         cached: false,
       }));
 
+      const before = await readLocalResolve('remote_fallback');
       await rootParentDataSource.getData({ id: dataItemId });
+      assert.strictEqual(
+        (await readLocalResolve('remote_fallback')) - before,
+        1,
+      );
 
       // Two lookups: local-first, then the remote fallback after the miss.
       assert.strictEqual(
@@ -2443,6 +2461,102 @@ describe('RootParentDataSource', () => {
           .arguments[1],
         [rootTxId, 'parent-nested'],
       );
+    });
+
+    it('resolves via direct offsets when the fallback lookup has no path', async () => {
+      const dataItemId = 'nested-offsets-item';
+      const rootTxId = 'root-tx-offsets';
+      (ans104OffsetSource as any).getDataItemOffsetWithPath = mock.fn();
+
+      (dataAttributesStore.getDataAttributes as any).mock.mockImplementation(
+        async () => null,
+      );
+      // First lookup: bare rootTxId. Fallback: direct offsets, no path.
+      let call = 0;
+      (dataItemRootTxIndex.getRootTx as any).mock.mockImplementation(
+        async () => {
+          call += 1;
+          return call === 1
+            ? { rootTxId }
+            : {
+                rootTxId,
+                rootOffset: 900,
+                rootDataOffset: 1000,
+                size: 600,
+                dataSize: 500,
+                contentType: 'text/plain',
+              };
+        },
+      );
+      // Local scan misses.
+      (ans104OffsetSource.getDataItemOffset as any).mock.mockImplementation(
+        async () => null,
+      );
+      (dataSource.getData as any).mock.mockImplementation(async () => ({
+        stream: Readable.from([Buffer.from('x')]),
+        size: 500,
+        verified: true,
+        trusted: true,
+        cached: false,
+      }));
+
+      const before = await readLocalResolve('remote_fallback');
+      await rootParentDataSource.getData({ id: dataItemId });
+      assert.strictEqual(
+        (await readLocalResolve('remote_fallback')) - before,
+        1,
+      );
+
+      // Resolved from the fallback's direct offsets — no path navigation.
+      assert.strictEqual(
+        (dataItemRootTxIndex.getRootTx as any).mock.calls.length,
+        2,
+      );
+      assert.strictEqual(
+        (ans104OffsetSource.getDataItemOffsetWithPath as any).mock.calls.length,
+        0,
+      );
+      // Data was served using the recovered offsets (dataOffset 1000).
+      assert.strictEqual(
+        (dataSource.getData as any).mock.calls[0].arguments[0].region.offset,
+        1000,
+      );
+    });
+
+    it('records unresolved when both the local scan and the fallback miss', async () => {
+      const dataItemId = 'truly-missing-item';
+      const rootTxId = 'root-tx-missing';
+      (ans104OffsetSource as any).getDataItemOffsetWithPath = mock.fn();
+
+      (dataAttributesStore.getDataAttributes as any).mock.mockImplementation(
+        async () => null,
+      );
+      // Both lookups return a bare rootTxId (no path/offsets).
+      (dataItemRootTxIndex.getRootTx as any).mock.mockImplementation(
+        async () => ({ rootTxId }),
+      );
+      // Local scan misses; the fallback lookup also yields nothing usable.
+      (ans104OffsetSource.getDataItemOffset as any).mock.mockImplementation(
+        async () => null,
+      );
+
+      const before = await readLocalResolve('unresolved');
+      await assert.rejects(
+        async () => {
+          await rootParentDataSource.getData({ id: dataItemId });
+        },
+        {
+          message: `Data item ${dataItemId} not found in root bundle ${rootTxId}`,
+        },
+      );
+      assert.strictEqual((await readLocalResolve('unresolved')) - before, 1);
+
+      // No path navigation and no data fetch on a genuine miss.
+      assert.strictEqual(
+        (ans104OffsetSource.getDataItemOffsetWithPath as any).mock.calls.length,
+        0,
+      );
+      assert.strictEqual((dataSource.getData as any).mock.calls.length, 0);
     });
   });
 });

--- a/src/data/root-parent-data-source.test.ts
+++ b/src/data/root-parent-data-source.test.ts
@@ -403,9 +403,12 @@ describe('RootParentDataSource', () => {
         },
       );
 
+      // Two root-tx lookups: the local-first lookup (bare rootTxId), then the
+      // remote fallback after the local scan misses — which also can't resolve
+      // it here, so the not-found error is thrown.
       assert.strictEqual(
         (dataItemRootTxIndex.getRootTx as any).mock.calls.length,
-        1,
+        2,
       );
       assert.strictEqual(
         (ans104OffsetSource.getDataItemOffset as any).mock.calls.length,
@@ -2325,6 +2328,120 @@ describe('RootParentDataSource', () => {
       assert.strictEqual(
         (ans104OffsetSource.getDataItemOffset as any).mock.calls.length,
         1,
+      );
+    });
+  });
+
+  describe('local-first offset resolution', () => {
+    it('resolves a bare rootTxId via local scan without a second (remote) lookup', async () => {
+      const dataItemId = 'local-first-item';
+      const rootTxId = 'root-tx-local';
+
+      (dataAttributesStore.getDataAttributes as any).mock.mockImplementation(
+        async () => null,
+      );
+      // Bare rootTxId only (no path/offsets) — the CDB case.
+      (dataItemRootTxIndex.getRootTx as any).mock.mockImplementation(
+        async () => ({ rootTxId }),
+      );
+      // Local header scan resolves it (shallow item).
+      (ans104OffsetSource.getDataItemOffset as any).mock.mockImplementation(
+        async () => ({
+          itemOffset: 900,
+          dataOffset: 1000,
+          itemSize: 600,
+          dataSize: 500,
+          contentType: 'text/plain',
+        }),
+      );
+      (dataSource.getData as any).mock.mockImplementation(async () => ({
+        stream: Readable.from([Buffer.from('x')]),
+        size: 500,
+        verified: true,
+        trusted: true,
+        cached: false,
+      }));
+
+      await rootParentDataSource.getData({ id: dataItemId });
+
+      // Exactly one root-tx lookup: the local scan succeeded, so no remote
+      // fallback lookup was issued.
+      assert.strictEqual(
+        (dataItemRootTxIndex.getRootTx as any).mock.calls.length,
+        1,
+      );
+      // The lookup opted into rootId-only acceptance.
+      const accept = (dataItemRootTxIndex.getRootTx as any).mock.calls[0]
+        .arguments[1]?.accept;
+      assert.strictEqual(typeof accept, 'function');
+      assert.strictEqual(accept({ rootTxId: 'anything' }), true);
+      assert.strictEqual(accept({}), false);
+    });
+
+    it('falls back to a path lookup when the local scan misses', async () => {
+      const dataItemId = 'nested-item';
+      const rootTxId = 'root-tx-nested';
+      (ans104OffsetSource as any).getDataItemOffsetWithPath = mock.fn();
+
+      (dataAttributesStore.getDataAttributes as any).mock.mockImplementation(
+        async () => null,
+      );
+      // First lookup: bare rootTxId. Second lookup (fallback): supplies a path.
+      let call = 0;
+      (dataItemRootTxIndex.getRootTx as any).mock.mockImplementation(
+        async () => {
+          call += 1;
+          return call === 1
+            ? { rootTxId }
+            : { rootTxId, path: [rootTxId, 'parent-nested'] };
+        },
+      );
+      // Local scan misses (nested item).
+      (ans104OffsetSource.getDataItemOffset as any).mock.mockImplementation(
+        async () => null,
+      );
+      // Path-guided navigation resolves it.
+      (
+        ans104OffsetSource.getDataItemOffsetWithPath as any
+      ).mock.mockImplementation(async () => ({
+        itemOffset: 10,
+        dataOffset: 20,
+        itemSize: 60,
+        dataSize: 50,
+        contentType: 'text/plain',
+      }));
+      (dataSource.getData as any).mock.mockImplementation(async () => ({
+        stream: Readable.from([Buffer.from('x')]),
+        size: 50,
+        verified: true,
+        trusted: true,
+        cached: false,
+      }));
+
+      await rootParentDataSource.getData({ id: dataItemId });
+
+      // Two lookups: local-first, then the remote fallback after the miss.
+      assert.strictEqual(
+        (dataItemRootTxIndex.getRootTx as any).mock.calls.length,
+        2,
+      );
+      // The fallback lookup used the default (no accept override).
+      assert.strictEqual(
+        (dataItemRootTxIndex.getRootTx as any).mock.calls[1].arguments[1],
+        undefined,
+      );
+      assert.strictEqual(
+        (ans104OffsetSource.getDataItemOffset as any).mock.calls.length,
+        1,
+      );
+      assert.strictEqual(
+        (ans104OffsetSource.getDataItemOffsetWithPath as any).mock.calls.length,
+        1,
+      );
+      assert.deepStrictEqual(
+        (ans104OffsetSource.getDataItemOffsetWithPath as any).mock.calls[0]
+          .arguments[1],
+        [rootTxId, 'parent-nested'],
       );
     });
   });

--- a/src/data/root-parent-data-source.ts
+++ b/src/data/root-parent-data-source.ts
@@ -19,6 +19,7 @@ import {
 import { startChildSpan } from '../tracing.js';
 import { Ans104OffsetSource } from './ans104-offset-source.js';
 import { MAX_BUNDLE_NESTING_DEPTH } from '../arweave/constants.js';
+import * as metrics from '../metrics.js';
 
 /**
  * Data source that resolves data items to their root bundles before fetching data.
@@ -670,7 +671,14 @@ export class RootParentDataSource implements ContiguousDataSource {
       let rootTxId: string | undefined;
       let rootResult: any;
       try {
-        rootResult = await this.dataItemRootTxIndex.getRootTx(id);
+        // Local-first: accept any result carrying a rootTxId so the lookup
+        // short-circuits on a local source (db/cdb) instead of probing remote
+        // sources (e.g. GraphQL) for a path shortcut. Offsets are resolved
+        // below from the bundle header — bytes we must read to serve the item
+        // anyway — and a path lookup is only issued if that local scan misses.
+        rootResult = await this.dataItemRootTxIndex.getRootTx(id, {
+          accept: (r) => r.rootTxId != null,
+        });
         rootTxId = rootResult?.rootTxId;
         rootTxLookupSpan.setAttributes({
           'root.tx_id': rootTxId ?? 'not_found',
@@ -821,15 +829,66 @@ export class RootParentDataSource implements ContiguousDataSource {
               'offset.path_length': rootResult.path.length,
             });
           } else {
-            // Fallback to linear search when path is not available
+            // No path from the local-first lookup: try a cheap linear scan of
+            // the root bundle header, which resolves shallow items (direct
+            // children of the root bundle) with no remote lookup.
             bundleParseResult = await this.ans104OffsetSource.getDataItemOffset(
               id,
               rootTxId,
               signal,
             );
-            offsetParseSpan.setAttributes({
-              'offset.method': 'linear_search',
-            });
+
+            if (bundleParseResult !== null) {
+              metrics.rootTxLocalResolveTotal.inc({ outcome: 'local' });
+              offsetParseSpan.setAttributes({
+                'offset.method': 'linear_search',
+              });
+            } else {
+              // Local scan missed — the item is nested beyond the root bundle's
+              // direct children. Recover the richer result the local-first
+              // lookup skipped by re-querying with the default actionable
+              // acceptance (which may consult remote sources such as GraphQL),
+              // then retry with its path or direct offsets.
+              const actionable = await this.dataItemRootTxIndex.getRootTx(id);
+              if (actionable?.path && actionable.path.length > 0) {
+                bundleParseResult =
+                  await this.ans104OffsetSource.getDataItemOffsetWithPath(
+                    id,
+                    actionable.path,
+                    signal,
+                  );
+                offsetParseSpan.setAttributes({
+                  'offset.method': 'linear_then_path_fallback',
+                  'offset.path_length': actionable.path.length,
+                });
+              } else if (
+                actionable?.rootOffset !== undefined &&
+                actionable?.rootDataOffset !== undefined &&
+                actionable?.dataSize !== undefined
+              ) {
+                // A source supplied direct offsets (absolute within the root
+                // TX), which serve regardless of nesting.
+                bundleParseResult = {
+                  itemOffset: actionable.rootOffset,
+                  dataOffset: actionable.rootDataOffset,
+                  itemSize: actionable.size ?? actionable.dataSize,
+                  dataSize: actionable.dataSize,
+                  contentType: actionable.contentType,
+                };
+                offsetParseSpan.setAttributes({
+                  'offset.method': 'linear_then_offsets_fallback',
+                });
+              } else {
+                offsetParseSpan.setAttributes({
+                  'offset.method': 'linear_search',
+                });
+              }
+
+              metrics.rootTxLocalResolveTotal.inc({
+                outcome:
+                  bundleParseResult !== null ? 'remote_fallback' : 'unresolved',
+              });
+            }
           }
           offsetParseSpan.setAttributes({
             'offset.found': bundleParseResult !== null,

--- a/src/data/root-parent-data-source.ts
+++ b/src/data/root-parent-data-source.ts
@@ -105,6 +105,85 @@ export class RootParentDataSource implements ContiguousDataSource {
   }
 
   /**
+   * Recovers a data item's offset after the local bundle-header scan missed
+   * (the item is nested beyond the root bundle's direct children). Re-queries
+   * the root index with the default actionable acceptance — which may consult
+   * remote sources such as GraphQL — and derives the offset from its path or
+   * direct offsets. Runs under its own span so this slow path's latency is
+   * visible in traces, separate from the cheap local scan.
+   *
+   * @returns The resolved offset (or `null` if unresolved) and the method used.
+   */
+  private async resolveRemoteFallbackOffset(
+    id: string,
+    parentSpan: Span,
+    signal?: AbortSignal,
+  ): Promise<{
+    result: {
+      itemOffset: number;
+      dataOffset: number;
+      itemSize: number;
+      dataSize: number;
+      contentType?: string;
+    } | null;
+    method:
+      | 'linear_then_path_fallback'
+      | 'linear_then_offsets_fallback'
+      | 'linear_search';
+  }> {
+    const span = startChildSpan(
+      'RootParentDataSource.remoteFallbackOffset',
+      { attributes: { 'data.id': id } },
+      parentSpan,
+    );
+    try {
+      const actionable = await this.dataItemRootTxIndex.getRootTx(id);
+
+      if (actionable?.path && actionable.path.length > 0) {
+        const result = await this.ans104OffsetSource.getDataItemOffsetWithPath(
+          id,
+          actionable.path,
+          signal,
+        );
+        span.setAttributes({
+          'offset.method': 'linear_then_path_fallback',
+          'offset.path_length': actionable.path.length,
+          'offset.found': result !== null,
+        });
+        return { result, method: 'linear_then_path_fallback' };
+      }
+
+      if (
+        actionable?.rootOffset !== undefined &&
+        actionable?.rootDataOffset !== undefined &&
+        actionable?.dataSize !== undefined
+      ) {
+        // Direct offsets are absolute within the root TX, so they serve
+        // regardless of nesting.
+        span.setAttributes({ 'offset.method': 'linear_then_offsets_fallback' });
+        return {
+          result: {
+            itemOffset: actionable.rootOffset,
+            dataOffset: actionable.rootDataOffset,
+            itemSize: actionable.size ?? actionable.dataSize,
+            dataSize: actionable.dataSize,
+            contentType: actionable.contentType,
+          },
+          method: 'linear_then_offsets_fallback',
+        };
+      }
+
+      span.setAttributes({
+        'offset.method': 'linear_search',
+        'offset.found': false,
+      });
+      return { result: null, method: 'linear_search' };
+    } finally {
+      span.end();
+    }
+  }
+
+  /**
    * Attempts to cache data attributes, logging a warning on failure.
    * Never throws — storage failures should not block data retrieval.
    */
@@ -844,46 +923,18 @@ export class RootParentDataSource implements ContiguousDataSource {
                 'offset.method': 'linear_search',
               });
             } else {
-              // Local scan missed — the item is nested beyond the root bundle's
-              // direct children. Recover the richer result the local-first
-              // lookup skipped by re-querying with the default actionable
-              // acceptance (which may consult remote sources such as GraphQL),
-              // then retry with its path or direct offsets.
-              const actionable = await this.dataItemRootTxIndex.getRootTx(id);
-              if (actionable?.path && actionable.path.length > 0) {
-                bundleParseResult =
-                  await this.ans104OffsetSource.getDataItemOffsetWithPath(
-                    id,
-                    actionable.path,
-                    signal,
-                  );
-                offsetParseSpan.setAttributes({
-                  'offset.method': 'linear_then_path_fallback',
-                  'offset.path_length': actionable.path.length,
-                });
-              } else if (
-                actionable?.rootOffset !== undefined &&
-                actionable?.rootDataOffset !== undefined &&
-                actionable?.dataSize !== undefined
-              ) {
-                // A source supplied direct offsets (absolute within the root
-                // TX), which serve regardless of nesting.
-                bundleParseResult = {
-                  itemOffset: actionable.rootOffset,
-                  dataOffset: actionable.rootDataOffset,
-                  itemSize: actionable.size ?? actionable.dataSize,
-                  dataSize: actionable.dataSize,
-                  contentType: actionable.contentType,
-                };
-                offsetParseSpan.setAttributes({
-                  'offset.method': 'linear_then_offsets_fallback',
-                });
-              } else {
-                offsetParseSpan.setAttributes({
-                  'offset.method': 'linear_search',
-                });
-              }
-
+              // Local scan missed — the item is nested beyond the root
+              // bundle's direct children. Recover via a full lookup (which may
+              // consult remote sources such as GraphQL).
+              const fallback = await this.resolveRemoteFallbackOffset(
+                id,
+                span,
+                signal,
+              );
+              bundleParseResult = fallback.result;
+              offsetParseSpan.setAttributes({
+                'offset.method': fallback.method,
+              });
               metrics.rootTxLocalResolveTotal.inc({
                 outcome:
                   bundleParseResult !== null ? 'remote_fallback' : 'unresolved',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1466,16 +1466,9 @@ export const compositeRootTxSourcesProbedSummary = new promClient.Summary({
   help: 'Number of sources queried per composite root TX lookup before returning',
 });
 
-// Outcome of the local-first data item offset resolution in RootParentDataSource
-// (only counted for bare-rootTxId results, where the optimization applies):
-//   - local: resolved to an offset by a local bundle-header scan, avoiding a
-//     remote path/offsets lookup (e.g. GraphQL)
-//   - remote_fallback: the local scan missed (nested item) and a full lookup
-//     (possibly remote) recovered a path or direct offsets
-//   - unresolved: neither the local scan nor the fallback lookup found the item
 export const rootTxLocalResolveTotal = new promClient.Counter({
   name: 'root_tx_local_resolve_total',
-  help: 'Outcome of local-first data item offset resolution by RootParentDataSource',
+  help: 'Outcome of RootParentDataSource local-first offset resolution for bare-rootTxId results: local (resolved by a local bundle-header scan, remote lookup avoided), remote_fallback (local scan missed and a full lookup recovered a path or direct offsets), or unresolved (neither found the item)',
   labelNames: ['outcome'] as const,
 });
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1466,6 +1466,19 @@ export const compositeRootTxSourcesProbedSummary = new promClient.Summary({
   help: 'Number of sources queried per composite root TX lookup before returning',
 });
 
+// Outcome of the local-first data item offset resolution in RootParentDataSource
+// (only counted for bare-rootTxId results, where the optimization applies):
+//   - local: resolved to an offset by a local bundle-header scan, avoiding a
+//     remote path/offsets lookup (e.g. GraphQL)
+//   - remote_fallback: the local scan missed (nested item) and a full lookup
+//     (possibly remote) recovered a path or direct offsets
+//   - unresolved: neither the local scan nor the fallback lookup found the item
+export const rootTxLocalResolveTotal = new promClient.Counter({
+  name: 'root_tx_local_resolve_total',
+  help: 'Outcome of local-first data item offset resolution by RootParentDataSource',
+  labelNames: ['outcome'] as const,
+});
+
 //
 // Root TX Semaphore metrics
 //


### PR DESCRIPTION
**Stacked on #828** (`PE-9134-roottx-accept-predicate`) → #827. Base retargets down the stack as each lands. Part 2 of the follow-up — the first change that actually *uses* the accept predicate.

## What

`RootParentDataSource` legacy traversal now resolves the root TX **local-first**:

1. `getRootTx(id, { accept: r => r.rootTxId != null })` — short-circuits on the first source carrying a rootTxId (db/cdb), skipping remote sources.
2. Resolve offsets from the bundle header via the existing `getDataItemOffset` linear scan — bytes the source reads to serve the item anyway.
3. **Only if that local scan misses** (item nested beyond the root bundle's direct children) do we issue a full actionable `getRootTx(id)` (which may consult GraphQL) and retry with its path (path-guided nav) or direct offsets.

## Why

Validated on a canary: `l1_root` short-circuits at db carry most of the win, but the frozen historical CDB population is bare `{r}` (rootTxId only, no path/offsets, un-re-exportable), so those hits still fell through to GraphQL for a path shortcut. When GraphQL is slow, every one of those eats a multi-second round-trip for an item the CDB already located. This resolves them from the local bundle header instead.

## Safety — today's behavior is the floor

- **Shallow items** (direct children of the root bundle): resolve with **zero remote lookup**. Win.
- **Nested items**: identical to today (the on-miss fallback issues the same GraphQL path lookup), plus one cheap local scan. Cannot do worse.
- The not-found path still consults the full chain (incl. GraphQL) before erroring — no coverage regression.

The only way this regresses is a bug in the on-miss fallback, which the new metric + canary error watch catch quickly.

## Observability

`root_tx_local_resolve_total{outcome}` with `local` (resolved by local scan, GraphQL avoided) / `remote_fallback` (local miss, recovered a path or offsets) / `unresolved`. The `local` share is the direct measure of GraphQL avoidance.

## Tests

New: local-scan short-circuit (asserts a single, rootId-accepting lookup and no remote fallback) and the on-miss path fallback (asserts the second default lookup + path-guided retry). Updated the existing not-found test for the extra fallback lookup. 38/38 pass.

## Rollout

Canary on one gateway, watch `root_tx_local_resolve_total` (expect a healthy `local` share), `caller_accept` exit reason, GraphQL probe rate, and error rate. `tx-metadata-resolver` gets the same treatment in a follow-up if this looks good.