### PR TITLE
test(e2e): give the trusted-gateway cascade room to fall back

### DIFF
--- a/test/end-to-end/indexing.test.ts
+++ b/test/end-to-end/indexing.test.ts
@@ -208,8 +208,11 @@ describe('Indexing', function () {
         },
       });
 
+      // A cold priority-2 gateway fetch can take most of
+      // TRUSTED_GATEWAYS_REQUEST_TIMEOUT_MS before the recursive unbundle
+      // even starts, so the 60s default leaves no room.
       await withCoreLogsOnFailure(compose, () =>
-        waitForContiguousDataIds({ dataDb, length: 19 }),
+        waitForContiguousDataIds({ dataDb, length: 19, timeout: 120_000 }),
       );
     });
 

--- a/test/end-to-end/utils.ts
+++ b/test/end-to-end/utils.ts
@@ -129,6 +129,13 @@ export const composeUp = async ({
     'http://peers.arweave.xyz:1984',
   TRUSTED_GATEWAYS_URLS = '{"https://arweave.net": 1, "https://turbo-gateway.com": 2}',
   BACKGROUND_RETRIEVAL_ORDER = 'trusted-gateways',
+  // The 10s production default is too short for this cascade. arweave.net
+  // (priority 1) intermittently rate-limits CI egress with a 429, and the
+  // priority 2 gateways need more than 30s to serve an object that is not
+  // already in their cache. A timed-out request still warms them, so the
+  // fetch completes; it just needs more room than 10s. Measured: >30s cold,
+  // ~1.2s once warm.
+  TRUSTED_GATEWAYS_REQUEST_TIMEOUT_MS = '45000',
   // Passed explicitly rather than left to process env inheritance so the
   // compose suites run the same image the job just built. Defaulting to
   // `latest` makes compose pull the published image, which is a different
@@ -154,6 +161,7 @@ export const composeUp = async ({
     TRUSTED_NODE_URL,
     TRUSTED_GATEWAYS_URLS,
     BACKGROUND_RETRIEVAL_ORDER,
+    TRUSTED_GATEWAYS_REQUEST_TIMEOUT_MS,
     CORE_IMAGE_TAG,
     ...ENVIRONMENT,
   });
@@ -270,7 +278,12 @@ export const dumpCoreLogs = async (
   }: { serviceName?: string; collectMs?: number; tailLines?: number } = {},
 ) => {
   try {
-    const stream = await compose.getContainer(serviceName).logs();
+    // Ask Docker for the tail. Without this, logs() replays the stream from
+    // the container's first line, so a bounded collection window returns
+    // startup output rather than whatever happened just before the failure.
+    const stream = await compose
+      .getContainer(serviceName)
+      .logs({ tail: tailLines });
     const chunks: string[] = [];
 
     await new Promise<void>((resolve) => {
@@ -293,9 +306,8 @@ export const dumpCoreLogs = async (
       });
     });
 
-    const tail = chunks.join('').split('\n').slice(-tailLines).join('\n');
     console.log(
-      `===== ${serviceName} logs (last ${tailLines} lines) =====\n${tail}\n===== end ${serviceName} logs =====`,
+      `===== ${serviceName} logs (last ${tailLines} lines) =====\n${chunks.join('')}\n===== end ${serviceName} logs =====`,
     );
   } catch (error) {
     console.log(`Could not capture ${serviceName} logs:`, error);

--- a/test/end-to-end/webhook.test.ts
+++ b/test/end-to-end/webhook.test.ts
@@ -81,6 +81,8 @@ describe('WebhookEmitter', { skip: isTestFiltered(['flaky']) }, () => {
         TRUSTED_GATEWAYS_URLS:
           '{"https://arweave.net": 1, "https://turbo-gateway.com": 2}',
         BACKGROUND_RETRIEVAL_ORDER: 'trusted-gateways',
+        // Matches the composeUp default; see the note there.
+        TRUSTED_GATEWAYS_REQUEST_TIMEOUT_MS: '45000',
       })
       .withExposedPorts(4000)
       .withWaitStrategy(Wait.forHttp('/ar-io/info', 4000))


### PR DESCRIPTION
Follow-up to #848, #849, #850. The in-suite log capture from #850 found the cause.

## What the logs showed

`DataItem indexing` failed with `Expected 19, saw 0`. Container logs from inside the failing hook:

```
error: Axios response error {"class":"GatewaysDataSource","status":429,
  "retry-after":"299","server":"CDN77-Turbo",
  "url":"/raw/kJA49GtBVUWex2yiRKX1KSDbCE6I2xGicR-62_pnJ_c"}
warn: Failed to fetch from gateway {"gatewayUrl":"https://arweave.net","priority":1}
warn: All gateways in priority tier failed {"priority":1}
error: Axios network error canceled                          <- exactly 10s later
warn: All gateways in priority tier failed {"priority":2}
warn: Unable to fetch data from data source canceled {"class":"SequentialDataSource"}
```

Neither tier could serve, for unrelated reasons:

- **Priority 1, arweave.net** — 429 immediately. Same CDN77 limiter as #848, this time on the data path rather than the chain path.
- **Priority 2** — canceled at exactly 10.000s, which is `TRUSTED_GATEWAYS_REQUEST_TIMEOUT_MS` (`config.ts:255`, default `10000`).

## Why priority 2 was too slow

Measured against the same object:

| Gateway | cold | warm |
|---|---|---|
| arweave.net | 0.17s | — |
| priority-2 gateway | >30s | 1.2s |
| two other AR.IO gateways | >15s | 0.13s / 1.3s |

Every AR.IO gateway cold-misses this object and needs well over the 10s budget. A timed-out request still warms the cache, so the fetch does complete — the client just gives up first. That is why the failure is intermittent: it needs arweave.net to rate-limit *and* the fallback to be cold at the same time.

## Changes

- `TRUSTED_GATEWAYS_REQUEST_TIMEOUT_MS` to 45s in the E2E `composeUp` default, and in `webhook.test.ts`, which builds its container directly and so does not inherit that default.
- The `DataItem indexing` wait gets a 120s budget. A cold fetch can consume most of the gateway timeout before the recursive unbundle of 19 items even starts, leaving nothing in the 60s default.
- `dumpCoreLogs` now passes `{ tail }` to `logs()`. The API supports it and I did not use it: `logs()` replays from the container's first line, so the bounded collection window returned startup migrations. It reached the useful output last run only because the log volume happened to be small enough to stream through in 3s.

**Production defaults are unchanged.** This is entirely test configuration.

## What was checked and deliberately not changed

- `data.test.ts:730` points at a fake gateway on `host.testcontainers.internal:4001`, which answers instantly. No timeout needed.
- `data-sources.test.ts` uses `ON_DEMAND_RETRIEVAL_ORDER: 's3'` and never touches the gateway cascade.
- `indexing.test.ts:973` sets `BACKGROUND_RETRIEVAL_ORDER` but goes through `composeUp`, so it inherits the new default.
- `TRUSTED_GATEWAYS_URLS` ordering is untouched. Promoting the priority-2 gateway would just move the cold-cache stall to the front, and it would disturb the `x-ar-io-hops` assertions.
- `bundler-sidecar.test.ts` has its own `composeUp` with no gateway settings, so it uses the production default, which orders the gateways the opposite way. It is SKIPped in CI, so it is left alone rather than widening this change.

## Caveat

This makes the suite more tolerant, not deterministic. It still depends on two third-party services cooperating inside a deadline. The durable fix is `ArweaveChainSourceStub` plus the 201 recorded fixtures already sitting in `test/mock_files/` — a larger change than belongs in a release unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)