### PR TITLE
fix(docker): exclude git worktrees from the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,11 @@ envoy/
 *.db*
 data/
 
+# Git worktrees created by ./tools/wt add. Each has its own node_modules and
+# data/ directory, so a handful of them can add tens of GB to the build
+# context - enough to exhaust the Docker daemon's disk part-way through COPY.
+wt/
+
 # Node
 node_modules/
 


### PR DESCRIPTION
`./tools/wt add` creates worktrees under `wt/`, each with its own `node_modules` and `data/` directory. Nothing in `.dockerignore` excluded them, so they were all sent to the daemon as build context.

Measured on one gateway: **`wt/` alone was 31 GB across 9 worktrees**, taking the context from ~2.5 GB to well over 30 GB. Combined with accumulated build cache that was enough to exhaust the daemon's disk part-way through `COPY`, which crashed `dockerd` and SIGKILLed every running container — that gateway was down about 8 hours before the cause was identified.

After the change, `COPY . .` drops to ~0.4s on that host.

This only bites operators who use the repo's own worktree tooling, which makes it easy to miss: the tool that creates the directories is in-tree, but the ignore rule for them was not.

### Scope note

An earlier revision of this PR also excluded `logs/`. I dropped it — `logs/.gitkeep` is tracked, so `logs/` exists in a fresh clone, and `src/log.ts` writes `logs/test.log` under test with a winston File transport that won't create the directory. Excluding it would remove `/app/logs` from the image and break anyone running the test suite inside a container, for essentially no benefit in CI (`/logs/*` is gitignored, so the directory is empty there). `wt/` is the whole win and carries no such risk.