### PR TITLE
fix: do not cache a body far smaller than the indexed data item size

### DIFF
--- a/src/data/read-through-data-cache.test.ts
+++ b/src/data/read-through-data-cache.test.ts
@@ -3980,6 +3980,32 @@ describe('ReadThroughDataCache short-read rejection', () => {
     assert.equal(counters.finalize, 1);
   });
 
+  it('stands down when itemSize is null (raw NULL column)', async () => {
+    const { cache, counters } = cacheFor('R', {
+      itemSize: null,
+      rootDataItemOffset: 1628,
+      rootDataOffset: 2759,
+    });
+
+    await drain(await cache.getData({ id: 'null-itemsize' }));
+
+    // Cannot compute a payload without itemSize, so it must fail open rather
+    // than compute a nonsense one from a coerced null.
+    assert.equal(counters.finalize, 1);
+  });
+
+  it('stands down when an offset is null (raw NULL column)', async () => {
+    const { cache, counters } = cacheFor('R', {
+      itemSize: 24106479,
+      rootDataItemOffset: null,
+      rootDataOffset: 2759,
+    });
+
+    await drain(await cache.getData({ id: 'null-offset' }));
+
+    assert.equal(counters.finalize, 1);
+  });
+
   it('does not reject when the item size is unknown', async () => {
     // No ANS-104 record (e.g. an L1 transaction): the guard must stay out of
     // the way rather than refuse to cache anything it cannot cross-check.

--- a/src/data/read-through-data-cache.test.ts
+++ b/src/data/read-through-data-cache.test.ts
@@ -3890,7 +3890,17 @@ describe('ReadThroughDataCache short-read rejection', () => {
   it('refuses to cache a 1-byte body when the item is indexed as 24 MB', async () => {
     // The real DwObkWEd… case: a RIFF header byte cached as the whole file.
     const { store, counters, finalized } = makeStore();
-    const cache = makeCache({ itemSize: 24106479 }, store);
+    // Real attribute values from the DwObkWEd… row: header is
+    // 2759 - 1628 = 1131, so the payload is 24,105,348 — exactly the size the
+    // file's RIFF header declares.
+    const cache = makeCache(
+      {
+        itemSize: 24106479,
+        rootDataItemOffset: 1628,
+        rootDataOffset: 2759,
+      },
+      store,
+    );
 
     await drain(await cache.getData({ id: 'short-id' }));
 
@@ -3907,9 +3917,7 @@ describe('ReadThroughDataCache short-read rejection', () => {
     );
   });
 
-  it('still caches a payload that is only shorter by an ANS-104 header', async () => {
-    // itemSize covers header + payload, so the guard must tolerate that gap.
-    const payload = 'x'.repeat(4096);
+  function cacheFor(payload: string, attributes: any) {
     const { store, counters } = makeStore();
     const cache = new ReadThroughDataCache({
       log,
@@ -3919,14 +3927,57 @@ describe('ReadThroughDataCache short-read rejection', () => {
       contiguousDataIndex: dataIndex,
       dataContentAttributeImporter: attributeImporter,
       dataAttributesStore: {
-        getDataAttributes: async () => ({ itemSize: payload.length + 1131 }),
+        getDataAttributes: async () => attributes,
         setDataAttributes: async () => undefined,
       } as any,
+    });
+    return { cache, counters };
+  }
+
+  it('caches a payload that exactly matches the indexed payload size', async () => {
+    const payload = 'x'.repeat(4096);
+    const { cache, counters } = cacheFor(payload, {
+      itemSize: payload.length + 1131,
+      rootDataItemOffset: 1628,
+      rootDataOffset: 1628 + 1131,
     });
 
     await drain(await cache.getData({ id: 'ok-id' }));
 
     assert.equal(counters.finalize, 1, 'a legitimate payload must still cache');
+  });
+
+  it('caches an item whose header is far larger than any fixed allowance', async () => {
+    // ANS-104 tags are variable-length and processBundleStream reads whatever
+    // tagsBytesLength an item declares — it does not apply DataItem.verify's
+    // 4 KiB tag limit — so a legitimately indexed item can carry a header of
+    // any size. A guard using a fixed slack would classify this complete
+    // payload as short and silently stop caching it.
+    const payload = 'x'.repeat(4096);
+    const hugeHeader = 512 * 1024;
+    const { cache, counters } = cacheFor(payload, {
+      itemSize: payload.length + hugeHeader,
+      rootDataItemOffset: 1000,
+      rootDataOffset: 1000 + hugeHeader,
+    });
+
+    await drain(await cache.getData({ id: 'big-header-id' }));
+
+    assert.equal(
+      counters.finalize,
+      1,
+      'a large header must not be mistaken for a truncated payload',
+    );
+  });
+
+  it('does not reject when the offsets needed for the header are missing', async () => {
+    // itemSize alone cannot separate header from payload, so the guard must
+    // stand down rather than guess.
+    const { cache, counters } = cacheFor('R', { itemSize: 24106479 });
+
+    await drain(await cache.getData({ id: 'no-offsets-id' }));
+
+    assert.equal(counters.finalize, 1);
   });
 
   it('does not reject when the item size is unknown', async () => {

--- a/src/data/read-through-data-cache.test.ts
+++ b/src/data/read-through-data-cache.test.ts
@@ -3790,3 +3790,186 @@ describe('ReadThroughDataCache', function () {
     });
   });
 });
+
+describe('ReadThroughDataCache short-read rejection', () => {
+  const log = createTestLogger({ silent: true } as any);
+
+  // Local stand-ins: the suite-wide mocks are scoped to the outer describe's
+  // beforeEach and are not visible here.
+  const dataIndex = {
+    getDataAttributes: async () => undefined,
+    getDataParent: async () => undefined,
+    saveDataContentAttributes: async () => undefined,
+    clearDataHash: async () => undefined,
+    setDataAttributes: async () => undefined,
+  } as any;
+  const attributeImporter = {
+    queueDataContentAttributes: () => undefined,
+  } as any;
+
+  // Records what actually reached durable storage, so a test can assert the
+  // difference between "finalized" and "cleaned up" rather than inspecting
+  // log output.
+  function makeStore() {
+    const finalized = new Map<string, string>();
+    const counters = { finalize: 0, cleanup: 0 };
+    const store = {
+      has: async () => false,
+      get: async () => undefined,
+      createWriteStream: async () => {
+        const chunks: Buffer[] = [];
+        const stream: any = new Writable({
+          write(chunk, _, callback) {
+            chunks.push(Buffer.from(chunk));
+            callback();
+          },
+        });
+        stream.__chunks = chunks;
+        return stream;
+      },
+      cleanup: async () => {
+        counters.cleanup++;
+      },
+      finalize: async (stream: any, hash: string) => {
+        counters.finalize++;
+        finalized.set(hash, Buffer.concat(stream.__chunks).toString());
+      },
+      delete: async () => undefined,
+    } as unknown as ContiguousDataStore;
+    return { store, finalized, counters };
+  }
+
+  // `payload` is what upstream sends AND what it declares as its size — the
+  // whole point of the bug being fixed is that a truncating peer reports a
+  // Content-Length consistent with its own truncated body.
+  function makeSource(payload: string): ContiguousDataSource {
+    return {
+      getData: async () => ({
+        stream: new Readable({
+          read() {
+            this.push(payload);
+            this.push(null);
+          },
+        }),
+        size: payload.length,
+        verified: false,
+        trusted: true,
+        cached: false,
+      }),
+    } as unknown as ContiguousDataSource;
+  }
+
+  function makeCache(attributes: any, store: ContiguousDataStore) {
+    return new ReadThroughDataCache({
+      log,
+      dataSource: makeSource('R'),
+      dataStore: store,
+      metadataStore: makeContiguousMetadataStore({ log, type: 'node' }),
+      contiguousDataIndex: dataIndex,
+      dataContentAttributeImporter: attributeImporter,
+      dataAttributesStore: {
+        getDataAttributes: async () =>
+          attributes instanceof Error ? Promise.reject(attributes) : attributes,
+        setDataAttributes: async () => undefined,
+      } as any,
+    });
+  }
+
+  async function drain(result: any) {
+    try {
+      for await (const _ of result.stream) {
+        // discard
+      }
+    } catch {
+      // discard
+    }
+    // let the stream 'end' handler finish its async cache decision
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  it('refuses to cache a 1-byte body when the item is indexed as 24 MB', async () => {
+    // The real DwObkWEd… case: a RIFF header byte cached as the whole file.
+    const { store, counters, finalized } = makeStore();
+    const cache = makeCache({ itemSize: 24106479 }, store);
+
+    await drain(await cache.getData({ id: 'short-id' }));
+
+    assert.equal(counters.finalize, 0, 'must not finalize a fragment');
+    assert.equal(
+      counters.cleanup >= 1,
+      true,
+      'staging file must be cleaned up',
+    );
+    assert.equal(
+      finalized.size,
+      0,
+      'nothing may be bound to the fragment hash',
+    );
+  });
+
+  it('still caches a payload that is only shorter by an ANS-104 header', async () => {
+    // itemSize covers header + payload, so the guard must tolerate that gap.
+    const payload = 'x'.repeat(4096);
+    const { store, counters } = makeStore();
+    const cache = new ReadThroughDataCache({
+      log,
+      dataSource: makeSource(payload),
+      dataStore: store,
+      metadataStore: makeContiguousMetadataStore({ log, type: 'node' }),
+      contiguousDataIndex: dataIndex,
+      dataContentAttributeImporter: attributeImporter,
+      dataAttributesStore: {
+        getDataAttributes: async () => ({ itemSize: payload.length + 1131 }),
+        setDataAttributes: async () => undefined,
+      } as any,
+    });
+
+    await drain(await cache.getData({ id: 'ok-id' }));
+
+    assert.equal(counters.finalize, 1, 'a legitimate payload must still cache');
+  });
+
+  it('does not reject when the item size is unknown', async () => {
+    // No ANS-104 record (e.g. an L1 transaction): the guard must stay out of
+    // the way rather than refuse to cache anything it cannot cross-check.
+    const { store, counters } = makeStore();
+    const cache = makeCache({}, store);
+
+    await drain(await cache.getData({ id: 'no-attrs-id' }));
+
+    assert.equal(counters.finalize, 1);
+  });
+
+  it("does not reject when the guard's attribute lookup throws", async () => {
+    // A transient index error at guard time must not become a silent cache
+    // bypass. Only the guard's own lookup fails here — the earlier lookup in
+    // getData succeeds, so this isolates the guard rather than the whole path.
+    const { store, counters } = makeStore();
+    let calls = 0;
+    const cache = new ReadThroughDataCache({
+      log,
+      dataSource: makeSource('R'),
+      dataStore: store,
+      metadataStore: makeContiguousMetadataStore({ log, type: 'node' }),
+      contiguousDataIndex: dataIndex,
+      dataContentAttributeImporter: attributeImporter,
+      dataAttributesStore: {
+        getDataAttributes: async () => {
+          calls++;
+          if (calls === 1) return undefined;
+          throw new Error('index unavailable');
+        },
+        setDataAttributes: async () => undefined,
+      } as any,
+    });
+
+    await drain(await cache.getData({ id: 'throws-id' }));
+
+    assert.equal(calls > 1, true, 'the guard must have attempted a lookup');
+    assert.equal(
+      counters.finalize,
+      1,
+      'a lookup failure must not block caching',
+    );
+  });
+});

--- a/src/data/read-through-data-cache.ts
+++ b/src/data/read-through-data-cache.ts
@@ -25,6 +25,7 @@ import { KvJsonStore } from '../store/kv-attributes-store.js';
 import { startChildSpan } from '../tracing.js';
 import {
   ContiguousData,
+  ContiguousDataAttributes,
   ContiguousDataAttributesStore,
   ContiguousDataCacheIndex,
   ContiguousDataIndex,
@@ -36,21 +37,6 @@ import {
 import { DataContentAttributeImporter } from '../workers/data-content-attribute-importer.js';
 
 const MAX_MRU_ARNS_NAMES_LENGTH = 10;
-
-/**
- * Slack allowed between an ANS-104 item's `itemSize` (header + payload) and
- * the payload actually retrieved, used by {@link
- * ReadThroughDataCache.isShortRead}.
- *
- * A real header cannot approach this. Taking the largest signature type in
- * `SIG_CONFIG` (type 6, multi-Aptos: 2052-byte signature + 1025-byte owner)
- * with the spec's maximum 4096 bytes of tags, plus target, anchor and the
- * length fields, the worst case is 7257 bytes -- so this bound carries a 2.26x
- * margin and cannot reject a legitimate payload for any signature type. Note
- * the worst case is NOT the RSA 512+512: an allowance derived from RSA alone
- * would be too tight.
- */
-const MAX_DATA_ITEM_HEADER_BYTES = 16384;
 
 /**
  * How a leader's foreground fetch ended, as seen by callers waiting on it.
@@ -388,8 +374,8 @@ export class ReadThroughDataCache implements ContiguousDataSource {
   }
 
   /**
-   * Decide whether a completed full-body retrieval is implausibly small for
-   * the data item it claims to be, and must therefore not be cached.
+   * Decide whether a completed full-body retrieval is smaller than the payload
+   * this data item is indexed as having, and must therefore not be cached.
    *
    * The existing `bytesReceived !== data.size` check cannot catch this.
    * `data.size` is taken from the upstream `Content-Length`, so a peer that is
@@ -401,18 +387,12 @@ export class ReadThroughDataCache implements ContiguousDataSource {
    * item sharing a first byte collapses onto a single blob -- every truncated
    * RIFF file lands on `sha256("R")`.
    *
-   * `itemSize` is the cross-check that closes this, because it does not come
-   * from retrieval: it is the ANS-104 item length recorded when the bundle
-   * header was parsed (`data_item_size`, falling back to the bundles index).
-   * A poisoned `contiguous_data.data_size` therefore cannot launder itself
-   * through this comparison.
-   *
-   * `itemSize` covers header + payload while `bytesReceived` is payload only,
-   * so the comparison is deliberately slack by one ANS-104 header, bounded by
-   * {@link MAX_DATA_ITEM_HEADER_BYTES} at 2.26x the worst case any signature
-   * type can produce. A legitimate payload can never trip this, while a
-   * fragment orders of magnitude too small always does. Undersize only: an
-   * oversize body is already rejected by the `data.size` comparison above.
+   * The expected payload size is reconstructed from three attributes that do
+   * not come from retrieval: `itemSize` (the ANS-104 item length recorded when
+   * the bundle header was parsed) minus the header length, which is the gap
+   * between where the item starts and where its data starts. A poisoned
+   * `contiguous_data.data_size` therefore cannot launder itself through this
+   * comparison.
    *
    * Deliberately NOT compared against the attributes' payload size (`size`):
    * that resolves as `txOrItemRow?.data_size ?? dataRow?.data_size`, and the
@@ -421,19 +401,28 @@ export class ReadThroughDataCache implements ContiguousDataSource {
    * against it would read 1 against a 1-byte body and wave the fragment
    * through, disarming this guard in exactly the case it exists for.
    *
-   * @returns the offending `itemSize` when the read is short, otherwise
-   *   `undefined`. Attribute lookup failures return `undefined` -- this guard
-   *   refuses to cache, so it must never turn a transient index error into a
-   *   silent cache bypass.
+   * The header length is measured rather than bounded by a constant. ANS-104
+   * tags are variable-length and `processBundleStream` reads whatever
+   * `tagsBytesLength` an item declares -- it does not apply `DataItem.verify`'s
+   * 4 KiB tag limit -- so a legitimately indexed item can carry a header of
+   * any size. Any fixed allowance would eventually classify such an item's
+   * complete payload as short and silently stop caching it.
+   *
+   * Undersize only: an oversize body is already rejected by the `data.size`
+   * comparison above.
+   *
+   * @returns the expected payload size when the read is short, otherwise
+   *   `undefined`. Missing attributes and lookup failures both return
+   *   `undefined` -- this guard refuses to cache, so it must never turn an
+   *   incomplete index or a transient error into a silent cache bypass.
    */
   private async isShortRead(
     id: string,
     bytesReceived: number,
-  ): Promise<{ itemSize: number } | undefined> {
-    let itemSize: number | undefined;
+  ): Promise<{ expectedPayloadSize: number } | undefined> {
+    let attributes: ContiguousDataAttributes | undefined;
     try {
-      itemSize = (await this.dataAttributesStore.getDataAttributes(id))
-        ?.itemSize;
+      attributes = await this.dataAttributesStore.getDataAttributes(id);
     } catch (error: any) {
       this.log.debug('Short-read check skipped; attribute lookup failed', {
         id,
@@ -442,12 +431,27 @@ export class ReadThroughDataCache implements ContiguousDataSource {
       return undefined;
     }
 
-    if (itemSize === undefined || itemSize <= MAX_DATA_ITEM_HEADER_BYTES) {
+    const itemSize = attributes?.itemSize;
+    const rootDataOffset = attributes?.rootDataOffset;
+    const rootDataItemOffset = attributes?.rootDataItemOffset;
+    if (
+      itemSize === undefined ||
+      rootDataOffset === undefined ||
+      rootDataItemOffset === undefined
+    ) {
       return undefined;
     }
 
-    return bytesReceived + MAX_DATA_ITEM_HEADER_BYTES < itemSize
-      ? { itemSize }
+    // Both offsets are absolute positions in the root transaction's payload,
+    // so their difference is this item's header length exactly.
+    const headerLength = rootDataOffset - rootDataItemOffset;
+    if (headerLength < 0 || headerLength >= itemSize) {
+      return undefined;
+    }
+
+    const expectedPayloadSize = itemSize - headerLength;
+    return bytesReceived < expectedPayloadSize
+      ? { expectedPayloadSize }
       : undefined;
   }
 
@@ -1481,21 +1485,22 @@ export class ReadThroughDataCache implements ContiguousDataSource {
                     });
                     await this.dataStore.cleanup(cacheStream);
                   } else if (shortRead !== undefined) {
-                    // The body agreed with its own Content-Length but is far
-                    // too small for this data item. See {@link isShortRead}:
-                    // caching it here is what makes a truncated body durable
-                    // and contagious.
+                    // The body agreed with its own Content-Length but is
+                    // smaller than this item's indexed payload. See {@link
+                    // isShortRead}: caching it here is what makes a truncated
+                    // body durable and contagious.
                     metrics.shortReadsRejectedTotal.inc();
                     span.addEvent('Skipping cache storage - short read', {
-                      'data.item_size': shortRead.itemSize,
+                      'data.expected_payload_size':
+                        shortRead.expectedPayloadSize,
                       'data.received_size': bytesReceived,
                     });
                     span.setAttribute('cache.operation.short_read', true);
                     this.log.warn(
-                      'Retrieved body far smaller than the indexed data item size - not caching',
+                      'Retrieved body smaller than the indexed data item payload - not caching',
                       {
                         id,
-                        itemSize: shortRead.itemSize,
+                        expectedPayloadSize: shortRead.expectedPayloadSize,
                         receivedSize: bytesReceived,
                         reportedSize: data.size,
                       },

--- a/src/data/read-through-data-cache.ts
+++ b/src/data/read-through-data-cache.ts
@@ -40,10 +40,15 @@ const MAX_MRU_ARNS_NAMES_LENGTH = 10;
 /**
  * Slack allowed between an ANS-104 item's `itemSize` (header + payload) and
  * the payload actually retrieved, used by {@link
- * ReadThroughDataCache.isShortRead}. A real header is far smaller -- signature
- * and owner are 512 bytes each for RSA and tags are capped at 4096 by the spec
- * -- so this is a deliberately generous bound that cannot reject a legitimate
- * payload.
+ * ReadThroughDataCache.isShortRead}.
+ *
+ * A real header cannot approach this. Taking the largest signature type in
+ * `SIG_CONFIG` (type 6, multi-Aptos: 2052-byte signature + 1025-byte owner)
+ * with the spec's maximum 4096 bytes of tags, plus target, anchor and the
+ * length fields, the worst case is 7257 bytes -- so this bound carries a 2.26x
+ * margin and cannot reject a legitimate payload for any signature type. Note
+ * the worst case is NOT the RSA 512+512: an allowance derived from RSA alone
+ * would be too tight.
  */
 const MAX_DATA_ITEM_HEADER_BYTES = 16384;
 
@@ -403,12 +408,18 @@ export class ReadThroughDataCache implements ContiguousDataSource {
    * through this comparison.
    *
    * `itemSize` covers header + payload while `bytesReceived` is payload only,
-   * so the comparison is deliberately slack by one ANS-104 header. The spec
-   * bounds that well below {@link MAX_DATA_ITEM_HEADER_BYTES} (signature and
-   * owner are 512 bytes each for RSA, tags at most 4096), so a legitimate
-   * payload can never trip this while a fragment orders of magnitude too small
-   * always does. Undersize only: an oversize body is already rejected by the
-   * `data.size` comparison above.
+   * so the comparison is deliberately slack by one ANS-104 header, bounded by
+   * {@link MAX_DATA_ITEM_HEADER_BYTES} at 2.26x the worst case any signature
+   * type can produce. A legitimate payload can never trip this, while a
+   * fragment orders of magnitude too small always does. Undersize only: an
+   * oversize body is already rejected by the `data.size` comparison above.
+   *
+   * Deliberately NOT compared against the attributes' payload size (`size`):
+   * that resolves as `txOrItemRow?.data_size ?? dataRow?.data_size`, and the
+   * fallback is `contiguous_data.data_size` -- the very column a poisoned
+   * entry corrupts. Whenever the bundles row is missing, an exact comparison
+   * against it would read 1 against a 1-byte body and wave the fragment
+   * through, disarming this guard in exactly the case it exists for.
    *
    * @returns the offending `itemSize` when the read is short, otherwise
    *   `undefined`. Attribute lookup failures return `undefined` -- this guard

--- a/src/data/read-through-data-cache.ts
+++ b/src/data/read-through-data-cache.ts
@@ -1469,7 +1469,14 @@ export class ReadThroughDataCache implements ContiguousDataSource {
               if (cacheStream !== undefined) {
                 const hash = hasher.digest('base64url');
 
-                const shortRead = await this.isShortRead(id, bytesReceived);
+                // Gated on the cheap comparison so the attribute read only
+                // happens for bodies that agree with their own Content-Length.
+                // Running it unconditionally would add a SQLite round trip to
+                // every successful cache write.
+                const shortRead =
+                  bytesReceived === data.size
+                    ? await this.isShortRead(id, bytesReceived)
+                    : undefined;
 
                 try {
                   if (bytesReceived !== data.size) {

--- a/src/data/read-through-data-cache.ts
+++ b/src/data/read-through-data-cache.ts
@@ -431,25 +431,37 @@ export class ReadThroughDataCache implements ContiguousDataSource {
       return undefined;
     }
 
+    // Validated as finite numbers rather than merely !== undefined. The types
+    // say `number | undefined`, but the values reach here straight off a raw
+    // SQLite row (`selectDataItemAttributes` is returned unmapped), so a NULL
+    // column arrives as `null` -- and `itemSize` in particular is produced by
+    // `data_item_size ?? dataItemAttributes?.size`, which yields `null` when
+    // both sides are NULL rather than falling through to undefined.
+    //
+    // A null would currently land in the stand-down path anyway, but only by
+    // way of `headerLength >= null` coercing to `>= 0`. That is not a property
+    // worth depending on: it is invisible at the call site and inverts if the
+    // comparison is ever reordered.
     const itemSize = attributes?.itemSize;
     const rootDataOffset = attributes?.rootDataOffset;
     const rootDataItemOffset = attributes?.rootDataItemOffset;
     if (
-      itemSize === undefined ||
-      rootDataOffset === undefined ||
-      rootDataItemOffset === undefined
+      !Number.isFinite(itemSize) ||
+      !Number.isFinite(rootDataOffset) ||
+      !Number.isFinite(rootDataItemOffset)
     ) {
       return undefined;
     }
 
     // Both offsets are absolute positions in the root transaction's payload,
     // so their difference is this item's header length exactly.
-    const headerLength = rootDataOffset - rootDataItemOffset;
-    if (headerLength < 0 || headerLength >= itemSize) {
+    const headerLength =
+      (rootDataOffset as number) - (rootDataItemOffset as number);
+    if (headerLength < 0 || headerLength >= (itemSize as number)) {
       return undefined;
     }
 
-    const expectedPayloadSize = itemSize - headerLength;
+    const expectedPayloadSize = (itemSize as number) - headerLength;
     return bytesReceived < expectedPayloadSize
       ? { expectedPayloadSize }
       : undefined;

--- a/src/data/read-through-data-cache.ts
+++ b/src/data/read-through-data-cache.ts
@@ -38,6 +38,16 @@ import { DataContentAttributeImporter } from '../workers/data-content-attribute-
 const MAX_MRU_ARNS_NAMES_LENGTH = 10;
 
 /**
+ * Slack allowed between an ANS-104 item's `itemSize` (header + payload) and
+ * the payload actually retrieved, used by {@link
+ * ReadThroughDataCache.isShortRead}. A real header is far smaller -- signature
+ * and owner are 512 bytes each for RSA and tags are capped at 4096 by the spec
+ * -- so this is a deliberately generous bound that cannot reject a legitimate
+ * payload.
+ */
+const MAX_DATA_ITEM_HEADER_BYTES = 16384;
+
+/**
  * How a leader's foreground fetch ended, as seen by callers waiting on it.
  *
  * The distinction drives leader re-election. `false` alone conflated three
@@ -370,6 +380,64 @@ export class ReadThroughDataCache implements ContiguousDataSource {
     }
 
     return undefined;
+  }
+
+  /**
+   * Decide whether a completed full-body retrieval is implausibly small for
+   * the data item it claims to be, and must therefore not be cached.
+   *
+   * The existing `bytesReceived !== data.size` check cannot catch this.
+   * `data.size` is taken from the upstream `Content-Length`, so a peer that is
+   * itself serving a truncated body reports a size that matches the bytes it
+   * actually sends: the two agree, the truncation is finalized as if complete,
+   * and the ID is bound to the hash of the fragment. The next gateway then
+   * fetches from us and inherits it the same way. A one-byte body is how this
+   * shows up in practice, and because the store is content-addressed every
+   * item sharing a first byte collapses onto a single blob -- every truncated
+   * RIFF file lands on `sha256("R")`.
+   *
+   * `itemSize` is the cross-check that closes this, because it does not come
+   * from retrieval: it is the ANS-104 item length recorded when the bundle
+   * header was parsed (`data_item_size`, falling back to the bundles index).
+   * A poisoned `contiguous_data.data_size` therefore cannot launder itself
+   * through this comparison.
+   *
+   * `itemSize` covers header + payload while `bytesReceived` is payload only,
+   * so the comparison is deliberately slack by one ANS-104 header. The spec
+   * bounds that well below {@link MAX_DATA_ITEM_HEADER_BYTES} (signature and
+   * owner are 512 bytes each for RSA, tags at most 4096), so a legitimate
+   * payload can never trip this while a fragment orders of magnitude too small
+   * always does. Undersize only: an oversize body is already rejected by the
+   * `data.size` comparison above.
+   *
+   * @returns the offending `itemSize` when the read is short, otherwise
+   *   `undefined`. Attribute lookup failures return `undefined` -- this guard
+   *   refuses to cache, so it must never turn a transient index error into a
+   *   silent cache bypass.
+   */
+  private async isShortRead(
+    id: string,
+    bytesReceived: number,
+  ): Promise<{ itemSize: number } | undefined> {
+    let itemSize: number | undefined;
+    try {
+      itemSize = (await this.dataAttributesStore.getDataAttributes(id))
+        ?.itemSize;
+    } catch (error: any) {
+      this.log.debug('Short-read check skipped; attribute lookup failed', {
+        id,
+        message: error?.message,
+      });
+      return undefined;
+    }
+
+    if (itemSize === undefined || itemSize <= MAX_DATA_ITEM_HEADER_BYTES) {
+      return undefined;
+    }
+
+    return bytesReceived + MAX_DATA_ITEM_HEADER_BYTES < itemSize
+      ? { itemSize }
+      : undefined;
   }
 
   // Record a freshly-cached blob in the cleanup index (best-effort). Tier 1 =
@@ -1386,6 +1454,8 @@ export class ReadThroughDataCache implements ContiguousDataSource {
               if (cacheStream !== undefined) {
                 const hash = hasher.digest('base64url');
 
+                const shortRead = await this.isShortRead(id, bytesReceived);
+
                 try {
                   if (bytesReceived !== data.size) {
                     span.addEvent('Skipping cache storage - size mismatch', {
@@ -1398,6 +1468,27 @@ export class ReadThroughDataCache implements ContiguousDataSource {
                       expectedSize: data.size,
                       receivedSize: bytesReceived,
                     });
+                    await this.dataStore.cleanup(cacheStream);
+                  } else if (shortRead !== undefined) {
+                    // The body agreed with its own Content-Length but is far
+                    // too small for this data item. See {@link isShortRead}:
+                    // caching it here is what makes a truncated body durable
+                    // and contagious.
+                    metrics.shortReadsRejectedTotal.inc();
+                    span.addEvent('Skipping cache storage - short read', {
+                      'data.item_size': shortRead.itemSize,
+                      'data.received_size': bytesReceived,
+                    });
+                    span.setAttribute('cache.operation.short_read', true);
+                    this.log.warn(
+                      'Retrieved body far smaller than the indexed data item size - not caching',
+                      {
+                        id,
+                        itemSize: shortRead.itemSize,
+                        receivedSize: bytesReceived,
+                        reportedSize: data.size,
+                      },
+                    );
                     await this.dataStore.cleanup(cacheStream);
                   } else if (data.trusted === true) {
                     // Trusted source: finalize, save with trusted: true

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1709,6 +1709,11 @@ export const foregroundCacheCoalescedOutcomeTotal = new promClient.Counter({
   labelNames: ['outcome'] as const,
 });
 
+export const shortReadsRejectedTotal = new promClient.Counter({
+  name: 'short_reads_rejected_total',
+  help: 'Completed full-body retrievals refused by the cache because the payload was implausibly small for the indexed ANS-104 item size. The upstream Content-Length agreed with the bytes actually sent, so the existing size check alone would have stored the fragment and bound the ID to its hash — the mechanism by which a truncated body becomes durable and spreads to the next gateway',
+});
+
 export const arIOPeersSkippedLeavingTotal = new promClient.Counter({
   name: 'ar_io_peers_skipped_leaving_total',
   help: 'Gateways excluded from the AR.IO peer pool because the registry reports them as leaving the network',


### PR DESCRIPTION
A truncated upstream body is currently cached as if it were the complete item, and because the store is content-addressed the damage compounds and spreads between gateways.

### Why the existing guard does not catch this

`ReadThroughDataCache` already refuses to cache when `bytesReceived !== data.size`. But `data.size` comes from the peer's `Content-Length`, so a gateway that is itself serving a fragment reports a size that **matches the bytes it actually sends**. The two agree, the fragment is finalized as complete, and the ID is bound to the fragment's hash. The next gateway fetches from that one and inherits it the same way.

### The fix

The expected payload is reconstructed from attributes that do **not** come from retrieval: `itemSize` (the ANS-104 item length recorded when the bundle header was parsed) minus the header length, measured as `rootDataOffset - rootDataItemOffset`. A poisoned `contiguous_data.data_size` cannot launder itself through it.

The header is **measured, not bounded by a constant**. ANS-104 tags are variable-length and `processBundleStream` reads whatever `tagsBytesLength` an item declares — it does not apply `DataItem.verify`'s 4 KiB tag limit — so a legitimately indexed item can carry a header of any size, and any fixed allowance would eventually classify its complete payload as short.

Undersize only; oversize is already rejected by the `data.size` comparison. Fails open when attributes are missing or the lookup throws, and the lookup is gated on the cheap size comparison so it costs nothing on the common path.

Adds `short_reads_rejected_total`.

### Scope — this is a partial fix, deliberately

The guard needs `itemSize`, `rootDataOffset` and `rootDataItemOffset` together. Measured on a production gateway (gw1):

| cached data items | 4,195,306 | |
|---|---|---|
| all three present | 1,729,576 | **41.2% — guard can act** |
| missing ≥ 1 | 2,465,730 | 58.8% — inert, fails open |

Of poisoned data items it would catch **~56%**. Poisoning continues at roughly half the current rate; this closes the largest share of it, not all of it.

Fail-open is required rather than convenient: `itemSize` resolves only from data-item sources, and an L1 transaction has none. On gw1, **0 of 3,942,276 L1/self-root rows carry `itemSize`**, so the guard is inert there by construction — a fail-closed version would refuse to cache every L1 transaction.

### Known trade-off: cache-bypass amplification

Items behind a **permanent** upstream gap become permanent cache misses — every request re-fetches and is refused again.

```
before:  wrong answer, cheap, served from cache
after:   wrong answer, expensive, hits the network every time
```

There is no negative caching or backoff. The candidate population is small (382 on the author's node, ~3,314 on gw1) and expected to be cold, but if any are hot or crawled this adds sustained load to `ar-io-network`, measured recently at 9.6% success. Flagging it explicitly rather than discovering it in production; a TTL'd negative marker is the natural follow-up.

### Measuring the affected population — read this before writing cleanup SQL

`data_item_size` is **header + payload**, not payload. A `data_item_size > 1` predicate badly overcounts:

| | |
|---|---|
| bound to a 1-byte blob | 9,232 |
| `data_item_size > 1` says | 7,897 |
| **legitimately 1-byte payloads** | **7,515** |
| header length unknown | 1,335 |
| **actually poisoned** | **382** |
| largest true payload | 1,245,287,452 |

Most are real ANS-104 items with a ~1 KB header and a genuine single byte of payload. A naive cleanup would destroy 7,515 correct entries. Use `data_item_size - COALESCE(data_offset - data_item_offset, root_data_offset - root_data_item_offset) > 1`.

**There is also no safe SQL-only remediation.** `DELETE` removes the very attributes the guard needs, so the re-fetch rebuilds a bare row and re-poisons. `clearDataHash` is no better: `selectDataAttributes` reads those columns only through `JOIN contiguous_data ON cdi.contiguous_data_hash = cd.hash`, so nulling the hash makes them unreadable. The attributes are reachable only while the row stays bound to the blob you are trying to evict. Worth considering whether this PR should relax that join.

### Testing

- `read-through-data-cache.test.ts`: **74 pass, 0 fail**
- 5 new tests incl. a 512 KiB-header regression that fails against a constant-based bound
- Failing-first verified in both directions
- `lint:check`, `build`: clean
- CI green on ubuntu and macos, including `yarn typecheck`

### How this was found

A data item that streams only 3 seconds of a 2:17 WAV. That truncation is a real Arweave chunk gap — two 256 KiB chunks absent from all 324 reachable nodes, confirmed against `arweave.net` with a known-good control — and is not fixable here. What is ours: other gateways hitting the identical gap still serve 521 KB. We served one byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015R5EBQvBycT5dbNq2YRAgJ
