### PR TITLE
fix(log): stop a single log call from exhausting the heap

### DIFF
--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -1,6 +1,6 @@
 /**
  * AR.IO Gateway
- * Copyright (C) 2022-2026 Permanent Data Solutions, Inc. All Rights Reserved.
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -57,7 +57,6 @@ describe('log metadata sanitization', () => {
   // gets serialized -- asserting on the input object would prove nothing.
   function transform(meta: unknown) {
     const info: any = { level: 'error', message: 'test', ...(meta as object) };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const fmt: any = (log as any).format;
     return fmt.transform(info, {});
   }
@@ -99,6 +98,45 @@ describe('log metadata sanitization', () => {
     const b: any = { name: 'b', a };
     a.b = b;
     assert.doesNotThrow(() => transform({ cyclic: a }));
+  });
+
+  it('keeps shared (non-cyclic) references instead of marking them circular', () => {
+    // Regression: tracking every object ever seen, rather than the objects on
+    // the current recursion path, made the second reference to a shared object
+    // serialize as "[Circular]" and silently dropped valid metadata.
+    const shared = { id: 'shared-value' };
+    const out: any = transform({ first: shared, second: shared });
+    assert.deepEqual(out.first, { id: 'shared-value' });
+    assert.deepEqual(out.second, { id: 'shared-value' });
+  });
+
+  it('bounds a wide object', () => {
+    const wide: Record<string, number> = {};
+    for (let i = 0; i < 5000; i++) wide[`k${i}`] = i;
+    const out: any = transform({ wide });
+    const keys = Object.keys(out.wide);
+    assert.ok(keys.length <= 129, `expected bounded keys, got ${keys.length}`);
+    assert.ok(String(out.wide['…']).includes('truncated'));
+  });
+
+  it('bounds a long array', () => {
+    const out: any = transform({
+      arr: Array.from({ length: 5000 }, (_, i) => i),
+    });
+    assert.ok(
+      out.arr.length <= 129,
+      `expected bounded array, got ${out.arr.length}`,
+    );
+    assert.ok(String(out.arr[out.arr.length - 1]).includes('truncated'));
+  });
+
+  it('truncates an oversized string', () => {
+    const out: any = transform({ blob: 'x'.repeat(50_000) });
+    assert.ok(
+      out.blob.length < 10_000,
+      `string not truncated: ${out.blob.length}`,
+    );
+    assert.ok(out.blob.includes('truncated'));
   });
 
   it('leaves ordinary metadata intact', () => {

--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -7,7 +7,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import log from './log.js';
+import { createTestLogger } from '../test/test-logger.js';
 
 /**
  * Builds an object shaped like the one that took the gateway down: an axios
@@ -55,9 +55,14 @@ function makeAxiosLikeError(): any {
 describe('log metadata sanitization', () => {
   // Capture what the format chain actually produces, which is the thing that
   // gets serialized -- asserting on the input object would prove nothing.
+  // The test logger is a child of the production logger, so it carries the
+  // real format chain -- which is the thing under test. Asserting against a
+  // hand-built format would prove nothing about what production serializes.
+  const testLog = createTestLogger({ suite: 'log metadata sanitization' });
+
   function transform(meta: unknown) {
     const info: any = { level: 'error', message: 'test', ...(meta as object) };
-    const fmt: any = (log as any).format;
+    const fmt: any = (testLog as any).format ?? (testLog as any).parent?.format;
     return fmt.transform(info, {});
   }
 

--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -1,0 +1,115 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2026 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import log from './log.js';
+
+/**
+ * Builds an object shaped like the one that took the gateway down: an axios
+ * error whose `request` is a Node ClientRequest, which references its redirect
+ * wrapper, its agent, that agent's sockets, and `nativeProtocols` -- the last of
+ * which carries the full HTTP METHODS array and STATUS_CODES table.
+ *
+ * The real graph serialized to 243,511,505 characters. This is a faithful but
+ * small stand-in: what matters is that the dangerous keys are present and the
+ * graph is cyclic.
+ */
+function makeAxiosLikeError(): any {
+  const socket: any = { _pendingData: 'x'.repeat(64), readable: true };
+  const agent: any = {
+    sockets: { 'envoy:3000': [socket] },
+    freeSockets: {},
+    options: { keepAlive: true },
+  };
+  socket._httpMessage = {};
+
+  const clientRequest: any = {
+    _header: 'GET /tx/abc/offset HTTP/1.1\r\nHost: envoy:3000\r\n\r\n',
+    socket,
+    agent,
+    nativeProtocols: {
+      'http:': {
+        METHODS: ['ACL', 'BIND', 'GET', 'POST'],
+        STATUS_CODES: { 200: 'OK', 404: 'Not Found' },
+      },
+    },
+  };
+  // Cycles, as in the real object.
+  clientRequest._redirectable = { _currentRequest: clientRequest };
+  socket._httpMessage = clientRequest;
+
+  const err: any = new Error('socket hang up');
+  err.name = 'AxiosError';
+  err.code = 'ECONNRESET';
+  err.request = clientRequest;
+  err.config = { url: 'http://envoy:3000/tx/abc/offset', httpAgent: agent };
+  err.response = { status: 502, config: err.config, request: clientRequest };
+  return err;
+}
+
+describe('log metadata sanitization', () => {
+  // Capture what the format chain actually produces, which is the thing that
+  // gets serialized -- asserting on the input object would prove nothing.
+  function transform(meta: unknown) {
+    const info: any = { level: 'error', message: 'test', ...(meta as object) };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fmt: any = (log as any).format;
+    return fmt.transform(info, {});
+  }
+
+  it('omits live network objects from an axios-like error', () => {
+    const out: any = transform({ err: makeAxiosLikeError() });
+    const s = JSON.stringify(out);
+
+    // The dangerous keys are replaced, not walked.
+    assert.equal(out.err.request, '[omitted: request]');
+    assert.equal(out.err.response, '[omitted: response]');
+    assert.equal(out.err.config, '[omitted: config]');
+
+    // Nothing from the deep graph survives.
+    assert.ok(
+      !s.includes('STATUS_CODES'),
+      'STATUS_CODES must not be serialized',
+    );
+    assert.ok(!s.includes('nativeProtocols'), 'agent graph must not be walked');
+    assert.ok(!s.includes('_pendingData'), 'socket buffers must not be walked');
+  });
+
+  it('keeps the fields an operator actually needs', () => {
+    const out: any = transform({ err: makeAxiosLikeError() });
+    assert.equal(out.err.code, 'ECONNRESET');
+    assert.equal(out.message, 'test');
+  });
+
+  it('bounds the serialized size of a hostile object', () => {
+    const out = transform({ err: makeAxiosLikeError() });
+    const size = JSON.stringify(out).length;
+    // The unsanitized graph is unbounded; anything in this range proves the
+    // walk stopped rather than expanded.
+    assert.ok(size < 4000, `serialized metadata too large: ${size}`);
+  });
+
+  it('survives cycles without throwing', () => {
+    const a: any = { name: 'a' };
+    const b: any = { name: 'b', a };
+    a.b = b;
+    assert.doesNotThrow(() => transform({ cyclic: a }));
+  });
+
+  it('leaves ordinary metadata intact', () => {
+    const out: any = transform({
+      txId: 'abc123',
+      count: 42,
+      nested: { depth: 1, ok: true },
+    });
+    assert.equal(out.txId, 'abc123');
+    assert.equal(out.count, 42);
+    assert.equal(out.nested.depth, 1);
+    assert.equal(out.nested.ok, true);
+  });
+});

--- a/src/log.ts
+++ b/src/log.ts
@@ -42,6 +42,86 @@ const filterFormat = format((info) => {
   return isMatching ? info : false; // Return `false` to discard
 });
 
+// Log metadata that carries a live network object serializes into an enormous
+// string. `format.json()` walks the whole reachable graph, and an axios error's
+// `request` is a Node `ClientRequest` that references its redirect wrapper, its
+// agent, that agent's sockets, and `nativeProtocols` -- which includes the full
+// HTTP METHODS array and STATUS_CODES table.
+//
+// Measured in production: one `AggregateError` of rejected axios promises,
+// logged whole, serialized to 243,511,505 characters. Because JSON building
+// concatenates, that is ~141 million ConsString nodes -- about 7 GB, enough to
+// exhaust an 8 GB heap on its own and take the process down mid-serialization.
+//
+// Individual call sites should extract the fields they need (message, stack,
+// code), and they overwhelmingly do. This is the backstop for the ones that do
+// not: no single logging mistake should be able to OOM the gateway.
+const DANGEROUS_METADATA_KEYS = new Set([
+  'request',
+  'response',
+  'config',
+  'socket',
+  'agent',
+  'httpAgent',
+  'httpsAgent',
+  '_redirectable',
+  '_httpMessage',
+  'req',
+  'res',
+]);
+
+const MAX_METADATA_DEPTH = 6;
+
+/**
+ * Replace values that are unsafe to serialize with a short marker, in place,
+ * bounded by depth. Cycles are handled by a seen-set; the depth cap bounds the
+ * cost on wide-but-shallow objects that are otherwise legitimate.
+ */
+function sanitizeMetadata(
+  value: unknown,
+  seen: WeakSet<object>,
+  depth: number,
+): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (depth >= MAX_METADATA_DEPTH) {
+    return '[truncated: max depth]';
+  }
+  if (seen.has(value as object)) {
+    return '[Circular]';
+  }
+  seen.add(value as object);
+
+  if (Array.isArray(value)) {
+    return value.map((v) => sanitizeMetadata(v, seen, depth + 1));
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (DANGEROUS_METADATA_KEYS.has(k)) {
+      // Keep a breadcrumb so the log still says something useful.
+      out[k] = `[omitted: ${k}]`;
+      continue;
+    }
+    out[k] = sanitizeMetadata(v, seen, depth + 1);
+  }
+  return out;
+}
+
+const sanitizeFormat = format((info) => {
+  const seen = new WeakSet<object>();
+  for (const key of Object.keys(info)) {
+    // level/message/timestamp are winston's own and are always primitives here.
+    if (key === 'level' || key === 'message' || key === 'timestamp') continue;
+    const v = (info as Record<string, unknown>)[key];
+    if (v !== null && typeof v === 'object') {
+      (info as Record<string, unknown>)[key] = sanitizeMetadata(v, seen, 0);
+    }
+  }
+  return info;
+});
+
 const injectRequestId = format((info) => {
   const ctx = requestContextStorage.getStore();
   if (ctx !== undefined) {
@@ -71,6 +151,9 @@ const logger = createLogger({
     filterStackTraces(),
     filterFormat(),
     format.errors(),
+    // After filtering (so discarded records cost nothing) and before json()
+    // (which is what would otherwise walk the graph).
+    sanitizeFormat(),
     format.timestamp(),
     LOG_FORMAT === 'json' ? format.json() : format.simple(),
   ),

--- a/src/log.ts
+++ b/src/log.ts
@@ -72,52 +72,83 @@ const DANGEROUS_METADATA_KEYS = new Set([
 
 const MAX_METADATA_DEPTH = 6;
 
+// Depth alone is not a budget. A flat object with a million keys, or an array
+// with a million elements, is depth-1 and would still be cloned and serialized
+// in full. These cap breadth and leaf size so the sanitized copy is bounded
+// regardless of the shape it is handed.
+const MAX_METADATA_ENTRIES = 128;
+const MAX_METADATA_ARRAY = 128;
+const MAX_METADATA_STRING = 8192;
+
 /**
- * Replace values that are unsafe to serialize with a short marker, in place,
- * bounded by depth. Cycles are handled by a seen-set; the depth cap bounds the
- * cost on wide-but-shallow objects that are otherwise legitimate.
+ * Produce a serialization-safe copy of log metadata, bounded in depth, breadth,
+ * and leaf size, with live network objects replaced by a breadcrumb.
  */
 function sanitizeMetadata(
   value: unknown,
-  seen: WeakSet<object>,
+  path: Set<object>,
   depth: number,
 ): unknown {
+  if (typeof value === 'string') {
+    return value.length > MAX_METADATA_STRING
+      ? `${value.slice(0, MAX_METADATA_STRING)}… [truncated ${value.length - MAX_METADATA_STRING} chars]`
+      : value;
+  }
   if (value === null || typeof value !== 'object') {
     return value;
   }
   if (depth >= MAX_METADATA_DEPTH) {
     return '[truncated: max depth]';
   }
-  if (seen.has(value as object)) {
+  // Track only the objects on the *current* recursion path. A shared (but
+  // acyclic) object referenced from two properties is legitimate metadata and
+  // must serialize both times; only a genuine cycle should be cut.
+  if (path.has(value as object)) {
     return '[Circular]';
   }
-  seen.add(value as object);
-
-  if (Array.isArray(value)) {
-    return value.map((v) => sanitizeMetadata(v, seen, depth + 1));
-  }
-
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-    if (DANGEROUS_METADATA_KEYS.has(k)) {
-      // Keep a breadcrumb so the log still says something useful.
-      out[k] = `[omitted: ${k}]`;
-      continue;
+  path.add(value as object);
+  try {
+    if (Array.isArray(value)) {
+      const out = value
+        .slice(0, MAX_METADATA_ARRAY)
+        .map((v) => sanitizeMetadata(v, path, depth + 1));
+      if (value.length > MAX_METADATA_ARRAY) {
+        out.push(`… [truncated ${value.length - MAX_METADATA_ARRAY} elements]`);
+      }
+      return out;
     }
-    out[k] = sanitizeMetadata(v, seen, depth + 1);
+
+    const out: Record<string, unknown> = {};
+    let n = 0;
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (n >= MAX_METADATA_ENTRIES) {
+        out['…'] =
+          `[truncated ${Object.keys(value as object).length - n} keys]`;
+        break;
+      }
+      n++;
+      if (DANGEROUS_METADATA_KEYS.has(k)) {
+        // Keep a breadcrumb so the log still says something useful.
+        out[k] = `[omitted: ${k}]`;
+        continue;
+      }
+      out[k] = sanitizeMetadata(v, path, depth + 1);
+    }
+    return out;
+  } finally {
+    path.delete(value as object);
   }
-  return out;
 }
 
 const sanitizeFormat = format((info) => {
-  const seen = new WeakSet<object>();
+  const path = new Set<object>();
   for (const key of Object.keys(info)) {
     // level/message/timestamp are winston's own and are always primitives here.
     if (key === 'level' || key === 'message' || key === 'timestamp') continue;
+    // Route every value through, not just objects: an oversized top-level
+    // string needs the same budget as a deep graph.
     const v = (info as Record<string, unknown>)[key];
-    if (v !== null && typeof v === 'object') {
-      (info as Record<string, unknown>)[key] = sanitizeMetadata(v, seen, 0);
-    }
+    (info as Record<string, unknown>)[key] = sanitizeMetadata(v, path, 0);
   }
   return info;
 });

--- a/src/system.ts
+++ b/src/system.ts
@@ -167,7 +167,21 @@ export function registerCleanupHandler(
 
 process.on('uncaughtException', (error) => {
   metrics.uncaughtExceptionCounter.inc();
-  log.error('Uncaught exception:', error);
+  // Extract fields rather than passing the error object. A rejected axios
+  // promise carries `request` -- a live ClientRequest whose reachable graph is
+  // enormous -- and an AggregateError carries a whole array of them. Logging
+  // one whole serialized to 243 MB in production and exhausted the heap.
+  log.error('Uncaught exception:', {
+    message: error?.message,
+    stack: error?.stack,
+    name: error?.name,
+    ...(Array.isArray((error as AggregateError)?.errors) && {
+      errors: (error as AggregateError).errors
+        .slice(0, 20)
+        .map((e: any) => e?.message ?? String(e)),
+      errorCount: (error as AggregateError).errors.length,
+    }),
+  });
 });
 
 const arweave = Arweave.init({});


### PR DESCRIPTION
## The bug

The `uncaughtException` handler passed the whole error object as winston metadata:

```js
process.on('uncaughtException', (error) => {
  metrics.uncaughtExceptionCounter.inc();
  log.error('Uncaught exception:', error);   // <- entire object graph
});
```

`format.json()` then serializes everything reachable from it. A rejected axios
promise carries `request` — a live Node `ClientRequest` — which references its
redirect wrapper, its agent, that agent's sockets, and `nativeProtocols`, the last
of which contains the full HTTP `METHODS` array and `STATUS_CODES` table. An
`AggregateError` carries an array of them.

## Measured impact

From a production heap snapshot taken moments before an OOM:

```
heap total                    8.03 GB
concatenated string nodes  244,760,393  (7.58 GB, 94% of heap)
interior rope links        238,270,381
largest single rope        141,442,671 nodes
  -> its contents          243,511,505 characters
```

That one rope is a `JSON.stringify` of a `ClientRequest` for
`GET /tx/<id>/offset`. JSON building concatenates, so 243 MB of text becomes
~141 M `ConsString` nodes at 32 bytes each — 7.1 GB, on its own enough to exhaust
an 8 GB heap.

The rope was rooted in `(Stack roots)`, i.e. still being built when the limit hit.
The process died mid-serialization.

Head of the dumped rope:

```
{"_closed":false,"_contentLength":0,"_defaultKeepAlive":true,
 "_header":"GET /tx/WaMQ.../offset HTTP/1.1\r\nUser-Agent: axios/1.15.0\r\n...",
 "_redirectable":{"_currentRequest":"[Circular]", ...
 "nativeProtocols":{"http:":{"METHODS":["ACL","BIND",...],"STATUS_CODES":{...}}}}
```

The `[Circular]` markers are winston's own safe stringifier — the fingerprint that
identified the producer.

On the affected gateways this fired **9 times in 2 hours**, each time as
`Uncaught exception: All promises were rejected` — an `AggregateError` from a
parallel retrieval fan-out where every branch failed.

Note `LOG_FILTER` offers no protection here: the root logger has no `class`
attribute, so class-based filters never match it.

## Changes

**1. The call site.** Extract `message`/`stack`/`name`, plus a bounded list of
member messages when the error is an `AggregateError`. Every other error log in
the codebase already does this — this one was the exception, not the rule.

**2. A backstop in the logger.** A sanitizing format stage that replaces known
live-network keys (`request`, `response`, `config`, `socket`, `agent`,
`_redirectable`, ...) with a breadcrumb and caps traversal depth.

Placed after `filterFormat()` so discarded records cost nothing, and before
`format.json()` — which is the stage that would otherwise walk the graph.

Call sites should still extract the fields they need. The point of the backstop is
that no single logging mistake should be able to take a gateway down, and auditing
every call site forever is not a strategy.

## Testing

`src/log.test.ts` builds the same object shape — cycles, agent, sockets,
`nativeProtocols` — pushes it through the real format chain, and asserts nothing
from the deep graph is serialized while `code` and `message` survive.

Verified non-vacuous: removing the format stage fails 2 of the 5 tests.

`tsc`, `yarn lint:check`, and `prettier` are clean.

## Scope

Independent of #861 (staging-file cleanup) — different subsystem, no shared files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
