### PR TITLE
test(e2e): run the built image and capture logs from the failing suite

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -35,9 +35,17 @@ jobs:
       - run: yarn lint:check
       - run: yarn test:ci
       # Run E2E tests if pushing to develop branch
+      # Two tags for one build. `core` is what the GenericContainer suites
+      # ask for; the ghcr tag is what docker-compose.yaml resolves via
+      # CORE_IMAGE_TAG. Without the second one, compose pulls the published
+      # `latest` and the compose-based suites test a different build than the
+      # commit under test.
       - name: Build core Docker image
         if: github.ref == 'refs/heads/develop' && matrix.os == 'ubuntu-latest'
-        run: docker build -t core .
+        run: |
+          docker build \
+            -t core \
+            -t ghcr.io/ar-io/ar-io-core:ci-${{ github.sha }} .
       - name: Run E2E tests
         id: e2e
         if: github.ref == 'refs/heads/develop' && matrix.os == 'ubuntu-latest'
@@ -45,6 +53,7 @@ jobs:
         env:
           TEST_SKIP_TAGS: flaky
           USE_PREBUILT_IMAGE: 'true'
+          CORE_IMAGE_TAG: ci-${{ github.sha }}
       # E2E failures give no upstream detail without the container logs.
       # Testcontainers randomizes the compose project name, so enumerate
       # whatever containers survive instead of naming a project.

--- a/test/end-to-end/indexing.test.ts
+++ b/test/end-to-end/indexing.test.ts
@@ -22,6 +22,7 @@ import {
   waitForDataItemToBeIndexed,
   waitForLogMessage,
   waitForTxToBeIndexed,
+  withCoreLogsOnFailure,
 } from './utils.js';
 import { isTestFiltered } from '../utils.js';
 
@@ -207,7 +208,9 @@ describe('Indexing', function () {
         },
       });
 
-      await waitForContiguousDataIds({ dataDb, length: 19 });
+      await withCoreLogsOnFailure(compose, () =>
+        waitForContiguousDataIds({ dataDb, length: 19 }),
+      );
     });
 
     after(async function () {
@@ -997,8 +1000,10 @@ describe('Indexing', function () {
           },
         );
 
-        await waitForIndexing();
-        await waitVerification();
+        await withCoreLogsOnFailure(compose, async () => {
+          await waitForIndexing();
+          await waitVerification();
+        });
       },
       { timeout: 120_000 },
     );

--- a/test/end-to-end/utils.ts
+++ b/test/end-to-end/utils.ts
@@ -8,6 +8,7 @@ import Sqlite, { Database } from 'better-sqlite3';
 import {
   DockerComposeEnvironment,
   GenericContainer,
+  StartedDockerComposeEnvironment,
   Wait,
 } from 'testcontainers';
 import { StartedGenericContainer } from 'testcontainers/build/generic-container/started-generic-container';
@@ -128,6 +129,11 @@ export const composeUp = async ({
     'http://peers.arweave.xyz:1984',
   TRUSTED_GATEWAYS_URLS = '{"https://arweave.net": 1, "https://turbo-gateway.com": 2}',
   BACKGROUND_RETRIEVAL_ORDER = 'trusted-gateways',
+  // Passed explicitly rather than left to process env inheritance so the
+  // compose suites run the same image the job just built. Defaulting to
+  // `latest` makes compose pull the published image, which is a different
+  // build than the commit under test.
+  CORE_IMAGE_TAG = process.env.CORE_IMAGE_TAG ?? 'latest',
   ...ENVIRONMENT
 }: Environment = {}) => {
   // disable .env file read
@@ -148,6 +154,7 @@ export const composeUp = async ({
     TRUSTED_NODE_URL,
     TRUSTED_GATEWAYS_URLS,
     BACKGROUND_RETRIEVAL_ORDER,
+    CORE_IMAGE_TAG,
     ...ENVIRONMENT,
   });
 
@@ -244,6 +251,73 @@ export const waitForBlocks = ({
     waitingMessage: (height) =>
       `Waiting for blocks to import... Current height: ${height}, Target: ${stopHeight}`,
   });
+};
+
+/**
+ * Print the core container's recent logs.
+ *
+ * The workflow's job-level dump cannot see these. Testcontainers reaps each
+ * suite's containers as it goes, so by the time a job-level step runs, the
+ * container that actually failed is long gone. This runs inside the failing
+ * hook, while the container is still up.
+ */
+export const dumpCoreLogs = async (
+  compose: StartedDockerComposeEnvironment,
+  {
+    serviceName = 'core-1',
+    collectMs = 3000,
+    tailLines = 200,
+  }: { serviceName?: string; collectMs?: number; tailLines?: number } = {},
+) => {
+  try {
+    const stream = await compose.getContainer(serviceName).logs();
+    const chunks: string[] = [];
+
+    await new Promise<void>((resolve) => {
+      const finish = () => {
+        stream.destroy();
+        resolve();
+      };
+      // logs() follows the stream, so stop after a bounded window rather
+      // than waiting for an end event that only arrives on container exit.
+      const timer = setTimeout(finish, collectMs);
+
+      stream.on('data', (chunk) => chunks.push(chunk.toString('utf8')));
+      stream.on('end', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      stream.on('error', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+
+    const tail = chunks.join('').split('\n').slice(-tailLines).join('\n');
+    console.log(
+      `===== ${serviceName} logs (last ${tailLines} lines) =====\n${tail}\n===== end ${serviceName} logs =====`,
+    );
+  } catch (error) {
+    console.log(`Could not capture ${serviceName} logs:`, error);
+  }
+};
+
+/**
+ * Run `fn`, dumping the core container's logs if it throws, then rethrow.
+ *
+ * Wrap the waits in a `before` hook with this so a timeout arrives with the
+ * upstream detail attached instead of a bare message.
+ */
+export const withCoreLogsOnFailure = async <T>(
+  compose: StartedDockerComposeEnvironment,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  try {
+    return await fn();
+  } catch (error) {
+    await dumpCoreLogs(compose);
+    throw error;
+  }
 };
 
 export const waitForLogMessage = ({


### PR DESCRIPTION
Follow-up to #848 and #849. Two problems that the last develop run exposed.

## 1. The compose suites were not testing the commit

The container dump from [run 31610878824](https://github.com/ar-io/ar-io-node/actions/runs/31610878824) shows what actually ran:

```
7ff36bb7826d   ghcr.io/ar-io/ar-io-core:latest   ...   testcontainers-7f52fde6304c-core-1
```

`docker-compose.yaml` resolves `image: ghcr.io/ar-io/ar-io-core:${CORE_IMAGE_TAG:-latest}`. Nothing set `CORE_IMAGE_TAG`, so compose pulled the **published** `latest` — currently `731da0d4`, published 2026-08-11 21:46, which predates #843, #846, #848, and #849. Meanwhile `docker build -t core .` produced an image that only `getCoreContainer` (`utils.ts:21`) uses.

So one run tested two different builds:

| Suite style | Image | Code under test |
|---|---|---|
| `composeUp` — Indexing, DataItem indexing, metrics, moderation | `ghcr.io/ar-io/ar-io-core:latest` | last published build |
| `GenericContainer` — data-sources, webhook, fake trusted node | locally built `core` | the actual commit |

This PR tags the build twice and points compose at the CI tag, so both halves run the same image. `CORE_IMAGE_TAG` is threaded through `composeUp` explicitly rather than left to process-env inheritance, so the resolved image is visible at the call site.

Verified with `docker compose config`:

```
$ CORE_IMAGE_TAG=ci-deadbeef docker compose config | grep ar-io-core
    image: ghcr.io/ar-io/ar-io-core:ci-deadbeef
$ docker compose config | grep ar-io-core
    image: ghcr.io/ar-io/ar-io-core:latest      # unchanged for local use
```

## 2. The job-level log dump cannot see the failing container

#848 added a dump step that enumerates surviving containers. The last run proved it cannot work for a suite that fails early: testcontainers reaps each suite's containers as it goes, so the step ran 20 minutes after `DataItem indexing` died and captured the *final* suite's startup migrations instead.

`dumpCoreLogs` and `withCoreLogsOnFailure` run inside the failing hook, while the container is still up. Wired into the two suites that currently fail on a wait — `DataItem indexing` and `Background data verification`. The helper is exported so other suites can adopt it.

The job-level step stays as a cheap catch-all for whatever is still running.

## Why this matters for the current failure

#849's instrument reported `Expected 19, saw 0` — held at `0/19` for the full 60s, so not even the root bundle's own data was cached. Nothing was processed at all.

What that already rules out:

- **Rate limiting on the data path** — every suite before `Indexing` passed in that run, including `DataSources`, `Data`, `ANS-104 Bundles`, and `X-AR-IO headers`.
- **Bundle size or timeout** — `kJA49Gt…` is 168 KB and fetches from arweave.net in 0.27s.
- **The trusted-node swap from #848** — `Initialization` passed in 12.9s.

What remains is either a real regression or an artifact of the image skew above. This PR makes that answerable: the next run tests the actual commit, and if it still fails, the core logs arrive attached to the failure.

## Verification

- `yarn lint:check`, prettier — pass
- `yarn typecheck` — identical to the `develop` baseline, zero new errors
- compose substitution verified both ways, as above
- E2E still cannot run locally (no Docker daemon on this machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)