### PR TITLE
chore: bump default observer image to 4d1c9046 (observation snapshot fix)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -638,7 +638,7 @@ services:
       - clickhouse
 
   observer:
-    image: ghcr.io/ar-io/ar-io-observer:${OBSERVER_IMAGE_TAG:-15e285b0a539dfb732ab70e13ab062c02c9906d0}
+    image: ghcr.io/ar-io/ar-io-observer:${OBSERVER_IMAGE_TAG:-4d1c904642dbe51a69434b6bf60736481ee51286}
     restart: unless-stopped
     ports:
       - ${OBSERVER_PORT:-5050}:5050


### PR DESCRIPTION
Rolls [ar-io-observer#127](https://github.com/ar-io/ar-io-observer/pull/127) and [#128](https://github.com/ar-io/ar-io-observer/pull/128) into the gateway default, so a fresh `docker compose up` picks them up without an explicit `OBSERVER_IMAGE_TAG`.

One line: `15e285b0…` → `4d1c9046…`. It is the only observer pin in the repo.

## What the new image fixes

**#128 — `@ar.io/sdk` 4.1.4 → 4.2.0**, carrying [ar-io-sdk#717](https://github.com/ar-io/ar-io-sdk/pull/717).

`saveObservations` derived `gateway_count` from a **live** registry read, but the chain validates it against the epoch's frozen `Epoch.active_gateway_count`. One gateway joining mid-epoch desynced the two and rejected **every observer's** submission with `InvalidObservation` (6041) for the rest of the epoch.

Mainnet **epoch 523** closed with `observations_submitted = 0` across all 50 prescribed observers — protocol-wide, not one operator's misconfiguration. Isolated by simulation: 644 (the snapshot) succeeds, 643/645 revert.

4.2.0 also refuses to submit when a `finalize_gone` swap-remove has reordered registry slots, since the observation bitmap is positional and would otherwise attribute results to the wrong gateways — landing silently rather than reverting.

**#127 — cranker error table.** The hand-maintained Anchor codes had drifted **+2** for everything at or above 6032 (two variants were inserted into the GAR enum). Real failures were being swallowed as "already done" — 6041 is `InvalidObservation`, 6049 is `InvalidGatewayAccount` — while genuine already-done races were reported as real errors. Now imported from `@ar.io/solana-contracts`, generated from the deployed IDL.

## Why it matters soon

248 gateways sit in `leaving` status with no delegated stake, and the first becomes `finalize_gone`-eligible on **2026-09-10**. Until now the registry has been nearly static, which is what kept this bug dormant — 14 joins in 90 days and no removals. Once that backlog drains the count moves most epochs, and this stops being a rare race.

## Verification

- Both observer PRs merged to `develop` with **CodeRabbit clean, zero findings**; `build-and-push` succeeded on `4d1c9046`
- The image was checked by **inspecting its contents**, not trusting the tag: `@ar.io/sdk` **4.2.0** present, epoch-snapshot resolver present, error table built from the generated constants
- `docker compose config` parses with the new default
- Running on a production gateway since **02:12 UTC** — healthy, 0 errors, and it restored the in-progress epoch state across the recreate rather than losing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kexn8mPZfVRHiWCW2k4kU3