### PR TITLE
fix(data): enforce blocklist on manifest-resolved data items

### DIFF
--- a/src/routes/data/handlers.test.ts
+++ b/src/routes/data/handlers.test.ts
@@ -2088,6 +2088,67 @@ st
           assert.equal(getDataMock.mock.calls.length, 0);
         });
 
+        it('should fail closed (503) when the blocklist check throws for a manifest-resolved item', async () => {
+          const manifestId = 'manifest-id';
+          const resolvedId = 'resolved-id';
+
+          mock.method(dataAttributesSource, 'getDataAttributes', () =>
+            Promise.resolve({
+              size: 100,
+              contentType: 'application/x.arweave-manifest+json',
+              isManifest: true,
+              stable: true,
+              verified: true,
+              signature: null,
+            }),
+          );
+
+          // Top-level id check passes; the resolved-leaf check throws.
+          mock.method(
+            dataBlockListValidator,
+            'isIdBlocked',
+            (checkId: string) => {
+              if (checkId === resolvedId) {
+                return Promise.reject(
+                  new Error('blocklist backend unavailable'),
+                );
+              }
+              return Promise.resolve(false);
+            },
+          );
+
+          mock.method(manifestPathResolver, 'resolveFromIndex', () =>
+            Promise.resolve({
+              id: manifestId,
+              resolvedId,
+              complete: true,
+              resolutionType: 'path',
+            }),
+          );
+
+          // Content must not be served when we cannot verify it is unblocked.
+          const getDataMock = mock.method(dataSource, 'getData', () =>
+            Promise.reject(
+              new Error('getData should not be called when failing closed'),
+            ),
+          );
+
+          app.get(
+            '/:id/*',
+            createDataHandler({
+              log,
+              dataAttributesSource,
+              dataSource,
+              dataBlockListValidator,
+              manifestPathResolver,
+            }),
+          );
+
+          await request(app).get('/manifest-id/path/to/file.html').expect(503);
+
+          assert.equal(getDataMock.mock.calls.length, 0);
+        });
+
         it('should evict resolvedId from negative cache when manifest-resolved data is served', async () => {
           const manifestId = 'manifest-id';
           const resolvedId = 'resolved-manifest-path-id';

--- a/src/routes/data/handlers.test.ts
+++ b/src/routes/data/handlers.test.ts
@@ -1947,6 +1947,147 @@ st
             });
         });
 
+        it('should return 451 when a manifest resolves to a data item blocked by ID', async () => {
+          const manifestId = 'manifest-id';
+          const resolvedId = 'resolved-blocked-id';
+
+          // manifest-id is a manifest; the resolved leaf is a normal item.
+          mock.method(
+            dataAttributesSource,
+            'getDataAttributes',
+            (checkId: string) =>
+              Promise.resolve({
+                size: 100,
+                contentType:
+                  checkId === manifestId
+                    ? 'application/x.arweave-manifest+json'
+                    : 'text/html',
+                isManifest: checkId === manifestId,
+                stable: true,
+                verified: true,
+                signature: null,
+              }),
+          );
+
+          // The manifest itself is NOT blocked; only the resolved leaf is.
+          mock.method(
+            dataBlockListValidator,
+            'isIdBlocked',
+            (checkId: string) => Promise.resolve(checkId === resolvedId),
+          );
+
+          mock.method(manifestPathResolver, 'resolveFromIndex', () =>
+            Promise.resolve({
+              id: manifestId,
+              resolvedId,
+              complete: true,
+              resolutionType: 'path',
+            }),
+          );
+
+          // Blocked content must never be fetched/streamed.
+          const getDataMock = mock.method(dataSource, 'getData', () =>
+            Promise.reject(
+              new Error('getData should not be called for blocked content'),
+            ),
+          );
+
+          app.get(
+            '/:id/*',
+            createDataHandler({
+              log,
+              dataAttributesSource,
+              dataSource,
+              dataBlockListValidator,
+              manifestPathResolver,
+            }),
+          );
+
+          await request(app)
+            .get('/manifest-id/path/to/file.html')
+            .expect(451)
+            .then((res: any) => {
+              assert.match(
+                res.text,
+                /Requested content blocked by this node's content policy/,
+              );
+              // The blocked leaf id is reported, not the manifest id.
+              assert.match(res.text, new RegExp(resolvedId));
+            });
+
+          assert.equal(getDataMock.mock.calls.length, 0);
+        });
+
+        it('should return 451 when a manifest resolves to a data item blocked by hash', async () => {
+          const manifestId = 'manifest-id';
+          const resolvedId = 'resolved-hash-blocked-id';
+          const blockedHash = 'blocked-content-hash';
+
+          mock.method(
+            dataAttributesSource,
+            'getDataAttributes',
+            (checkId: string) =>
+              Promise.resolve(
+                checkId === manifestId
+                  ? {
+                      size: 100,
+                      contentType: 'application/x.arweave-manifest+json',
+                      isManifest: true,
+                      stable: true,
+                      verified: true,
+                      signature: null,
+                    }
+                  : {
+                      size: 42,
+                      contentType: 'text/html',
+                      isManifest: false,
+                      stable: true,
+                      verified: true,
+                      signature: null,
+                      hash: blockedHash,
+                    },
+              ),
+          );
+
+          // Nothing blocked by ID; the resolved leaf's content hash IS blocked.
+          mock.method(dataBlockListValidator, 'isIdBlocked', () =>
+            Promise.resolve(false),
+          );
+          mock.method(dataBlockListValidator, 'isHashBlocked', (hash: string) =>
+            Promise.resolve(hash === blockedHash),
+          );
+
+          mock.method(manifestPathResolver, 'resolveFromIndex', () =>
+            Promise.resolve({
+              id: manifestId,
+              resolvedId,
+              complete: true,
+              resolutionType: 'path',
+            }),
+          );
+
+          const getDataMock = mock.method(dataSource, 'getData', () =>
+            Promise.reject(
+              new Error('getData should not be called for blocked content'),
+            ),
+          );
+
+          app.get(
+            '/:id/*',
+            createDataHandler({
+              log,
+              dataAttributesSource,
+              dataSource,
+              dataBlockListValidator,
+              manifestPathResolver,
+            }),
+          );
+
+          await request(app).get('/manifest-id/path/to/file.html').expect(451);
+
+          assert.equal(getDataMock.mock.calls.length, 0);
+        });
+
         it('should evict resolvedId from negative cache when manifest-resolved data is served', async () => {
           const manifestId = 'manifest-id';
           const resolvedId = 'resolved-manifest-path-id';

--- a/src/routes/data/handlers.ts
+++ b/src/routes/data/handlers.ts
@@ -1429,6 +1429,7 @@ const sendManifestResponse = async ({
   res,
   dataSource,
   dataAttributesSource,
+  dataBlockListValidator,
   dataItemMetaResolver,
   id,
   resolvedId,
@@ -1445,6 +1446,7 @@ const sendManifestResponse = async ({
   res: Response;
   dataSource: ContiguousDataSource;
   dataAttributesSource: DataAttributesSource;
+  dataBlockListValidator: DataBlockListValidator;
   dataItemMetaResolver?: TxMetadataResolver;
   id: string;
   resolvedId: string | undefined;
@@ -1469,6 +1471,27 @@ const sendManifestResponse = async ({
       return true;
     }
 
+    // Return 451 if the manifest-resolved data item is blocked by ID.
+    // The top-level handler only checks the request id — which for a manifest
+    // path is the manifest tx, not the item it resolves to. Without this check
+    // blocked content stays reachable via any manifest that references it.
+    try {
+      if (await dataBlockListValidator.isIdBlocked(resolvedId)) {
+        parentSpan?.setAttribute('http.status_code', 451);
+        parentSpan?.setAttribute('data.error', 'id_blocked');
+        sendBlocked(res, resolvedId);
+        // Indicate response was sent
+        return true;
+      }
+    } catch (error: any) {
+      parentSpan?.recordException(error);
+      log.error('Error checking blocklist:', {
+        dataId: resolvedId,
+        message: error.message,
+        stack: error.stack,
+      });
+    }
+
     let dataAttributes: ContiguousDataAttributes | undefined;
     try {
       dataAttributes = await dataAttributesSource.getDataAttributes(resolvedId);
@@ -1480,6 +1503,26 @@ const sendManifestResponse = async ({
       });
       // Indicate response was NOT sent
       return false;
+    }
+
+    // Return 451 if the manifest-resolved data item is blocked by hash.
+    if (dataAttributes?.hash !== undefined) {
+      try {
+        if (await dataBlockListValidator.isHashBlocked(dataAttributes.hash)) {
+          parentSpan?.setAttribute('http.status_code', 451);
+          parentSpan?.setAttribute('data.error', 'hash_blocked');
+          sendBlocked(res, resolvedId);
+          // Indicate response was sent
+          return true;
+        }
+      } catch (error: any) {
+        parentSpan?.recordException(error);
+        log.error('Error checking blocklist:', {
+          dataId: resolvedId,
+          message: error.message,
+          stack: error.stack,
+        });
+      }
     }
 
     // Retrieve data based on ID resolved from manifest path or index
@@ -1832,6 +1875,7 @@ export const createDataHandler = ({
               res,
               dataAttributesSource,
               dataSource,
+              dataBlockListValidator,
               dataItemMetaResolver,
               requestAttributes,
               rateLimiter,
@@ -1973,6 +2017,7 @@ export const createDataHandler = ({
               res,
               dataAttributesSource,
               dataSource,
+              dataBlockListValidator,
               dataItemMetaResolver,
               requestAttributes,
               rateLimiter,

--- a/src/routes/data/handlers.ts
+++ b/src/routes/data/handlers.ts
@@ -1485,11 +1485,19 @@ const sendManifestResponse = async ({
       }
     } catch (error: any) {
       parentSpan?.recordException(error);
+      parentSpan?.setAttribute('http.status_code', 503);
+      parentSpan?.setAttribute('data.error', 'blocklist_check_failed');
       log.error('Error checking blocklist:', {
         dataId: resolvedId,
         message: error.message,
         stack: error.stack,
       });
+      // Fail closed: if we cannot confirm the resolved item is unblocked, do
+      // not serve it — otherwise a validator outage silently reopens the
+      // manifest-path bypass this check exists to close.
+      res.status(503).send('Unable to verify content policy for this item');
+      // Indicate response was sent
+      return true;
     }
 
     let dataAttributes: ContiguousDataAttributes | undefined;
@@ -1517,11 +1525,17 @@ const sendManifestResponse = async ({
         }
       } catch (error: any) {
         parentSpan?.recordException(error);
+        parentSpan?.setAttribute('http.status_code', 503);
+        parentSpan?.setAttribute('data.error', 'blocklist_check_failed');
         log.error('Error checking blocklist:', {
           dataId: resolvedId,
           message: error.message,
           stack: error.stack,
         });
+        // Fail closed (see the id-blocked branch above).
+        res.status(503).send('Unable to verify content policy for this item');
+        // Indicate response was sent
+        return true;
       }
     }
 


### PR DESCRIPTION

### Summary
A data item blocked by ID or content hash was still reachable through any
manifest/ArNS path that resolved to it. The data handler runs its blocklist
checks (`isIdBlocked` / `isHashBlocked`) only against the **top-level request
id** — which for a manifest request is the manifest tx, not the item the path
resolves to. `sendManifestResponse` then fetched and streamed the resolved leaf
with **no** blocklist check.

Result: `GET /raw/<leaf>` and `GET /<leaf>` correctly return **451**, but
`GET /<manifest>/<path>` (and the equivalent ArNS `https://<name>/<path>`)
returned **200** for the exact same blocked bytes.

### How it was found
Production incident on the testnet gateway (`ar-io.dev`): a Google Safe
Browsing–flagged phishing page (`wdhl.html`) whose leaf data item was already
blocked (451 on `/raw` and bare `/<id>`) was **still served 200** via its
manifest path. Blocking the manifest tx worked around it; this PR fixes the
root cause.

### Fix
In `sendManifestResponse` (`src/routes/data/handlers.ts`), after a manifest
resolves to `resolvedId`:
- check `isIdBlocked(resolvedId)` **before** fetching data, and
- check `isHashBlocked(hash)` on the resolved item's attributes,

mirroring the top-level handler. On a hit we send 451 via `sendBlocked` and
return "response sent" — the blocked content is never fetched or streamed. The
validator is now threaded into both resolution call sites (index and on-demand
data parse).

### Tests
Adds three regression tests to `handlers.test.ts`:
- manifest resolves to an **ID-blocked** leaf → 451, and `getData` is never called.
- manifest resolves to a **hash-blocked** leaf → 451, and `getData` is never called.
- the blocklist check **throws** for a manifest-resolved item → 503, and `getData`
  is never called (added in 5f3ef68).

Each asserts that `getData` was never invoked, not merely that the response was
451/503 — the property that matters is that blocked bytes are never fetched.

### Verification (local)
- `eslint src/routes/data/*` — clean
- `tsc --noEmit -p tsconfig.json` — clean
- targeted `handlers.test.ts` — new tests pass; the only failing test
  (`fallback range requests`, `HPE_CLOSED_CONNECTION`) is a pre-existing
  Node-v22 HTTP flake that fails identically on untouched `develop` (CI pins
  Node v20.11.1 via `.nvmrc`).

### Risk / blast radius
Blocked content that was previously leaking via manifest paths now correctly
returns 451, and is never fetched or streamed.

One behaviour change is **not** purely enforcement-tightening and is called out
deliberately: the new checks **fail closed**. If `isIdBlocked` / `isHashBlocked`
throws, the manifest path now returns 503 rather than serving. `isIdBlocked` is
`queueRead('moderation', ...)` — a worker-thread read against the moderation
SQLite DB with no internal try/catch — so `SQLITE_BUSY`, worker death or a queue
timeout can surface as a throw. During such an outage, manifest and ArNS requests
for *non-blocked* content return 503 where they previously returned 200.

That is the correct direction (a validator outage must not silently reopen the
bypass this PR exists to close), but it creates an asymmetry worth stating:

- **new manifest checks** — fail closed (503)
- **existing top-level checks** — fail *open*: they log and continue serving,
  with a literal `// TODO return 500` at `src/routes/data/handlers.ts:1126`

So after this merges, a moderation-DB error 503s manifest/ArNS traffic while
`GET /raw/<blocked-id>` keeps serving the blocked bytes. The top-level handler is
the half that is wrong, and its own TODO says so — but fixing it changes the
behaviour of the highest-traffic path in the gateway under failure, so it belongs
in its own PR with its own risk discussion rather than riding along here.

### Deliberately out of scope
- **HTTPSIG-signing the 451/503 responses.** `sendBlocked` is a bare
  `res.status(451).send()` with only a `Cache-Control` header, and `develop`
  already has four unsigned call sites. This PR adds a fifth in the existing
  style; it introduces no new inconsistency. Signing them is a change to the
  shared helper and every existing caller.
- **Making the top-level checks fail closed.** See above.
- **Validating `resolvedId`.** The top-level handler validates `id` with
  `isValidTxId` (handlers.ts:1105, :1696); the manifest path never validates the
  id it reads out of manifest JSON, which is attacker-controlled. Pre-existing,
  and not reachable as a new fault through these checks — `fromB64Url` is
  `Buffer.from(input, 'base64')`, which does not throw on malformed input — so a
  guard is a cheap follow-up rather than a blocker.
