### PR TITLE
feat(arns): resolve on-demand by default + bundled observer self-references local gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **ArNS resolves on-demand (from chain) by default** — the default
+  `ARNS_RESOLVER_PRIORITY_ORDER` is now `on-demand,gateway` (was
+  `gateway,on-demand`). Each gateway resolves ArNS names authoritatively from the
+  ANT record itself, falling back to a trusted-gateway hop only if the on-demand
+  resolver fails. This makes gateways self-sufficient rather than clients of a few
+  trusted gateways (more decentralized) and reads the source of truth instead of
+  another gateway's possibly-stale cached answer. On-demand adds a chain read per
+  cache-miss resolution (cheap on Solana RPC; heavier as an AO CU dryrun) — set
+  `ARNS_RESOLVER_PRIORITY_ORDER=gateway,on-demand` to restore the prior behavior.
+  The bundled observer now references this node's own gateway
+  (`ARNS_ROOT_HOST`) by default, so its reference resolution is authoritative and
+  local.
+
 - **Chunk-post fan-out narrows to the configured threshold** — now that HTTP 303
   counts as a successful (temporary) acceptance (see Fixed), broadcasts stop at
   `CHUNK_POST_MIN_SUCCESS_COUNT` as intended instead of grinding the full peer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,13 @@ disk and take down every container on the host.
   (`ARNS_ROOT_HOST`) by default, so its reference resolution is authoritative and
   local.
 
+  `ARNS_COMPOSITE_LAST_RESOLVER_TIMEOUT_MS` drops from `30000` to `5000` as part
+  of the same change. The order flip makes the gateway resolver last, so a name
+  that does not exist costs the on-demand attempt (~3s) plus that entire budget
+  before 404ing — a ~33s 404 at the old default. Names that do exist are
+  unaffected, since on-demand resolves them first and never reaches the last
+  resolver.
+
 - **Untrusted gateways no longer receive `ar-io-*` provenance query params** —
   gateways configured with `"trusted": false` in `TRUSTED_GATEWAYS_URLS` now get
   provenance via `X-AR-IO-*` headers only. Required for CDN-fronted gateways

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,19 @@ disk and take down every container on the host.
 
 ### Changed
 
+- **ArNS resolves on-demand (from chain) by default** — the default
+  `ARNS_RESOLVER_PRIORITY_ORDER` is now `on-demand,gateway` (was
+  `gateway,on-demand`). Each gateway resolves ArNS names authoritatively from the
+  ANT record itself, falling back to a trusted-gateway hop only if the on-demand
+  resolver fails. This makes gateways self-sufficient rather than clients of a few
+  trusted gateways (more decentralized) and reads the source of truth instead of
+  another gateway's possibly-stale cached answer. On-demand adds a chain read per
+  cache-miss resolution (cheap on Solana RPC; heavier as an AO CU dryrun) — set
+  `ARNS_RESOLVER_PRIORITY_ORDER=gateway,on-demand` to restore the prior behavior.
+  The bundled observer now references this node's own gateway
+  (`ARNS_ROOT_HOST`) by default, so its reference resolution is authoritative and
+  local.
+
 - **Untrusted gateways no longer receive `ar-io-*` provenance query params** —
   gateways configured with `"trusted": false` in `TRUSTED_GATEWAYS_URLS` now get
   provenance via `X-AR-IO-*` headers only. Required for CDN-fronted gateways

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -660,7 +660,14 @@ services:
       - AR_IO_NODE_RELEASE=${AR_IO_NODE_RELEASE:-82-pre}
       - AR_IO_SDK_LOG_LEVEL=${AR_IO_SDK_LOG_LEVEL:-none}
       # Reference Gateway Configuration
-      - REFERENCE_GATEWAY_HOSTS=${REFERENCE_GATEWAY_HOSTS:-}
+      # The bundled observer references THIS node's own gateway by default (its
+      # ARNS_ROOT_HOST), rather than external gateways. Since the gateway now
+      # resolves ArNS on-demand (authoritatively, from chain), self-reference is
+      # both authoritative and more decentralized — the observer forms its own
+      # chain-derived view and the protocol aggregates observers by majority.
+      # Falls back to the observer's own default (turbo/ar-io.net) if neither
+      # REFERENCE_GATEWAY_HOSTS nor ARNS_ROOT_HOST is set.
+      - REFERENCE_GATEWAY_HOSTS=${REFERENCE_GATEWAY_HOSTS:-${ARNS_ROOT_HOST:-}}
       - REFERENCE_GATEWAY_NETWORK_ONLY=${REFERENCE_GATEWAY_NETWORK_ONLY:-}
       - REFERENCE_GATEWAY_NETWORK_FALLBACK=${REFERENCE_GATEWAY_NETWORK_FALLBACK:-}
       - REFERENCE_GATEWAY_CONSENSUS_SIZE=${REFERENCE_GATEWAY_CONSENSUS_SIZE:-}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -713,7 +713,14 @@ services:
       - AR_IO_NODE_RELEASE=${AR_IO_NODE_RELEASE:-83-pre}
       - AR_IO_SDK_LOG_LEVEL=${AR_IO_SDK_LOG_LEVEL:-none}
       # Reference Gateway Configuration
-      - REFERENCE_GATEWAY_HOSTS=${REFERENCE_GATEWAY_HOSTS:-}
+      # The bundled observer references THIS node's own gateway by default (its
+      # ARNS_ROOT_HOST), rather than external gateways. Since the gateway now
+      # resolves ArNS on-demand (authoritatively, from chain), self-reference is
+      # both authoritative and more decentralized — the observer forms its own
+      # chain-derived view and the protocol aggregates observers by majority.
+      # Falls back to the observer's own default (turbo/ar-io.net) if neither
+      # REFERENCE_GATEWAY_HOSTS nor ARNS_ROOT_HOST is set.
+      - REFERENCE_GATEWAY_HOSTS=${REFERENCE_GATEWAY_HOSTS:-${ARNS_ROOT_HOST:-}}
       - REFERENCE_GATEWAY_NETWORK_ONLY=${REFERENCE_GATEWAY_NETWORK_ONLY:-}
       - REFERENCE_GATEWAY_NETWORK_FALLBACK=${REFERENCE_GATEWAY_NETWORK_FALLBACK:-}
       - REFERENCE_GATEWAY_CONSENSUS_SIZE=${REFERENCE_GATEWAY_CONSENSUS_SIZE:-}

--- a/src/config.ts
+++ b/src/config.ts
@@ -2629,8 +2629,14 @@ export const ARNS_CACHE_MAX_KEYS = +env.varOrDefault(
   '10000',
 );
 
+// Resolve ArNS names authoritatively from chain first (on-demand ANT lookups),
+// falling back to a trusted-gateway hop only if the on-demand resolver fails.
+// This makes each gateway self-sufficient rather than a client of a few trusted
+// gateways (more decentralized) and reads the source of truth (the ANT record)
+// instead of another gateway's possibly-stale cached answer. Operators can revert
+// to the previous behavior with ARNS_RESOLVER_PRIORITY_ORDER=gateway,on-demand.
 export const ARNS_RESOLVER_PRIORITY_ORDER = env
-  .varOrDefault('ARNS_RESOLVER_PRIORITY_ORDER', 'gateway,on-demand')
+  .varOrDefault('ARNS_RESOLVER_PRIORITY_ORDER', 'on-demand,gateway')
   .split(',');
 
 export const ARNS_COMPOSITE_RESOLVER_TIMEOUT_MS = +env.varOrDefault(

--- a/src/config.ts
+++ b/src/config.ts
@@ -2935,8 +2935,14 @@ export const ARNS_CACHE_MAX_KEYS = +env.varOrDefault(
   '10000',
 );
 
+// Resolve ArNS names authoritatively from chain first (on-demand ANT lookups),
+// falling back to a trusted-gateway hop only if the on-demand resolver fails.
+// This makes each gateway self-sufficient rather than a client of a few trusted
+// gateways (more decentralized) and reads the source of truth (the ANT record)
+// instead of another gateway's possibly-stale cached answer. Operators can revert
+// to the previous behavior with ARNS_RESOLVER_PRIORITY_ORDER=gateway,on-demand.
 export const ARNS_RESOLVER_PRIORITY_ORDER = env
-  .varOrDefault('ARNS_RESOLVER_PRIORITY_ORDER', 'gateway,on-demand')
+  .varOrDefault('ARNS_RESOLVER_PRIORITY_ORDER', 'on-demand,gateway')
   .split(',');
 
 export const ARNS_COMPOSITE_RESOLVER_TIMEOUT_MS = +env.varOrDefault(

--- a/src/config.ts
+++ b/src/config.ts
@@ -2950,9 +2950,20 @@ export const ARNS_COMPOSITE_RESOLVER_TIMEOUT_MS = +env.varOrDefault(
   '3000',
 );
 
+// Budget for the LAST resolver in the chain, which is allowed to run longer
+// than the others because nothing follows it.
+//
+// Lowered from 30000 alongside the on-demand-first default above, because that
+// flip is what makes this timeout user-visible. The gateway resolver is now
+// last, so a name that does not exist costs the full on-demand attempt
+// (bounded by ARNS_COMPOSITE_RESOLVER_TIMEOUT_MS, ~3s) and then the whole of
+// this budget before 404ing. At 30000 that is a ~33s 404; measured on a
+// production gateway running this order since 2026-06-08, and the reason that
+// operator has overridden it to 5000 ever since. Real names are unaffected:
+// on-demand resolves them first and never reaches this resolver.
 export const ARNS_COMPOSITE_LAST_RESOLVER_TIMEOUT_MS = +env.varOrDefault(
   'ARNS_COMPOSITE_LAST_RESOLVER_TIMEOUT_MS',
-  '30000',
+  '5000',
 );
 
 export const ARNS_NAMES_CACHE_TTL_SECONDS = +env.varOrDefault(


### PR DESCRIPTION
## What

Two small, synergistic default changes that make the standard AR.IO node deployment resolve ArNS **authoritatively and decentrally**:

1. **`ARNS_RESOLVER_PRIORITY_ORDER` default → `on-demand,gateway`** (was `gateway,on-demand`). The gateway resolves ArNS names by reading the **ANT record from chain** first (`OnDemandArNSResolver` via `SolanaANTReadable`), falling back to a trusted-gateway hop (`TrustedGatewayArNSResolver`) only if the on-demand resolver fails.
2. **Bundled observer references this node's own gateway** (`ARNS_ROOT_HOST`) by default, instead of external gateways.

## Why

- **Decentralization.** A gateway that hops to turbo/ar-io.net for resolution is a *client* of those gateways — a soft centralization. Reading the ANT directly makes each gateway self-sufficient and removes the chokepoint.
- **Authoritative.** Reads the source of truth (the ANT record) rather than another gateway's possibly-stale cached answer.
- **It's what serious operators already run** (turbo-gateway.com and others use on-demand).
- The two changes reinforce each other: the observer's self-reference is only *authoritative* because the gateway now resolves on-demand. Together they make the default deployment's observation trustless-by-default, while the protocol continues to aggregate observers by majority.

## Safety / fallback

- The trusted-gateway hop is **kept as a fallback**, so resolution degrades gracefully if chain RPC is briefly unavailable — no new single point of failure.
- The observer falls back to its own default (turbo/ar-io.net) if neither `REFERENCE_GATEWAY_HOSTS` nor `ARNS_ROOT_HOST` is set.
- Both are fully overridable per operator (`ARNS_RESOLVER_PRIORITY_ORDER=gateway,on-demand`, `REFERENCE_GATEWAY_HOSTS=…`).

## For reviewers — the one thing to weigh

On-demand adds a chain read per **cache-miss** resolution. That's cheap on Solana (RPC account read) but **heavier on AO** (CU dryrun, rate-limitable). Worth a quick latency / RPC-load sanity check on the heavier network before this ships broadly; per-gateway caching recovers repeat-name latency, and the `gateway` fallback + per-op override bound the downside. Consider per-network defaults if AO cost is material.

## Scope

Intentionally standalone — this flips resolution behavior for **all** names and operators, so it's separated from any feature work for its own review and perf validation. No test asserts the prior order; `docker compose config` validated (self-reference resolves when `ARNS_ROOT_HOST` is set, empty otherwise).


---

## Update 2026-09-01 — rebased onto develop, plus one companion fix

Rebased onto `develop` (`cc7bedf2`); the conflict was CHANGELOG-only and the diff is back to the same three files.

### Added: `ARNS_COMPOSITE_LAST_RESOLVER_TIMEOUT_MS` 30000 → 5000

Flipping the order moves the **gateway resolver to last**, and the last resolver gets its own much larger budget. So a name that does not exist now costs the full on-demand attempt (~3s, bounded by `ARNS_COMPOSITE_RESOLVER_TIMEOUT_MS`) **and then the entire 30s last-resolver budget** before returning 404 — a ~33 second 404.

Names that do exist are unaffected: on-demand resolves them first and the last resolver is never reached. Revert with `ARNS_COMPOSITE_LAST_RESOLVER_TIMEOUT_MS=30000`.

### Field evidence for the main change

A production mainnet gateway has run `ARNS_RESOLVER_PRIORITY_ORDER=on-demand,gateway` since **2026-06-08 — just under three months**. Two things that operator learned are directly relevant here:

- It has overridden `ARNS_COMPOSITE_LAST_RESOLVER_TIMEOUT_MS=5000` that entire time, for exactly the 33s-404 reason above. The new default is therefore a value already validated under load rather than a guess.
- It also sets `ARNS_ON_DEMAND_CIRCUIT_BREAKER_TIMEOUT_MS=15000`, believing that widened the on-demand budget. **That variable does not exist** — it appears nowhere in `src/`, nowhere in `docker-compose.yaml`, and is not in the container's environment. Which cuts in this PR's favour: on-demand-first has run in production for three months on the stock `ARNS_COMPOSITE_RESOLVER_TIMEOUT_MS=3000`, so the 3s default needs no change here.

### Validation

`lint:check` clean, `build` clean, config + resolution suites **60 pass / 0 fail**. Nothing in the test suite asserted either old default.
