### PR TITLE
fix(chunks): retry a chunk write when its data-root directory disappears

### DIFF
--- a/src/store/fs-chunk-data-store.test.ts
+++ b/src/store/fs-chunk-data-store.test.ts
@@ -35,6 +35,45 @@ describe('FsChunkDataStore', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
+  describe('write durability', () => {
+    it('should retry the write when the data-root directory disappears mid-set', async () => {
+      const dataRoot = 'wRq6f05oRupfTW_M5dcYBtwK5P8rSNYu20vC6D_o-M4';
+      const relativeOffset = 0;
+      const chunkData: ChunkData = {
+        chunk: Buffer.from('survives a concurrent rmdir'),
+        hash: crypto
+          .createHash('sha256')
+          .update('survives a concurrent rmdir')
+          .digest(),
+      };
+      const fsp = (await import('node:fs')).promises;
+
+      // Simulate the directory being reaped between mkdir and writeFile, which
+      // is what data-root-granularity eviction will do. Without a retry the
+      // ENOENT is swallowed and the chunk is silently lost.
+      const realWriteFile = fsp.writeFile.bind(fsp);
+      let firstAttempt = true;
+      (fsp as any).writeFile = async (p: any, d: any) => {
+        if (firstAttempt && String(p).includes('by-dataroot')) {
+          firstAttempt = false;
+          const err: any = new Error('ENOENT: no such file or directory');
+          err.code = 'ENOENT';
+          throw err;
+        }
+        return realWriteFile(p, d);
+      };
+      try {
+        await store.set(dataRoot, relativeOffset, chunkData);
+      } finally {
+        (fsp as any).writeFile = realWriteFile;
+      }
+
+      assert.equal(await store.has(dataRoot, relativeOffset), true);
+      const stream = await store.get(dataRoot, relativeOffset);
+      assert.ok(stream !== undefined);
+    });
+  });
+
   describe('absolute offset symlink', () => {
     const dataRoot = 'wRq6f05oRupfTW_M5dcYBtwK5P8rSNYu20vC6D_o-M4';
     const relativeOffset = 0;

--- a/src/store/fs-chunk-data-store.ts
+++ b/src/store/fs-chunk-data-store.ts
@@ -172,7 +172,20 @@ export class FsChunkDataStore implements ChunkDataStore {
       await fs.promises.mkdir(chunkDataRootDir, { recursive: true });
 
       const chunkPath = this.chunkDataRootPath(dataRoot, relativeOffset);
-      await fs.promises.writeFile(chunkPath, chunkData.chunk);
+      try {
+        await fs.promises.writeFile(chunkPath, chunkData.chunk);
+      } catch (error: any) {
+        // The directory can be removed between the mkdir above and this write:
+        // nothing reaps empty data-root directories today, but eviction that
+        // works at data-root granularity will, and the resulting ENOENT would
+        // otherwise be swallowed by the outer catch -- silently dropping a
+        // chunk the caller believes was cached. Recreate and retry once.
+        if (error.code !== 'ENOENT') {
+          throw error;
+        }
+        await fs.promises.mkdir(chunkDataRootDir, { recursive: true });
+        await fs.promises.writeFile(chunkPath, chunkData.chunk);
+      }
 
       // If absoluteOffset provided, create symlink in by-absolute-offset index
       if (absoluteOffset !== undefined) {


### PR DESCRIPTION
## Problem

`FsChunkDataStore.set()` creates the data-root directory, then writes the chunk into it:

```js
await fs.promises.mkdir(chunkDataRootDir, { recursive: true });
const chunkPath = this.chunkDataRootPath(dataRoot, relativeOffset);
await fs.promises.writeFile(chunkPath, chunkData.chunk);
```

If the directory is removed between those two calls, `writeFile` fails `ENOENT`, the outer `catch` swallows it (the index is best-effort, so failures are logged and not rethrown), and **the chunk is silently dropped** — the caller is told nothing and believes it was cached.

## Why now

This is **latent, not live**: nothing reaps empty data-root directories today, which is why 67% of them are empty on a production gateway.

It stops being latent the moment eviction works at data-root granularity — which is exactly what [ADR 005](https://github.com/ar-io/ar-io-node/blob/docs/chunk-cache-indexed-eviction/docs/madr/005-chunk-data-cache-indexed-eviction.md) proposes. That ADR flags this as a prerequisite:

> *"note `FsChunkDataStore.set()` does `mkdir` then `writeFile` with **no ENOENT retry** — removing a directory between those two calls silently drops the chunk. Any `rmdir` work must add that retry first."*

Landing it separately means the eviction work doesn't have to carry a silent-data-loss fix alongside a design change, and the fix stands on its own regardless of whether directory reaping is ever built.

## Change

Recreate the directory and retry the write once on `ENOENT`. Anything else rethrows, so unrelated write failures still reach the existing error path unchanged. No behaviour change on the happy path — one extra `try` around a call that already succeeds.

## Testing

The new test simulates the directory vanishing mid-`set()` and asserts the chunk is still readable afterwards. Confirmed to fail without the fix:

```
without: not ok 1 - should retry the write when the data-root directory disappears mid-set
         19 pass / 1 fail
with:    20 pass / 0 fail
```

Type-clean; no new lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WndVj5cprBtfa5d2qqnacp
