### PR TITLE
feat(manifest): observability metrics for path resolution

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1806,3 +1806,35 @@ export const optimisticTxVerificationBlockedCounter = new promClient.Counter({
   name: 'optimistic_tx_verification_blocked_total',
   help: 'Count of verification attempts withheld because the root tx is not yet mined (optimistic / NULL height)',
 });
+
+//
+// Manifest path resolution
+//
+
+// Count of manifest path resolutions, split by `source` — `index` (served
+// from the persistent/cached index without parsing the body) vs `data`
+// (on-demand body parse) — and by how the path resolved (`resolution_type`:
+// path / index / fallback / unresolved). The index-vs-data ratio is the
+// effectiveness signal for the resolution index and cache.
+export const manifestResolutionsTotal = new promClient.Counter({
+  name: 'manifest_resolutions_total',
+  help: 'Manifest path resolutions, by source (index vs on-demand data parse) and resolution type',
+  labelNames: ['source', 'resolution_type'] as const,
+});
+
+// Count of manifest root/index requests that resolved to nothing. A rising
+// value points at malformed manifests (e.g. an `index.path` with no matching
+// `paths` entry and no fallback) being served from the gateway.
+export const manifestUnresolvedRootTotal = new promClient.Counter({
+  name: 'manifest_unresolved_root_total',
+  help: 'Manifest root/index requests that resolved to nothing (likely a malformed manifest)',
+});
+
+// Manifest path resolution latency, by `source`. `data` resolutions parse the
+// (potentially large) manifest body; `index` resolutions are a bounded lookup.
+export const manifestResolutionDurationSeconds = new promClient.Histogram({
+  name: 'manifest_resolution_duration_seconds',
+  help: 'Manifest path resolution latency, by source',
+  labelNames: ['source'] as const,
+  buckets: [0.0005, 0.001, 0.005, 0.025, 0.1, 0.5, 2],
+});

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1811,27 +1811,33 @@ export const optimisticTxVerificationBlockedCounter = new promClient.Counter({
 // Manifest path resolution
 //
 
-// Count of manifest path resolutions, split by `source` — `index` (served
-// from the persistent/cached index without parsing the body) vs `data`
-// (on-demand body parse) — and by how the path resolved (`resolution_type`:
-// path / index / fallback / unresolved). The index-vs-data ratio is the
-// effectiveness signal for the resolution index and cache.
+/**
+ * Count of manifest path resolutions, split by `source` — `index` (served from
+ * the persistent/cached index without parsing the body) vs `data` (on-demand
+ * body parse) — and by how the path resolved (`resolution_type`:
+ * path / index / fallback / unresolved). The index-vs-data ratio is the
+ * effectiveness signal for the resolution index and cache.
+ */
 export const manifestResolutionsTotal = new promClient.Counter({
   name: 'manifest_resolutions_total',
   help: 'Manifest path resolutions, by source (index vs on-demand data parse) and resolution type',
   labelNames: ['source', 'resolution_type'] as const,
 });
 
-// Count of manifest root/index requests that resolved to nothing. A rising
-// value points at malformed manifests (e.g. an `index.path` with no matching
-// `paths` entry and no fallback) being served from the gateway.
+/**
+ * Count of manifest root/index requests that resolved to nothing. A rising
+ * value points at malformed manifests (e.g. an `index.path` with no matching
+ * `paths` entry and no fallback) being served from the gateway.
+ */
 export const manifestUnresolvedRootTotal = new promClient.Counter({
   name: 'manifest_unresolved_root_total',
   help: 'Manifest root/index requests that resolved to nothing (likely a malformed manifest)',
 });
 
-// Manifest path resolution latency, by `source`. `data` resolutions parse the
-// (potentially large) manifest body; `index` resolutions are a bounded lookup.
+/**
+ * Manifest path resolution latency, by `source`. `data` resolutions parse the
+ * (potentially large) manifest body; `index` resolutions are a bounded lookup.
+ */
 export const manifestResolutionDurationSeconds = new promClient.Histogram({
   name: 'manifest_resolution_duration_seconds',
   help: 'Manifest path resolution latency, by source',

--- a/src/routes/data/handlers.ts
+++ b/src/routes/data/handlers.ts
@@ -1381,9 +1381,19 @@ export const createRawDataHandler = ({
   });
 };
 
-// Record Prometheus metrics for a manifest path resolution. `source` is
-// `index` when the persistent/cached index produced the outcome, or `data`
-// when the manifest body was parsed on demand. Exported for testing.
+/**
+ * Record Prometheus metrics for a single manifest path resolution.
+ *
+ * Exported for testing.
+ *
+ * @param source - `index` when the persistent/cached index produced the
+ *   outcome, or `data` when the manifest body was parsed on demand.
+ * @param resolution - The resolution result; `resolvedId`/`resolutionType`
+ *   drive the `resolution_type` label (`unresolved` when nothing matched).
+ * @param manifestPath - The requested sub-path (undefined/empty is the root);
+ *   an unresolved root increments `manifest_unresolved_root_total`.
+ * @param durationMs - Resolution wall-clock time, in milliseconds.
+ */
 export const recordManifestResolutionMetrics = ({
   source,
   resolution,

--- a/src/routes/data/handlers.ts
+++ b/src/routes/data/handlers.ts
@@ -20,6 +20,7 @@ import { Span } from '@opentelemetry/api';
 import { MANIFEST_CONTENT_TYPE } from '../../lib/encoding.js';
 import { formatContentDigest } from '../../lib/digest.js';
 import { extractAllClientIPs } from '../../lib/ip-utils.js';
+import * as metrics from '../../metrics.js';
 import {
   parseViaHeader,
   detectLoopInViaChain,
@@ -33,6 +34,7 @@ import {
   ContiguousDataSource,
   DataAttributesSource,
   ManifestPathResolver,
+  ManifestResolution,
   RequestAttributes,
 } from '../../types.js';
 import { RateLimiter } from '../../limiter/types.js';
@@ -1379,6 +1381,38 @@ export const createRawDataHandler = ({
   });
 };
 
+// Record Prometheus metrics for a manifest path resolution. `source` is
+// `index` when the persistent/cached index produced the outcome, or `data`
+// when the manifest body was parsed on demand. Exported for testing.
+export const recordManifestResolutionMetrics = ({
+  source,
+  resolution,
+  manifestPath,
+  durationMs,
+}: {
+  source: 'index' | 'data';
+  resolution: ManifestResolution;
+  manifestPath: string | undefined;
+  durationMs: number;
+}): void => {
+  const resolutionType =
+    resolution.resolvedId !== undefined && resolution.resolutionType
+      ? resolution.resolutionType
+      : 'unresolved';
+  metrics.manifestResolutionsTotal.inc({
+    source,
+    resolution_type: resolutionType,
+  });
+  metrics.manifestResolutionDurationSeconds.observe(
+    { source },
+    durationMs / 1000,
+  );
+  const isRoot = (manifestPath ?? '').replace(/\/+$/g, '') === '';
+  if (isRoot && resolution.resolvedId === undefined) {
+    metrics.manifestUnresolvedRootTotal.inc();
+  }
+};
+
 const sendManifestResponse = async ({
   log,
   req,
@@ -1758,6 +1792,17 @@ export const createDataHandler = ({
             'manifest.resolution_duration_ms',
             manifestDuration,
           );
+          // Only count `index` when the index actually determined the outcome
+          // (complete). A miss (`complete: false`) falls through and is counted
+          // at the data-parse site below.
+          if (manifestResolution.complete) {
+            recordManifestResolutionMetrics({
+              source: 'index',
+              resolution: manifestResolution,
+              manifestPath,
+              durationMs: manifestDuration,
+            });
+          }
           if (
             manifestResolution.resolvedId !== undefined &&
             manifestResolution.resolvedId !== ''
@@ -1899,6 +1944,12 @@ export const createDataHandler = ({
             'manifest.resolution_from_data_duration_ms',
             manifestDuration,
           );
+          recordManifestResolutionMetrics({
+            source: 'data',
+            resolution: manifestResolution,
+            manifestPath,
+            durationMs: manifestDuration,
+          });
 
           // The original stream is no longer needed after path resolution
           data.stream.destroy();

--- a/src/routes/data/manifest-resolution-metrics.test.ts
+++ b/src/routes/data/manifest-resolution-metrics.test.ts
@@ -11,6 +11,11 @@ import * as metrics from '../../metrics.js';
 import { ManifestResolution } from '../../types.js';
 import { recordManifestResolutionMetrics } from './handlers.js';
 
+/**
+ * Read a counter/gauge sample value from a prom-client metric. Counter and
+ * gauge samples have no `metricName` (only histogram bucket/sum/count samples
+ * do), so those are filtered out. Returns 0 when no sample matches `labels`.
+ */
 const counterValue = async (
   metric: { get: () => Promise<any> },
   labels: Record<string, string> = {},
@@ -24,6 +29,10 @@ const counterValue = async (
   return match?.value ?? 0;
 };
 
+/**
+ * Read a histogram's observation count (the `<name>_count` sample) for the
+ * given `labels`. Returns 0 when no matching sample exists.
+ */
 const histogramCount = async (
   metric: { get: () => Promise<any> },
   labels: Record<string, string>,
@@ -38,6 +47,10 @@ const histogramCount = async (
   return match?.value ?? 0;
 };
 
+/**
+ * Build a ManifestResolution, defaulting to a resolved root index resolution;
+ * pass `overrides` to vary individual fields (e.g. an unresolved result).
+ */
 const resolution = (
   overrides: Partial<ManifestResolution> = {},
 ): ManifestResolution => ({

--- a/src/routes/data/manifest-resolution-metrics.test.ts
+++ b/src/routes/data/manifest-resolution-metrics.test.ts
@@ -1,0 +1,129 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { strict as assert } from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+
+import * as metrics from '../../metrics.js';
+import { ManifestResolution } from '../../types.js';
+import { recordManifestResolutionMetrics } from './handlers.js';
+
+const counterValue = async (
+  metric: { get: () => Promise<any> },
+  labels: Record<string, string> = {},
+): Promise<number> => {
+  const data = await metric.get();
+  const match = data.values.find(
+    (v: any) =>
+      v.metricName === undefined &&
+      Object.entries(labels).every(([k, val]) => v.labels[k] === val),
+  );
+  return match?.value ?? 0;
+};
+
+const histogramCount = async (
+  metric: { get: () => Promise<any> },
+  labels: Record<string, string>,
+): Promise<number> => {
+  const data = await metric.get();
+  const match = data.values.find(
+    (v: any) =>
+      typeof v.metricName === 'string' &&
+      v.metricName.endsWith('_count') &&
+      Object.entries(labels).every(([k, val]) => v.labels[k] === val),
+  );
+  return match?.value ?? 0;
+};
+
+const resolution = (
+  overrides: Partial<ManifestResolution> = {},
+): ManifestResolution => ({
+  id: 'manifest-id',
+  resolvedId: 'x2P63S6rvp5d16Js-xDdk9AijHDNd5Vtbys95Jg65i4',
+  complete: true,
+  resolutionType: 'index',
+  ...overrides,
+});
+
+describe('recordManifestResolutionMetrics', () => {
+  beforeEach(() => {
+    metrics.manifestResolutionsTotal.reset();
+    metrics.manifestUnresolvedRootTotal.reset();
+    metrics.manifestResolutionDurationSeconds.reset();
+  });
+
+  it('counts a resolved root by source and resolution type, and records duration', async () => {
+    recordManifestResolutionMetrics({
+      source: 'data',
+      resolution: resolution({ resolutionType: 'index' }),
+      manifestPath: undefined,
+      durationMs: 5,
+    });
+
+    assert.equal(
+      await counterValue(metrics.manifestResolutionsTotal, {
+        source: 'data',
+        resolution_type: 'index',
+      }),
+      1,
+    );
+    assert.equal(
+      await histogramCount(metrics.manifestResolutionDurationSeconds, {
+        source: 'data',
+      }),
+      1,
+    );
+    assert.equal(await counterValue(metrics.manifestUnresolvedRootTotal), 0);
+  });
+
+  it('labels a resolved id with no resolution type as "unresolved" defensively', async () => {
+    recordManifestResolutionMetrics({
+      source: 'index',
+      resolution: resolution({
+        resolvedId: undefined,
+        resolutionType: undefined,
+      }),
+      manifestPath: 'assets/app.js',
+      durationMs: 1,
+    });
+
+    assert.equal(
+      await counterValue(metrics.manifestResolutionsTotal, {
+        source: 'index',
+        resolution_type: 'unresolved',
+      }),
+      1,
+    );
+  });
+
+  it('increments the unresolved-root counter for an unresolved root request', async () => {
+    recordManifestResolutionMetrics({
+      source: 'data',
+      resolution: resolution({
+        resolvedId: undefined,
+        resolutionType: undefined,
+      }),
+      manifestPath: '/',
+      durationMs: 1,
+    });
+
+    assert.equal(await counterValue(metrics.manifestUnresolvedRootTotal), 1);
+  });
+
+  it('does not increment the unresolved-root counter for an unresolved sub-path', async () => {
+    recordManifestResolutionMetrics({
+      source: 'data',
+      resolution: resolution({
+        resolvedId: undefined,
+        resolutionType: undefined,
+      }),
+      manifestPath: 'some/missing/asset.png',
+      durationMs: 1,
+    });
+
+    assert.equal(await counterValue(metrics.manifestUnresolvedRootTotal), 0);
+  });
+});


### PR DESCRIPTION
Adds the observability layer (1e) for manifest path resolution. Independent of the resolution PR (#833) — touches only `metrics.ts` and the data handler, no overlap — and is meaningful now (data-path metrics) and richer once #833 lands (index-path metrics start firing).

## Metrics
- **`manifest_resolutions_total{source,resolution_type}`** — resolutions by `source` (`index` = served from the persistent/cached index without parsing the body, vs `data` = on-demand body parse) and `resolution_type` (`path`/`index`/`fallback`/`unresolved`). The **index-vs-data ratio** is the effectiveness signal for the resolution index + cache.
- **`manifest_unresolved_root_total`** — root/index requests that resolved to nothing (a malformed-manifest signal that today only surfaces as a user 404).
- **`manifest_resolution_duration_seconds{source}`** — resolution latency by source (bounded lookup vs body parse).

## Placement
Instruments the two existing resolution sites in `src/routes/data/handlers.ts`. `index` is counted only when the index actually determined the outcome (`complete`); a miss falls through and is counted at the data-parse site, so each resolution is counted once.

## Tests
`manifest-resolution-metrics.test.ts` (new, 4): verifies label routing (source × resolution_type), duration observation, and that the unresolved-root counter fires for an unresolved **root** but not for an unresolved **sub-path**. Handler suite unaffected (96/96); lint clean; zero new type errors.

## Notes
No new env var and no metrics doc exists in `docs/`, so nothing to sync there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPbcF2M3P1XcM8mU8FWEf9