### PR TITLE
test(e2e): use CORE_LOG_LEVEL so the debug probe actually applies

### DIFF
--- a/test/end-to-end/indexing.test.ts
+++ b/test/end-to-end/indexing.test.ts
@@ -977,7 +977,7 @@ describe('Indexing', function () {
           MIN_DATA_VERIFICATION_PRIORITY: '0',
           // DIAGNOSTIC: the verification worker logs its decisions at debug.
           // Needed to see 'Withholding verification: root tx not yet mined'.
-          LOG_LEVEL: 'debug',
+          CORE_LOG_LEVEL: 'debug',
         });
         dataDb = new Sqlite(`${projectRootPath}/data/sqlite/data.db`);
 


### PR DESCRIPTION
Follow-up to #852. One-line fix to a probe that silently did nothing.

## Result from #852

**Probe 1 (height read) — CONFIRMED.** This is the probe built not to depend on log level:

```
===== root tx height diagnostic ===== {
  bundleId: '-H3KW7RKTXMg5Miq2jHx36OHSVsXBSYuE2kxgsFj6OQ',
  newTransactions: [ { height: null } ],
  stableTransactions: []
}
```

The root tx is present in `new_transactions` with `height` NULL and absent from `stable_transactions` — exactly the state predicted, and exactly the state `data-verification.ts:207` reads as "not yet mined".

**Probe 2 (debug log) — inconclusive, my mistake.** It set `LOG_LEVEL: 'debug'`, but `docker-compose.yaml:73` gives the core container:

```yaml
- LOG_LEVEL=${CORE_LOG_LEVEL:-info}
```

Nothing substitutes a bare `LOG_LEVEL` for that service, so the container stayed at `info`. The run produced zero debug lines and only the info-level `Starting background data verification`. The absence of `Withholding verification: root tx not yet mined` therefore means nothing — the log level never changed.

This PR changes `LOG_LEVEL` to `CORE_LOG_LEVEL`.

## What is still open

The DB state is confirmed. What is not yet directly observed is that the guard at `data-verification.ts:207` is the branch that returns false. The inference is short — `new_transactions` holds the row, so `selectDataAttributes` should return a defined object whose `height` is NULL, which is precisely the guard's condition — but it is still an inference. This probe closes it.

If the withholding line appears once per sweep, the diagnosis is complete and the fix belongs in the guard. If it does not appear even with debug on, something earlier returns false and the debug output will show which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)