### PR TITLE
test(e2e): bound the polling loops so a stall fails instead of hangs

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -8,6 +8,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    # Backstop only. A hung poll used to run out the 360-minute default and
+    # burn a runner; the E2E waits now time out on their own well before this.
+    timeout-minutes: 60
     permissions:
       checks: write
       contents: read

--- a/test/end-to-end/bundler-sidecar.test.ts
+++ b/test/end-to-end/bundler-sidecar.test.ts
@@ -13,7 +13,7 @@ import {
   StartedDockerComposeEnvironment,
   Wait,
 } from 'testcontainers';
-import wait from '../../src/lib/wait.js';
+import { waitFor } from './utils.js';
 import axios from 'axios';
 import Sqlite, { Database } from 'better-sqlite3';
 import { fromB64Url, sha256B64Url, toB64Url } from '../../src/lib/encoding.js';
@@ -92,13 +92,14 @@ describe('Bundler Sidecar', { skip: isTestFiltered(['flaky']) }, () => {
   let compose: StartedDockerComposeEnvironment;
 
   const waitForIndexing = async () => {
-    const getAll = () =>
-      bundlesDb.prepare('SELECT * FROM new_data_items').all();
-
-    while (getAll().length === 0) {
-      console.log('Waiting for data items to be indexed...');
-      await wait(5000);
-    }
+    return waitFor({
+      check: () => bundlesDb.prepare('SELECT * FROM new_data_items').all(),
+      validate: (rows) => rows.length > 0,
+      interval: 5000,
+      timeoutMessage: () =>
+        'Timeout waiting for data items to be indexed. None were indexed',
+      waitingMessage: 'Waiting for data items to be indexed...',
+    });
   };
 
   let jwk: JWKInterface;

--- a/test/end-to-end/indexing.test.ts
+++ b/test/end-to-end/indexing.test.ts
@@ -16,6 +16,7 @@ import {
   cleanDb,
   composeUp,
   getMaxHeight,
+  waitFor,
   waitForBlocks,
   waitForBundleToBeIndexed,
   waitForDataItemToBeIndexed,
@@ -83,17 +84,22 @@ async function fetchGqlHeight(): Promise<number | undefined> {
 const waitForContiguousDataIds = async ({
   dataDb,
   length,
+  timeout,
 }: {
   dataDb: Database;
   length: number;
+  timeout?: number;
 }) => {
-  const getAll = () =>
-    dataDb.prepare('SELECT * FROM contiguous_data_ids').all();
-
-  while (getAll().length !== length) {
-    console.log('Waiting for data items to be indexed...');
-    await wait(1000);
-  }
+  return waitFor({
+    check: () =>
+      dataDb.prepare('SELECT * FROM contiguous_data_ids').all().length,
+    validate: (count) => count === length,
+    timeout,
+    timeoutMessage: (count) =>
+      `Timeout waiting for data items to be indexed. Expected ${length}, saw ${count}`,
+    waitingMessage: (count) =>
+      `Waiting for data items to be indexed... ${count}/${length}`,
+  });
 };
 
 describe('Indexing', function () {
@@ -473,13 +479,14 @@ describe('Indexing', function () {
     let compose: StartedDockerComposeEnvironment;
 
     const waitForIndexing = async () => {
-      const getAll = () =>
-        coreDb.prepare('SELECT * FROM new_transactions').all();
-
-      while (getAll().length === 0) {
-        console.log('Waiting for pending txs to be indexed...');
-        await wait(1000);
-      }
+      return waitFor({
+        check: () =>
+          coreDb.prepare('SELECT * FROM new_transactions').all().length,
+        validate: (count) => count > 0,
+        timeoutMessage: () =>
+          'Timeout waiting for pending txs to be indexed. None were indexed',
+        waitingMessage: 'Waiting for pending txs to be indexed...',
+      });
     };
 
     before(async function () {
@@ -511,13 +518,14 @@ describe('Indexing', function () {
     let compose: StartedDockerComposeEnvironment;
 
     const waitForIndexing = async () => {
-      const getAll = () =>
-        coreDb.prepare('SELECT * FROM new_transactions').all();
-
-      while (getAll().length === 0) {
-        console.log('Waiting for pending txs to be indexed...');
-        await wait(1000);
-      }
+      return waitFor({
+        check: () =>
+          coreDb.prepare('SELECT * FROM new_transactions').all().length,
+        validate: (count) => count > 0,
+        timeoutMessage: () =>
+          'Timeout waiting for pending txs to be indexed. None were indexed',
+        waitingMessage: 'Waiting for pending txs to be indexed...',
+      });
     };
 
     const fetchGqlTxs = async () => {
@@ -935,28 +943,22 @@ describe('Indexing', function () {
     let compose: StartedDockerComposeEnvironment;
     const bundleId = '-H3KW7RKTXMg5Miq2jHx36OHSVsXBSYuE2kxgsFj6OQ';
 
-    const waitForIndexing = async () => {
-      const getAll = () =>
-        dataDb.prepare('SELECT * FROM contiguous_data_ids').all();
-
-      while (getAll().length !== 79) {
-        console.log('Waiting for data items to be indexed...');
-        await wait(1000);
-      }
-    };
+    // Budgets fit inside the before hook's 120s timeout so the message below
+    // wins over a bare hook abort.
+    const waitForIndexing = async () =>
+      waitForContiguousDataIds({ dataDb, length: 79, timeout: 55_000 });
 
     const waitVerification = async () => {
-      const getAll = () =>
-        dataDb.prepare('SELECT verified FROM contiguous_data_ids').all();
-
-      while (getAll().some((row) => row.verified === 0)) {
-        console.log('Waiting for data items to be verified...', {
-          verified: getAll().filter((row) => row.verified === 1).length,
-          total: getAll().length,
-        });
-
-        await wait(1000);
-      }
+      return waitFor({
+        check: () =>
+          dataDb.prepare('SELECT verified FROM contiguous_data_ids').all(),
+        validate: (rows) => rows.every((row) => row.verified !== 0),
+        timeout: 55_000,
+        timeoutMessage: (rows) =>
+          `Timeout waiting for data items to be verified. Verified ${rows.filter((row) => row.verified === 1).length}/${rows.length}`,
+        waitingMessage: (rows) =>
+          `Waiting for data items to be verified... ${rows.filter((row) => row.verified === 1).length}/${rows.length}`,
+      });
     };
 
     before(

--- a/test/end-to-end/utils.ts
+++ b/test/end-to-end/utils.ts
@@ -160,7 +160,15 @@ export const composeUp = async ({
     .up(['core']);
 };
 
-const waitFor = <T>({
+/**
+ * Poll `check` until `validate` passes or `timeout` elapses.
+ *
+ * `timeoutMessage` and `waitingMessage` accept a function so they can report
+ * the value actually observed. Passing a plain string builds the message once,
+ * before polling starts, which makes it stale for anything that changes while
+ * waiting.
+ */
+export const waitFor = <T>({
   check,
   validate,
   timeout = DEFAULT_TIMEOUT,
@@ -172,8 +180,8 @@ const waitFor = <T>({
   validate: (result: T) => boolean;
   timeout?: number;
   interval?: number;
-  timeoutMessage: string;
-  waitingMessage?: string;
+  timeoutMessage: string | ((lastResult: T) => string);
+  waitingMessage?: string | ((lastResult: T) => string);
 }): Promise<T> => {
   return new Promise((resolve, reject) => {
     const startTime = Date.now();
@@ -187,11 +195,21 @@ const waitFor = <T>({
         }
 
         if (waitingMessage !== undefined) {
-          console.log(waitingMessage);
+          console.log(
+            typeof waitingMessage === 'function'
+              ? waitingMessage(result)
+              : waitingMessage,
+          );
         }
 
         if (Date.now() - startTime >= timeout) {
-          reject(new Error(timeoutMessage));
+          reject(
+            new Error(
+              typeof timeoutMessage === 'function'
+                ? timeoutMessage(result)
+                : timeoutMessage,
+            ),
+          );
           return;
         }
 
@@ -221,8 +239,10 @@ export const waitForBlocks = ({
     validate: (height) => height === stopHeight,
     timeout,
     interval,
-    timeoutMessage: `Timeout waiting for blocks to reach height ${stopHeight}`,
-    waitingMessage: `Waiting for blocks to import... Current height: ${getMaxHeight(coreDb)['MAX(height)']}, Target: ${stopHeight}`,
+    timeoutMessage: (height) =>
+      `Timeout waiting for blocks to reach height ${stopHeight}. Current height: ${height}`,
+    waitingMessage: (height) =>
+      `Waiting for blocks to import... Current height: ${height}, Target: ${stopHeight}`,
   });
 };
 


### PR DESCRIPTION
Follow-up to #848. That PR fixed block import; this one makes the *next* failure diagnosable.

## What happened

With #848 merged, `Indexing > Initialization` passed in 13.3s (previously a 65s timeout), and `Header caching behavior` passed too. The suite after them, `DataItem indexing`, then printed this forever:

```
Waiting for data items to be indexed...
Waiting for data items to be indexed...
```

It never failed. Six E2E helpers poll in bare `while` loops with no timeout:

```ts
while (getAll().length !== length) {
  console.log('Waiting for data items to be indexed...');
  await wait(1000);
}
```

`node --test` sets no test timeout, and the job set no `timeout-minutes`, so the run burned a runner toward GitHub's 360-minute default and reported nothing. The container-log step added in #848 never fired either — it triggers on step *failure*, and a hang is not a failure.

## What this changes

Route all six through the existing `waitFor` helper (60s default), and make their messages report the value actually observed:

```
Timeout waiting for data items to be indexed. Expected 19, saw 0
```

That single number separates the hypotheses. `saw 0` is a retrieval failure. `saw 12` is partial unbundling. `saw 20` is a count that drifted since the expectation was written.

`waitFor` now accepts a function for `timeoutMessage` and `waitingMessage`. A plain string is built once, before polling starts — which is why `waitForBlocks` logged `Current height: null` on every tick even for imports that succeeded, including the passing run above. Plain strings still work, so existing callers are unaffected.

Also adds `timeout-minutes: 60` as a backstop.

## Sites converted

| File | Loop |
|---|---|
| `indexing.test.ts:83` | `waitForContiguousDataIds` — exact-count wait (the one that hung) |
| `indexing.test.ts:480, 518` | mempool / pending-tx polls |
| `indexing.test.ts:945, 955` | background verification indexing + verification polls |
| `bundler-sidecar.test.ts:94` | data-item poll (SKIPped in CI, same landmine) |

## Verification

- `yarn lint:check`, `yarn build`, prettier — pass
- `yarn typecheck` — fails identically to `develop`; error set is byte-for-byte the baseline, zero new errors
- `waitFor` behavior exercised directly, since E2E cannot run locally: resolves with the observed value, rejects with `Expected 19, saw 12` built from the last observation, and plain-string messages still work

## What this deliberately does not do

It does not change `TRUSTED_GATEWAYS_URLS`, where arweave.net is still priority 1 and remains the leading suspect for the `DataItem indexing` stall. That suite runs with `START_WRITERS: 'false'`, so it does no block import at all — its bundle bytes come over the trusted-gateways data path.

Stacking a speculative retrieval fix on top would risk breaking the `x-ar-io-hops` assertions in suites that currently pass, and would muddy the signal. One run with this merged should say plainly which problem it is.

Note the expected count of 19 was checked against the chain and is correct: the bundle's documented structure is 1 root + 11 direct children + 7 nested, and a GraphQL query for `bundledIn` returns exactly the 11 direct children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)