### PR TITLE
test(e2e): confirm why background verification withholds every item [DIAGNOSTIC]

### DIFF
--- a/test/end-to-end/indexing.test.ts
+++ b/test/end-to-end/indexing.test.ts
@@ -975,6 +975,9 @@ describe('Indexing', function () {
           BACKGROUND_DATA_VERIFICATION_INTERVAL_SECONDS: '1',
           BACKGROUND_RETRIEVAL_ORDER: 'trusted-gateways',
           MIN_DATA_VERIFICATION_PRIORITY: '0',
+          // DIAGNOSTIC: the verification worker logs its decisions at debug.
+          // Needed to see 'Withholding verification: root tx not yet mined'.
+          LOG_LEVEL: 'debug',
         });
         dataDb = new Sqlite(`${projectRootPath}/data/sqlite/data.db`);
 
@@ -1003,10 +1006,41 @@ describe('Indexing', function () {
           },
         );
 
-        await withCoreLogsOnFailure(compose, async () => {
-          await waitForIndexing();
-          await waitVerification();
-        });
+        await withCoreLogsOnFailure(
+          compose,
+          async () => {
+            await waitForIndexing();
+            try {
+              await waitVerification();
+            } catch (error) {
+              // DIAGNOSTIC: verification is withheld when the root tx has no
+              // height (data-verification.ts:207 reads NULL height as
+              // "not yet mined"). START_WRITERS is false here, so the block
+              // importer never fills it. Read the height directly, independent
+              // of log levels.
+              const coreDb = new Sqlite(
+                `${projectRootPath}/data/sqlite/core.db`,
+              );
+              const idBuffer = fromB64Url(bundleId);
+              console.log('===== root tx height diagnostic =====', {
+                bundleId,
+                newTransactions: coreDb
+                  .prepare('SELECT height FROM new_transactions WHERE id = ?')
+                  .all(idBuffer),
+                stableTransactions: coreDb
+                  .prepare(
+                    'SELECT height FROM stable_transactions WHERE id = ?',
+                  )
+                  .all(idBuffer),
+              });
+              coreDb.close();
+              throw error;
+            }
+          },
+          // Debug logging is verbose; take a bigger tail so the verification
+          // lines are not crowded out by unrelated workers.
+          { tailLines: 1500 },
+        );
       },
       { timeout: 120_000 },
     );

--- a/test/end-to-end/indexing.test.ts
+++ b/test/end-to-end/indexing.test.ts
@@ -1018,22 +1018,33 @@ describe('Indexing', function () {
               // "not yet mined"). START_WRITERS is false here, so the block
               // importer never fills it. Read the height directly, independent
               // of log levels.
-              const coreDb = new Sqlite(
-                `${projectRootPath}/data/sqlite/core.db`,
-              );
-              const idBuffer = fromB64Url(bundleId);
-              console.log('===== root tx height diagnostic =====', {
-                bundleId,
-                newTransactions: coreDb
-                  .prepare('SELECT height FROM new_transactions WHERE id = ?')
-                  .all(idBuffer),
-                stableTransactions: coreDb
-                  .prepare(
-                    'SELECT height FROM stable_transactions WHERE id = ?',
-                  )
-                  .all(idBuffer),
-              });
-              coreDb.close();
+              //
+              // A diagnostic must never replace the error it exists to
+              // explain, so failures here are reported and swallowed, and the
+              // handle always closes.
+              let coreDb: Database | undefined;
+              try {
+                coreDb = new Sqlite(`${projectRootPath}/data/sqlite/core.db`);
+                const idBuffer = fromB64Url(bundleId);
+                console.log('===== root tx height diagnostic =====', {
+                  bundleId,
+                  newTransactions: coreDb
+                    .prepare('SELECT height FROM new_transactions WHERE id = ?')
+                    .all(idBuffer),
+                  stableTransactions: coreDb
+                    .prepare(
+                      'SELECT height FROM stable_transactions WHERE id = ?',
+                    )
+                    .all(idBuffer),
+                });
+              } catch (diagnosticError) {
+                console.log(
+                  'root tx height diagnostic failed:',
+                  diagnosticError,
+                );
+              } finally {
+                coreDb?.close();
+              }
               throw error;
             }
           },

--- a/test/end-to-end/utils.ts
+++ b/test/end-to-end/utils.ts
@@ -323,11 +323,12 @@ export const dumpCoreLogs = async (
 export const withCoreLogsOnFailure = async <T>(
   compose: StartedDockerComposeEnvironment,
   fn: () => Promise<T>,
+  opts?: Parameters<typeof dumpCoreLogs>[1],
 ): Promise<T> => {
   try {
     return await fn();
   } catch (error) {
-    await dumpCoreLogs(compose);
+    await dumpCoreLogs(compose, opts);
     throw error;
   }
 };


### PR DESCRIPTION
**Diagnostic only — revert once confirmed.** No product code changes.

## Hypothesis

`Background data verification` fails with `Verified 0/79`, and the container logs show nothing at all about verification.

Suspected cause, `src/workers/data-verification.ts:207`:

```ts
if (dataAttributes !== undefined && dataAttributes.height == null) {
  withheldUnconfirmed = true;
  metrics.optimisticTxVerificationBlockedCounter.inc();
  log.debug('Withholding verification: root tx not yet mined');
  return false;
}
```

The chain:

1. The suite runs `START_WRITERS: 'false'` and indexes the root tx via `admin/queue-tx`.
2. That writes a `new_transactions` row with **`height = NULL`** — the tx JSON from `/tx/<id>` carries no height. Height is filled by the block importer, which `START_WRITERS: 'false'` never starts.
3. `getDataAttributes` sources height from core (`sql/core/data-attributes.sql:19`), so the row exists but has no height.
4. The guard reads that as "not yet mined" and withholds.
5. `-H3KW7RK…` was mined two years ago. It will never gain a height in this suite.

## Why it produced no signal

- The decision is logged at **debug**; the container runs at **info**.
- Withholding deliberately does **not** increment `verification_retry_count`, so items never age out, never exhaust retries, and never error.

## What this PR adds

Two independent confirmations, so the result does not hinge on one mechanism:

1. `LOG_LEVEL: 'debug'` on this suite — the captured logs should show `Withholding verification: root tx not yet mined`.
2. A direct read of the root tx height from `core.db` in the failure path, printed as `===== root tx height diagnostic =====`. This does not depend on log level.

The in-suite log capture takes a 1500-line tail here, since debug output is verbose enough to crowd out the relevant lines.

## Expected result

Both should agree: height `NULL` in `new_transactions`, absent from `stable_transactions`, and the withholding line repeating once per sweep.

If the height is **not** NULL, the hypothesis is wrong and the debug logs should show which branch actually returns false.

## Timeline note

The guard arrived in `2d841de7` (2026-06-18, "feat(tx): optimistic L1 transaction indexing"), merged as #784. Consistent E2E failures start immediately after. One data point does not fit: `bd738a24`, six minutes after #784 merged and containing it, is the last green run. Its logs have expired, so I cannot tell whether this suite passed, flaked, or was skipped. Worth keeping in mind if the confirmation comes back negative.

## Why this matters beyond CI

The guard's own comment states the assumption:

> `height === undefined` is exactly the unmined/optimistic state (a `new_transactions` row with NULL height — the state this feature creates)

That is not exclusively true. Any tx indexed without its block gets a NULL height — `admin/queue-tx`, backfills, selective indexing — including long-mined data. On a gateway not synced past that tx's height, verification would be withheld indefinitely and silently.

`optimistic_tx_verification_blocked_total` is the metric to watch for this in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)