### PR TITLE
docs: document data retrieval lookup hints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -96,6 +96,7 @@ components:
       required: false
       schema:
         type: string
+        pattern: '^[0-9a-zA-Z_-]{43}(\s*,\s*[0-9a-zA-Z_-]{43})*$'
       description: |
         Optional comma-separated traversal path of transaction IDs from the root
         L1 transaction through each parent bundle to the requested ANS-104 data
@@ -120,7 +121,7 @@ components:
       required: false
       schema:
         type: integer
-        minimum: 0
+        minimum: 1
       description: |
         Optional size of the complete ANS-104 data item, including its header,
         in bytes. This header is only used when X-AR-IO-Root-Item-Offset is also

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -77,6 +77,55 @@ components:
       scheme: bearer
       bearerFormat: apiToken
       description: ADMIN_API_KEY set in your .env file.
+  parameters:
+    RootTransactionIdHint:
+      name: X-AR-IO-Root-Transaction-Id
+      in: header
+      required: false
+      schema:
+        $ref: '#/components/schemas/Base64Url43'
+      description: |
+        Optional retrieval hint identifying the root L1 transaction that contains
+        the requested ANS-104 data item. The data item ID remains the path
+        parameter. The gateway validates this hint and falls back to its normal
+        lookup process when the hint is unusable.
+      example: '283VjqeZG65tPI6V0e-gucoHCaEBPL41_cI8rXVRbMc'
+    RootPathHint:
+      name: X-AR-IO-Root-Path
+      in: header
+      required: false
+      schema:
+        type: string
+      description: |
+        Optional comma-separated traversal path of transaction IDs from the root
+        L1 transaction through each parent bundle to the requested ANS-104 data
+        item's immediate parent. Use this when the item is nested in multiple
+        bundles. Every value must be a 43-character base64url transaction ID.
+      example: '283VjqeZG65tPI6V0e-gucoHCaEBPL41_cI8rXVRbMc,hs48Pj6C9TqAk7W7D3T8F5kWg3q5W7K3m9Gf2L4n8Ps'
+    RootItemOffsetHint:
+      name: X-AR-IO-Root-Item-Offset
+      in: header
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+      description: |
+        Optional byte offset of the complete ANS-104 data item, including its
+        header, from the start of the root transaction's data. This header is
+        only used when X-AR-IO-Root-Item-Size is also provided.
+      example: 2048
+    RootItemSizeHint:
+      name: X-AR-IO-Root-Item-Size
+      in: header
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+      description: |
+        Optional size of the complete ANS-104 data item, including its header,
+        in bytes. This header is only used when X-AR-IO-Root-Item-Offset is also
+        provided.
+      example: 2092
   schemas:
     ParquetExportStatus:
       type: object
@@ -1133,6 +1182,10 @@ paths:
           schema:
             $ref: '#/components/schemas/ByteRange'
           description: Byte range(s) to retrieve
+        - $ref: '#/components/parameters/RootTransactionIdHint'
+        - $ref: '#/components/parameters/RootPathHint'
+        - $ref: '#/components/parameters/RootItemOffsetHint'
+        - $ref: '#/components/parameters/RootItemSizeHint'
       responses:
         '200':
           description: Successful response
@@ -1405,6 +1458,10 @@ paths:
           schema:
             $ref: '#/components/schemas/ByteRange'
           description: Byte range(s) to check
+        - $ref: '#/components/parameters/RootTransactionIdHint'
+        - $ref: '#/components/parameters/RootPathHint'
+        - $ref: '#/components/parameters/RootItemOffsetHint'
+        - $ref: '#/components/parameters/RootItemSizeHint'
       responses:
         '200':
           description: Successful response
@@ -1478,6 +1535,10 @@ paths:
           schema:
             $ref: '#/components/schemas/ByteRange'
           description: Byte range(s) to retrieve
+        - $ref: '#/components/parameters/RootTransactionIdHint'
+        - $ref: '#/components/parameters/RootPathHint'
+        - $ref: '#/components/parameters/RootItemOffsetHint'
+        - $ref: '#/components/parameters/RootItemSizeHint'
       responses:
         '200':
           description: Successful response
@@ -1754,6 +1815,10 @@ paths:
           schema:
             $ref: '#/components/schemas/ByteRange'
           description: Byte range(s) to check
+        - $ref: '#/components/parameters/RootTransactionIdHint'
+        - $ref: '#/components/parameters/RootPathHint'
+        - $ref: '#/components/parameters/RootItemOffsetHint'
+        - $ref: '#/components/parameters/RootItemSizeHint'
       responses:
         '200':
           description: Successful response


### PR DESCRIPTION
### Motivation

- Provide a documented, discoverable mechanism for clients to supply root transaction and bundle-offset hints when retrieving ANS-104 data items so gateways can short-circuit expensive lookups and help troubleshooting large/older bundled items.
- Align the OpenAPI surface with recent code and changelog changes that added direct byte-offset and root-TX hint support and with the docs PR that describes curl/CLI usage.

### Description

- Add reusable OpenAPI `components.parameters` for header hints: `X-AR-IO-Root-Transaction-Id`, `X-AR-IO-Root-Path`, `X-AR-IO-Root-Item-Offset`, and `X-AR-IO-Root-Item-Size` including types, examples, and explanatory descriptions. 
- Expose those parameter refs on the `GET` and `HEAD` operations for `/{txId}` and `/raw/{txId}` so clients can send hints with normal data-item requests. 
- Clarify semantics in the parameter descriptions: `Root-Path` is a comma-separated traversal of tx IDs, offset/size headers must be supplied as a pair, and gateways re-validate hints and fall back to canonical lookup when hints are unusable.
- Constrain the schemas to the stated contract: `Root-Path` carries a comma-separated 43-character base64url pattern (spaces around commas allowed, because the handler trims each part), `Root-Item-Offset` stays `minimum: 0`, and `Root-Item-Size` uses `minimum: 1` since a complete data item always has a positive size.

### Testing

- Ran a Node.js YAML parse/assert script that verified each `GET` and `HEAD` for `/{txId}` and `/raw/{txId}` exposes the four hint parameters, and the assertion passed. 
- Re-parsed the spec after the schema constraints and confirmed the `Root-Path` pattern accepts the documented example, a single ID, and a spaced list, and rejects short IDs and a trailing comma.
- Ran `git diff --check` to ensure the patch has no whitespace/formatting issues and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7cc7fe91e8832d8411306c55738927)
