### PR TITLE
fix(test): point E2E chain sync at a non-rate-limited node

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -41,6 +41,17 @@ jobs:
         env:
           TEST_SKIP_TAGS: flaky
           USE_PREBUILT_IMAGE: 'true'
+      # E2E failures give no upstream detail without the container logs.
+      # Testcontainers randomizes the compose project name, so enumerate
+      # whatever containers survive instead of naming a project.
+      - name: Dump container logs on E2E failure
+        if: failure() && github.ref == 'refs/heads/develop' && matrix.os == 'ubuntu-latest'
+        run: |
+          docker ps -a || true
+          for c in $(docker ps -aq); do
+            echo "===== $(docker inspect -f '{{.Name}} {{.Config.Image}}' "$c") ====="
+            docker logs --tail 300 "$c" 2>&1 || true
+          done
 
       # Codecov report
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -36,6 +36,7 @@ jobs:
         if: github.ref == 'refs/heads/develop' && matrix.os == 'ubuntu-latest'
         run: docker build -t core .
       - name: Run E2E tests
+        id: e2e
         if: github.ref == 'refs/heads/develop' && matrix.os == 'ubuntu-latest'
         run: yarn test:e2e
         env:
@@ -45,7 +46,7 @@ jobs:
       # Testcontainers randomizes the compose project name, so enumerate
       # whatever containers survive instead of naming a project.
       - name: Dump container logs on E2E failure
-        if: failure() && github.ref == 'refs/heads/develop' && matrix.os == 'ubuntu-latest'
+        if: failure() && steps.e2e.conclusion == 'failure'
         run: |
           docker ps -a || true
           for c in $(docker ps -aq); do

--- a/test/end-to-end/utils.ts
+++ b/test/end-to-end/utils.ts
@@ -120,7 +120,12 @@ export const composeUp = async ({
   ANS104_UNBUNDLE_FILTER = '{"always": true}',
   ANS104_INDEX_FILTER = '{"always": true}',
   ADMIN_API_KEY = 'secret',
-  TRUSTED_NODE_URL = 'https://arweave.net',
+  // arweave.net sits behind a CDN that rate-limits CI egress IPs. A 429 with a
+  // large Retry-After stalls the block importer past the test timeout, so the
+  // chain source points at an Arweave node instead. Override with
+  // E2E_TRUSTED_NODE_URL to repoint without a code change.
+  TRUSTED_NODE_URL = process.env.E2E_TRUSTED_NODE_URL ??
+    'http://peers.arweave.xyz:1984',
   TRUSTED_GATEWAYS_URLS = '{"https://arweave.net": 1, "https://turbo-gateway.com": 2}',
   BACKGROUND_RETRIEVAL_ORDER = 'trusted-gateways',
   ...ENVIRONMENT

--- a/test/end-to-end/webhook.test.ts
+++ b/test/end-to-end/webhook.test.ts
@@ -74,6 +74,10 @@ describe('WebhookEmitter', { skip: isTestFiltered(['flaky']) }, () => {
         WEBHOOK_INDEX_FILTER: '{"always": true}',
         WEBHOOK_TARGET_SERVERS: 'http://host.testcontainers.internal:4001',
         WEBHOOK_BLOCK_FILTER: '{"always": true}',
+        // This suite imports block 1, so it needs the same non-rate-limited
+        // chain source that composeUp uses.
+        TRUSTED_NODE_URL:
+          process.env.E2E_TRUSTED_NODE_URL ?? 'http://peers.arweave.xyz:1984',
         TRUSTED_GATEWAYS_URLS:
           '{"https://arweave.net": 1, "https://turbo-gateway.com": 2}',
         BACKGROUND_RETRIEVAL_ORDER: 'trusted-gateways',


### PR DESCRIPTION
## Problem

`build-core` has failed on every `develop` push since 2026-07-14. The last green run was 2026-06-19. The `images` job is `needs: test`, so no core image has been published from `develop` in that window.

The failure is always the same. `Indexing > Initialization` times out:

```
Error: Timeout waiting for blocks to reach height 1
    at Timeout.checkCondition (test/end-to-end/utils.ts:189:18)
```

Then all 12 later suites fail with `Bind for 0.0.0.0:4000 failed: port is already allocated`, because the timed-out suite leaves its compose stack running. Those are cascade noise, not separate bugs.

## Cause

The E2E suites point `TRUSTED_NODE_URL` at a CDN-fronted public gateway that rate-limits CI egress. It answers `429` with `Retry-After: 299`:

```
HTTP/2 429
retry-after: 299
```

`trustedNodeAxios` uses retry-axios, which defaults to `checkRetryAfter: true` and `maxRetryAfter: 300000` ms. Since `299 s <= 300 s`, it sleeps the **full 299 seconds per retry**, up to 5 retries, and raises nothing while it waits. `BlockImporter.importBlock` has no timeout, so it parks there. The 60-second test budget is gone after the first 429.

Reproduced locally: `getBlockAndTxsByHeight(1)` hung indefinitely while the host was limiting, and completed in 71 ms once it stopped.

## Fix

Point the chain source at an Arweave node, which is the role `TRUSTED_NODE_URL` actually fills and has no third-party rate limiter in front. Two places import blocks and both are covered:

- `composeUp` in `test/end-to-end/utils.ts` (covers indexing, metrics, moderation, data-sources)
- `webhook.test.ts`, which set no `TRUSTED_NODE_URL` and fell through to the `config.ts` default

`E2E_TRUSTED_NODE_URL` repoints both from the workflow without another commit.

Verified all three endpoints the E2E chain sync needs — `/height`, `/block/height/0`, `/block/height/1`, `/peers` — return 200 across 8 consecutive requests, and block 1 is byte-identical to what the previous host returns.

## Not changed

`TRUSTED_GATEWAYS_URLS` is untouched. Those data suites pass today, and gateway ordering feeds the `x-ar-io-hops` assertions — several tests are already skipped with `x-ar-io-hops returns 2 instead of 1`. Changing it risks breaking passing tests while fixing the block import.

## Also included

A container log dump on E2E failure. The job currently surfaces no upstream detail, which is why this took so long to pin down. It enumerates surviving containers rather than naming a compose project, since testcontainers randomizes project names.

## Caveats

- The 429 in CI is **inferred**, not observed — reproduced from a local IP, never seen in a runner's container logs. That is exactly what the log-dump step is for. If block import still times out, the next run says why.
- The log dump may come back empty if Ryuk reaps containers before the step runs. The failing stacks were not torn down, so they should survive, but it is not guaranteed.
- E2E only runs on `develop` pushes, never on PRs. **This PR's own CI will not exercise the change.** First real validation is the merge.

## Follow-ups (not in this PR)

1. `maxRetryAfter` on `trustedNodeAxios` — a silent 25-minute stall on a 429 is a production risk, not just a CI one. Needs a companion backoff in `BlockImporter`, whose error path currently retries every 50 ms; failing fast without backoff would hammer a limiter.
2. The `Mempool indexing` and `Pending TX GQL indexing` suites poll in unbounded `while` loops with no timeout. They hang the job instead of failing it.
3. E2E does not run on PRs, which is why this went unnoticed for eight weeks.
4. `ArweaveChainSourceStub` and 201 recorded blocks already exist in `test/mock_files/`. The chain-sync suites could run offline and deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)