### PR TITLE
test(verification): build the flag-specific workers once, not per test

### DIFF
--- a/src/workers/data-verification.test.ts
+++ b/src/workers/data-verification.test.ts
@@ -29,21 +29,14 @@ describe('DataVerificationWorker', () => {
   let saveVerificationStatusMock: any;
   let getDataMock: any;
   let contiguousDataSource: ContiguousDataSource;
-  let extraWorkers: DataVerificationWorker[] = [];
-
-  // Build a worker with an explicit optimistic-indexing setting, registered for
-  // teardown in afterEach.
-  const workerWithOptimisticIndexing = (enabled: boolean) => {
-    const worker = new DataVerificationWorker({
-      log,
-      contiguousDataIndex,
-      dataItemRootTxIndex: contiguousDataIndex,
-      contiguousDataSource,
-      optimisticTxIndexingEnabled: enabled,
-    });
-    extraWorkers.push(worker);
-    return worker;
-  };
+  // Workers with an explicit optimistic-indexing setting. Built once in
+  // `before` and torn down in `after`, NOT per test: each worker owns a
+  // DataRootComputer whose threads only register for termination once they
+  // emit 'online'. A worker created and stopped inside a fast test (the guard
+  // short-circuits in ~2ms) would be stopped before its thread registers, and
+  // the orphan would keep the test process alive forever.
+  let guardOnWorker: DataVerificationWorker;
+  let guardOffWorker: DataVerificationWorker;
 
   // Matching data root for the 'testing...' fixture below. A mined root tx
   // (height set) is the default fixture — the serving guard only withholds
@@ -87,14 +80,25 @@ describe('DataVerificationWorker', () => {
       dataItemRootTxIndex: contiguousDataIndex,
       contiguousDataSource,
     });
+
+    guardOnWorker = new DataVerificationWorker({
+      log,
+      contiguousDataIndex,
+      dataItemRootTxIndex: contiguousDataIndex,
+      contiguousDataSource,
+      optimisticTxIndexingEnabled: true,
+    });
+
+    guardOffWorker = new DataVerificationWorker({
+      log,
+      contiguousDataIndex,
+      dataItemRootTxIndex: contiguousDataIndex,
+      contiguousDataSource,
+      optimisticTxIndexingEnabled: false,
+    });
   });
 
   afterEach(async () => {
-    // Each worker owns a DataRootComputer, which spawns worker threads. Any
-    // worker built inside a test must be stopped or the test process never
-    // exits.
-    await Promise.all(extraWorkers.map((worker) => worker.stop()));
-    extraWorkers = [];
     mock.restoreAll();
     incrementVerificationRetryCountMock.mock.resetCalls();
     saveVerificationStatusMock.mock.resetCalls();
@@ -106,6 +110,8 @@ describe('DataVerificationWorker', () => {
 
   after(async () => {
     await dataVerificationWorker.stop();
+    await guardOnWorker.stop();
+    await guardOffWorker.stop();
   });
 
   it('should verify data root correctly', async () => {
@@ -202,7 +208,7 @@ describe('DataVerificationWorker', () => {
 
     // The guard only applies when optimistic indexing is the thing creating
     // NULL-height rows.
-    const verified = await workerWithOptimisticIndexing(true).verifyDataRoot({
+    const verified = await guardOnWorker.verifyDataRoot({
       rootTxId: 'optimistic-tx',
       dataIds: ['optimistic-tx'],
     });
@@ -232,7 +238,7 @@ describe('DataVerificationWorker', () => {
       // no height, and no optimistic indexing to explain it
     });
 
-    const verified = await workerWithOptimisticIndexing(false).verifyDataRoot({
+    const verified = await guardOffWorker.verifyDataRoot({
       rootTxId: 'queued-tx',
       dataIds: ['queued-tx'],
     });


### PR DESCRIPTION
**Develop is currently broken — `yarn test:ci` hangs.** This is the fix. I introduced the hang in #855 and pushed this a few minutes after that PR merged, so it missed the merge.

## Symptom

`yarn test:ci` hangs on both runners with this as the last line:

```
▶ DataVerificationWorker (1797.485861ms)
```

All tests pass; the process then never exits. The job runs until the `timeout-minutes: 60` backstop added in #851 kills it.

## Cause

Each `DataVerificationWorker` owns a `DataRootComputer`, which registers a worker thread for termination only when the thread emits `online`:

```ts
worker.on('online', () => { self.workers.push({ takeWork }); ... })
```

and `stop()` sends terminates by iterating that array:

```ts
this.workers.forEach(() => { promises.push(this.queueWork('terminate')); });
```

The guard test finishes in **~1.7 ms** — by design, since it asserts the guard short-circuits before `computeDataRoot`. The worker I built inside it was therefore stopped before its thread registered. `stop()` saw an empty array, sent zero terminates, and the orphaned thread kept the process alive.

## Fix

Build both flag-specific workers in `before` and stop them in `after`, so their threads are online by teardown. No product code changes.

## Verification

Targeted file, exit code checked explicitly:

```
EXIT=0
ℹ tests 8   ℹ pass 8   ℹ fail 0
```

Full CI command locally:

```
ℹ tests 2285   ℹ pass 2278   ℹ fail 3
```

Runs to completion rather than hanging. The 3 failures are a local `node_modules` artifact — a nested `@solana/kit` mismatch producing `The requested module '@solana/codecs-core' does not provide an export named 'toArrayBuffer'` — in three files this branch does not touch. CI rebuilds with `yarn --immutable`, where `test:ci` has been green.

## Latent bug this exposed, not fixed here

`DataRootComputer.stop()` cannot terminate a worker that has not yet come online. The test tripped that race, but it applies equally to production shutdown shortly after boot: orphaned threads, or a cleanup handler that hangs. It lives in `src/lib/data-root.ts` and deserves its own fix rather than being folded into a test repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)