### PR TITLE
docs(cache): scope cache-cleanup.md to the contiguous cache

### DIFF
--- a/docs/cache-cleanup.md
+++ b/docs/cache-cleanup.md
@@ -116,3 +116,24 @@ Recommended large-cache setup:
   worker doesn't also run (or set it if you want it as an occasional reconciler).
 
 See [Environment Variables](envs.md) for the full list of related settings.
+
+## Scope: this document covers the contiguous data cache only
+
+The **chunk** data cache (`data/chunks`) is a separate volume with a separate
+lifecycle, and it has **no index evictor** — it is reclaimed solely by
+`FsCleanupWorker`, tuned by the `CHUNK_DATA_CACHE_*` watermarks rather than the
+`CONTIGUOUS_DATA_CACHE_*` ones above.
+
+That distinction matters when sizing: the walk cost described above applies to it
+too, and a chunk cache holds far more objects than a contiguous cache of the same
+size (millions of ~256 KiB chunks vs whole blobs). On a production gateway the
+chunk cleanup walk was measured spending 93.9s of every 94.9s batch cycle
+traversing rather than deleting, so the "use the index evictor on large caches"
+advice above has no equivalent escape hatch on the chunk side yet.
+
+One chunk-specific constraint has no analogue here: `AGGRESSIVE_MIN_AGE_SECONDS`
+must stay above the ingest confirmation lag, or the walk can free bytes out from
+under a placement the ingest GC still considers in flight (`row present, bytes
+gone` → later cache misses). Measure that lag from the `chunk_placements` table,
+not from `chunk_ingest_confirmation_latency` — the counter is process-lifetime
+scoped and drops the slow tail.


### PR DESCRIPTION
`docs/cache-cleanup.md` is titled *Contiguous Data Cache Cleanup*, but the body reads as general cache-cleanup guidance and its watermark sections use bare setting names that exist in both `CONTIGUOUS_DATA_CACHE_*` and `CHUNK_DATA_CACHE_*` forms. Someone tuning chunk cache settings from it would apply contiguous advice — and would go looking for the *use the index evictor on large caches* escape hatch, which has no chunk-side equivalent.

Adds a scope section recording two chunk-specific differences:

- The chunk cache has **no index evictor**. It is reclaimed only by `FsCleanupWorker`, so the walk cost this document already describes applies with no alternative. Measured on a production gateway: **93.9s of every 94.9s batch cycle spent traversing rather than deleting**.
- `AGGRESSIVE_MIN_AGE_SECONDS` must stay above the ingest confirmation lag, or the walk frees bytes out from under a placement the ingest GC still considers in flight (`row present, bytes gone` → later cache misses). Measure that lag from the `chunk_placements` table, **not** from `chunk_ingest_confirmation_latency` — that counter is process-lifetime scoped and drops the slow tail, which produced a materially wrong figure when we used it for exactly this.

Docs-only, 21 lines added, no behaviour change.