### PR TITLE
fix: incorrect content type for manifest-pathed data items

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -301,6 +301,24 @@ target rather than evicting a fixed number of coldest rows — and it **must**
 honour an age floor). Contrast the
 [filesystem-walk reclaimer](#filesystem-walk-reclaimer).
 
+<a id="original-source-content-type"></a> **Original Source Content Type** - The
+`contiguous_data.original_source_content_type` column: the content type a
+response is served with when the item is not in the local index.
+`getDataAttributes` prefers the tags-derived content type from
+`stable_transactions` / `new_transactions` / `bundles.*_data_items` and falls
+back to this column, so for any data item whose parent [bundle](#bundle) this
+gateway has never unbundled, this column _is_ the content type. Two properties
+make it easy to get wrong. It is keyed by the **data hash**, not the data item
+ID, so it is shared by every byte-identical upload — re-uploading a file cannot
+give it a different content type here. And it only ever transitions from the
+`application/octet-stream` placeholder (or NULL) to a real type, never between
+two real types, so two byte-identical items with conflicting `Content-Type` tags
+cannot flap the row. The placeholder is what a
+[bundle](#bundle)-range read reports — an ANS-104 bundle's own content type —
+so a data item served without its tags ever being read would otherwise be typed
+as the envelope around it. Unbundling the parent bundle
+(`POST /ar-io/admin/queue-bundle`) takes precedence over this column entirely.
+
 ## Data Verification
 
 **Data Verification** - The process of cryptographically verifying data

--- a/src/data/composite-data-attributes-source.test.ts
+++ b/src/data/composite-data-attributes-source.test.ts
@@ -336,4 +336,59 @@ describe('CompositeDataAttributesSource', () => {
       assert.strictEqual(result?.isManifest, true);
     });
   });
+
+  // The healing counterpart to insertDataHash's one-way transition: this cache
+  // has no TTL, so a placeholder preserved here outlives the DB row it came
+  // from and keeps serving the wrong content type after the row has healed.
+  describe('octet-stream placeholder handling', () => {
+    it('lets a specific content type displace the placeholder', async () => {
+      const source = {
+        getDataAttributes: async () =>
+          ({ contentType: 'application/octet-stream' }) as any,
+      };
+      const composite = new CompositeDataAttributesSource({ log, source });
+
+      // Seed from the (poisoned) DB record, as a request would.
+      await composite.getDataAttributes('id-1');
+      // The cache-miss path then writes the real type.
+      await composite.setDataAttributes('id-1', { contentType: 'text/html' });
+
+      assert.equal(
+        (await composite.getDataAttributes('id-1'))?.contentType,
+        'text/html',
+      );
+    });
+
+    it('does not let the placeholder displace a specific type', async () => {
+      const source = {
+        getDataAttributes: async () => ({ contentType: 'text/html' }) as any,
+      };
+      const composite = new CompositeDataAttributesSource({ log, source });
+
+      await composite.getDataAttributes('id-2');
+      await composite.setDataAttributes('id-2', {
+        contentType: 'application/octet-stream',
+      });
+
+      assert.equal(
+        (await composite.getDataAttributes('id-2'))?.contentType,
+        'text/html',
+      );
+    });
+
+    it('does not let one specific type displace another', async () => {
+      const source = {
+        getDataAttributes: async () => ({ contentType: 'text/html' }) as any,
+      };
+      const composite = new CompositeDataAttributesSource({ log, source });
+
+      await composite.getDataAttributes('id-3');
+      await composite.setDataAttributes('id-3', { contentType: 'image/png' });
+
+      assert.equal(
+        (await composite.getDataAttributes('id-3'))?.contentType,
+        'text/html',
+      );
+    });
+  });
 });

--- a/src/data/composite-data-attributes-source.ts
+++ b/src/data/composite-data-attributes-source.ts
@@ -12,6 +12,7 @@ import {
   ContiguousDataAttributesStore,
   DataAttributesSource,
 } from '../types.js';
+import { isOctetStreamPlaceholder } from '../lib/content-type.js';
 
 const DEFAULT_MAX_CACHE_SIZE = 10000;
 
@@ -105,6 +106,17 @@ export class CompositeDataAttributesSource
    * present, incoming values are applied on top, but DB-authoritative
    * fields (contentType, isManifest) are preserved via reverse splat
    * so partial producers cannot overwrite them.
+   *
+   * The one content type that does **not** hold its ground is the
+   * octet-stream placeholder. It is what an entry carries when nobody had
+   * read the item's tags yet, so preserving it over an incoming specific
+   * type pins the wrong answer in memory: the write that heals
+   * `contiguous_data.original_source_content_type` on the cache-miss path
+   * would correct the row while this cache — which has no TTL — kept serving
+   * the placeholder until eviction or restart. Yielding to a specific type
+   * mirrors the one-way transition `insertDataHash` allows, so memory and
+   * the persisted row heal together. A specific type is still never replaced
+   * by another specific type, or by the placeholder.
    */
   async setDataAttributes(
     id: string,
@@ -115,7 +127,14 @@ export class CompositeDataAttributesSource
     if (existingAttributes != null) {
       // Preserve DB-authoritative fields from the existing entry
       const authoritative: Partial<ContiguousDataAttributes> = {};
-      if (existingAttributes.contentType != null) {
+      if (
+        existingAttributes.contentType != null &&
+        !(
+          isOctetStreamPlaceholder(existingAttributes.contentType) &&
+          attributes.contentType != null &&
+          !isOctetStreamPlaceholder(attributes.contentType)
+        )
+      ) {
         authoritative.contentType = existingAttributes.contentType;
       }
       if (existingAttributes.isManifest != null) {

--- a/src/data/root-parent-data-source.test.ts
+++ b/src/data/root-parent-data-source.test.ts
@@ -2793,4 +2793,174 @@ describe('RootParentDataSource', () => {
       assert.strictEqual((await readRebased('incomplete')) - before, 1);
     });
   });
+
+  // A data item is served as a byte range of the bundle that contains it, so
+  // the root fetch reports the *bundle's* content type — `application/octet-
+  // stream` for every ANS-104 bundle. Reporting that as the item's type makes
+  // an HTML page download instead of render, and it does not stop at the
+  // response: the served type is written to `contiguous_data`, keyed by the
+  // data hash, where nothing corrects it and every byte-identical re-upload
+  // inherits it. None of these paths may pass the envelope's type through.
+  describe('bundle envelope content type', () => {
+    const ENVELOPE = 'application/octet-stream';
+
+    const stubRootFetch = (size = 150) => {
+      (dataSource.getData as any).mock.mockImplementation(async () => ({
+        stream: Readable.from([Buffer.from('x'.repeat(size))]),
+        size,
+        verified: false,
+        cached: false,
+        trusted: true,
+        sourceContentType: ENVELOPE,
+      }));
+    };
+
+    beforeEach(() => {
+      (dataAttributesStore.setDataAttributes as any).mock.mockImplementation(
+        async () => {},
+      );
+      stubRootFetch();
+    });
+
+    it('does not inherit it on the direct offset hint path', async () => {
+      const dataItemId = 'envelope-direct-hint-item';
+      (dataAttributesStore.getDataAttributes as any).mock.mockImplementation(
+        async () => ({}),
+      );
+      // Header parsed, but the item carries no Content-Type tag.
+      (ans104OffsetSource.parseDataItemHeader as any).mock.mockImplementation(
+        async () => ({ id: dataItemId, headerSize: 50, payloadSize: 150 }),
+      );
+
+      const result = await rootParentDataSource.getData({
+        id: dataItemId,
+        requestAttributes: {
+          rootTransactionIdHint: 'envelope-root',
+          rootByteHint: { offset: 5000, size: 200 },
+          hops: 0,
+          clientIps: [],
+        },
+      });
+
+      assert.strictEqual(result.sourceContentType, undefined);
+    });
+
+    it('does not inherit it on the bundle-parse hint path', async () => {
+      const dataItemId = 'envelope-parse-hint-item';
+      (dataAttributesStore.getDataAttributes as any).mock.mockImplementation(
+        async () => ({}),
+      );
+      (ans104OffsetSource.getDataItemOffset as any).mock.mockImplementation(
+        async () => ({
+          itemOffset: 900,
+          dataOffset: 1000,
+          itemSize: 600,
+          dataSize: 150,
+        }),
+      );
+
+      const result = await rootParentDataSource.getData({
+        id: dataItemId,
+        requestAttributes: {
+          rootTransactionIdHint: 'envelope-root',
+          hops: 0,
+          clientIps: [],
+        },
+      });
+
+      assert.strictEqual(result.sourceContentType, undefined);
+    });
+
+    it('does not inherit it on the attributes traversal path', async () => {
+      const dataItemId = 'envelope-attributes-item';
+      const rootTxId = 'envelope-root-bundle';
+      (dataAttributesStore.getDataAttributes as any).mock.mockImplementation(
+        async (id: string) =>
+          id === dataItemId
+            ? {
+                size: 150,
+                rootTransactionId: rootTxId,
+                rootDataItemOffset: 1234,
+                rootDataOffset: 1334,
+              }
+            : null,
+      );
+
+      const result = await rootParentDataSource.getData({ id: dataItemId });
+
+      assert.strictEqual(result.sourceContentType, undefined);
+    });
+
+    it('does not inherit it on the legacy traversal path', async () => {
+      const dataItemId = 'envelope-legacy-item';
+      (dataAttributesStore.getDataAttributes as any).mock.mockImplementation(
+        async () => null,
+      );
+      (dataItemRootTxIndex.getRootTx as any).mock.mockImplementation(
+        async () => ({ rootTxId: 'envelope-legacy-root' }),
+      );
+      (ans104OffsetSource.getDataItemOffset as any).mock.mockImplementation(
+        async () => ({
+          itemOffset: 900,
+          dataOffset: 1000,
+          itemSize: 600,
+          dataSize: 150,
+        }),
+      );
+
+      const result = await rootParentDataSource.getData({ id: dataItemId });
+
+      assert.strictEqual(result.sourceContentType, undefined);
+    });
+
+    it('keeps the fetched content type when the item is its own root', async () => {
+      // Not an envelope here: the fetch is of the item itself, so the content
+      // type it reports really does describe the bytes being returned.
+      const rootId = 'self-rooted-item';
+      (dataAttributesStore.getDataAttributes as any).mock.mockImplementation(
+        async (id: string) =>
+          id === rootId
+            ? {
+                size: 150,
+                rootTransactionId: rootId,
+                rootDataItemOffset: 0,
+                rootDataOffset: 0,
+              }
+            : null,
+      );
+      (dataSource.getData as any).mock.mockImplementation(async () => ({
+        stream: Readable.from([Buffer.from('page')]),
+        size: 150,
+        verified: false,
+        cached: false,
+        trusted: true,
+        sourceContentType: 'text/html',
+      }));
+
+      const result = await rootParentDataSource.getData({ id: rootId });
+
+      assert.strictEqual(result.sourceContentType, 'text/html');
+    });
+
+    it('still reports a known item content type over the envelope', async () => {
+      const dataItemId = 'envelope-known-item';
+      const rootTxId = 'envelope-known-root';
+      (dataAttributesStore.getDataAttributes as any).mock.mockImplementation(
+        async (id: string) =>
+          id === dataItemId
+            ? {
+                size: 150,
+                contentType: 'text/html',
+                rootTransactionId: rootTxId,
+                rootDataItemOffset: 1234,
+                rootDataOffset: 1334,
+              }
+            : null,
+      );
+
+      const result = await rootParentDataSource.getData({ id: dataItemId });
+
+      assert.strictEqual(result.sourceContentType, 'text/html');
+    });
+  });
 });

--- a/src/data/root-parent-data-source.ts
+++ b/src/data/root-parent-data-source.ts
@@ -203,6 +203,43 @@ export class RootParentDataSource implements ContiguousDataSource {
   }
 
   /**
+   * Picks the content type to report for a data item that is being served as a
+   * byte range of its root transaction.
+   *
+   * The root fetch's `sourceContentType` describes the *bundle envelope*, not
+   * the item inside it — an ANS-104 bundle is `application/octet-stream`. Using
+   * it as the item's content type makes a `text/html` item download instead of
+   * render, and the damage outlives the request: `ReadThroughDataCache` writes
+   * the served content type to `contiguous_data.original_source_content_type`,
+   * which is keyed by the data *hash*, is never rewritten once set, and is what
+   * `getDataAttributes` falls back to for any item this gateway has not indexed.
+   * One envelope-typed response therefore poisons the item permanently, is
+   * inherited by every byte-identical re-upload, and spreads to peers that copy
+   * the `Content-Type` header off our response.
+   *
+   * So when the item's own content type is unknown, report nothing and let the
+   * route handler apply its default rather than asserting the envelope's type.
+   * The one case where the fetched type does describe the item is when the item
+   * *is* the root transaction, where the fetch is of the item itself.
+   */
+  private resolveItemContentType({
+    id,
+    rootTxId,
+    itemContentType,
+    rootContentType,
+  }: {
+    id: string;
+    rootTxId: string;
+    itemContentType?: string;
+    rootContentType?: string;
+  }): string | undefined {
+    if (itemContentType !== undefined) {
+      return itemContentType;
+    }
+    return rootTxId === id ? rootContentType : undefined;
+  }
+
+  /**
    * Validates a stored root transaction ID and, when it turns out to be an
    * intermediate bundle rather than an L1 transaction, rebases the offsets onto
    * the real root.
@@ -684,10 +721,12 @@ export class RootParentDataSource implements ContiguousDataSource {
 
               return {
                 ...data,
-                sourceContentType:
-                  hintContentType ??
-                  originalContentType ??
-                  data.sourceContentType,
+                sourceContentType: this.resolveItemContentType({
+                  id,
+                  rootTxId: hintRootTxId,
+                  itemContentType: hintContentType ?? originalContentType,
+                  rootContentType: data.sourceContentType,
+                }),
               };
             }
           }
@@ -783,7 +822,12 @@ export class RootParentDataSource implements ContiguousDataSource {
 
           return {
             ...data,
-            sourceContentType: hintContentType ?? data.sourceContentType,
+            sourceContentType: this.resolveItemContentType({
+              id,
+              rootTxId: resolvedRootTxId,
+              itemContentType: hintContentType,
+              rootContentType: data.sourceContentType,
+            }),
           };
         }
 
@@ -896,7 +940,12 @@ export class RootParentDataSource implements ContiguousDataSource {
 
           return {
             ...data,
-            sourceContentType: originalContentType ?? data.sourceContentType,
+            sourceContentType: this.resolveItemContentType({
+              id,
+              rootTxId,
+              itemContentType: originalContentType,
+              rootContentType: data.sourceContentType,
+            }),
           };
         } finally {
           fetchSpan.end();
@@ -1253,7 +1302,12 @@ export class RootParentDataSource implements ContiguousDataSource {
         // Preserve the original data item's content type if available
         return {
           ...data,
-          sourceContentType: originalContentType ?? data.sourceContentType,
+          sourceContentType: this.resolveItemContentType({
+            id,
+            rootTxId,
+            itemContentType: originalContentType,
+            rootContentType: data.sourceContentType,
+          }),
         };
       } finally {
         fetchSpan.end();

--- a/src/database/sql/data/content-attributes.sql
+++ b/src/database/sql/data/content-attributes.sql
@@ -25,16 +25,32 @@ INSERT INTO contiguous_data (
   :original_source_content_type,
   :indexed_at,
   :cached_at
+--
+-- The placeholder is matched as a whole media type, not as a prefix: bare, or
+-- followed by parameters after a `;` or whitespace. A prefix match would also
+-- catch distinct specific types that merely start with the same characters —
+-- `application/octet-stream+json` is a structured-suffix type of its own, and
+-- treating it as the placeholder would let a later write replace it.
 ) ON CONFLICT(hash) DO UPDATE SET
   original_source_content_type = excluded.original_source_content_type
 WHERE
   excluded.original_source_content_type IS NOT NULL
-  AND lower(trim(excluded.original_source_content_type))
-    NOT LIKE 'application/octet-stream%'
+  AND NOT (
+    lower(trim(excluded.original_source_content_type))
+      = 'application/octet-stream'
+    OR lower(trim(excluded.original_source_content_type))
+      LIKE 'application/octet-stream;%'
+    OR lower(trim(excluded.original_source_content_type))
+      LIKE 'application/octet-stream %'
+  )
   AND (
     contiguous_data.original_source_content_type IS NULL
     OR lower(trim(contiguous_data.original_source_content_type))
-      LIKE 'application/octet-stream%'
+      = 'application/octet-stream'
+    OR lower(trim(contiguous_data.original_source_content_type))
+      LIKE 'application/octet-stream;%'
+    OR lower(trim(contiguous_data.original_source_content_type))
+      LIKE 'application/octet-stream %'
   )
 
 -- insertDataId

--- a/src/database/sql/data/content-attributes.sql
+++ b/src/database/sql/data/content-attributes.sql
@@ -1,4 +1,18 @@
 -- insertDataHash
+-- `original_source_content_type` is keyed by the data hash, so it is shared by
+-- every byte-identical upload and, for items this gateway has not indexed, it
+-- is the only content type `selectDataAttributes` can return. Under a plain
+-- DO NOTHING the first write was permanent: an item served once with the
+-- placeholder `application/octet-stream` (the ANS-104 envelope's own type,
+-- which a bundle-range read reports when the item's tags were never read) kept
+-- downloading instead of rendering forever, and re-uploading the file could not
+-- clear it because the new item hashes to the same row.
+--
+-- So allow exactly one transition — placeholder to real value — and never the
+-- reverse. Genuinely binary data keeps its octet-stream type because the only
+-- content type on offer for it is also octet-stream; nothing here can overwrite
+-- a specific type with another specific type, so two byte-identical items with
+-- conflicting `Content-Type` tags cannot flap the row between them.
 INSERT INTO contiguous_data (
   hash,
   data_size,
@@ -11,7 +25,17 @@ INSERT INTO contiguous_data (
   :original_source_content_type,
   :indexed_at,
   :cached_at
-) ON CONFLICT DO NOTHING
+) ON CONFLICT(hash) DO UPDATE SET
+  original_source_content_type = excluded.original_source_content_type
+WHERE
+  excluded.original_source_content_type IS NOT NULL
+  AND lower(trim(excluded.original_source_content_type))
+    NOT LIKE 'application/octet-stream%'
+  AND (
+    contiguous_data.original_source_content_type IS NULL
+    OR lower(trim(contiguous_data.original_source_content_type))
+      LIKE 'application/octet-stream%'
+  )
 
 -- insertDataId
 WITH ParentStatus AS (

--- a/src/database/standalone-sqlite.test.ts
+++ b/src/database/standalone-sqlite.test.ts
@@ -2289,6 +2289,17 @@ describe('StandaloneSqliteDatabase', () => {
       assert.equal(await contentTypeOf(id), 'text/html');
     });
 
+    it('treats a structured-suffix type as real, not as the placeholder', async () => {
+      // `application/octet-stream+json` is a specific type of its own, not the
+      // placeholder — a prefix match would have let text/html replace it.
+      const id = idFor('heal-structured-suffix');
+      await save(id, 'heal-structured-suffix', 'application/octet-stream+json');
+
+      await save(id, 'heal-structured-suffix', 'text/html');
+
+      assert.equal(await contentTypeOf(id), 'application/octet-stream+json');
+    });
+
     it('never overwrites one real content type with another', async () => {
       const id = idFor('heal-no-flap');
       await save(id, 'heal-no-flap', 'text/html');

--- a/src/database/standalone-sqlite.test.ts
+++ b/src/database/standalone-sqlite.test.ts
@@ -2238,6 +2238,99 @@ describe('StandaloneSqliteDatabase', () => {
     });
   });
 
+  // `contiguous_data.original_source_content_type` is keyed by the data hash
+  // and, for an item this gateway has not indexed, it is the only content type
+  // getDataAttributes can return. It used to be write-once, so an item served
+  // even a single time with the `application/octet-stream` placeholder — the
+  // ANS-104 envelope's own type, which a bundle-range read reports when the
+  // item's tags were never read — downloaded instead of rendering forever.
+  describe('content type healing', () => {
+    // Both dedupe caches in front of these writes — the main thread's
+    // saveDataContentAttributes LRU and the worker's insertDataHashCache —
+    // outlive the per-test database reset, so every case needs an ID and a
+    // hash no other case has written, or its writes are silently suppressed.
+    //
+    // 43-char base64url; the final character carries only 2 significant bits,
+    // so it must be canonical to survive a decode/encode round trip.
+    const idFor = (label: string) => label.padEnd(42, 'x') + '0';
+
+    const save = (id: string, hash: string, contentType?: string) =>
+      db.saveDataContentAttributes({ id, hash, dataSize: 5357, contentType });
+
+    const contentTypeOf = async (id: string) =>
+      (await db.getDataAttributes(id))?.contentType ?? undefined;
+
+    it('replaces the octet-stream placeholder with a real content type', async () => {
+      const id = idFor('heal-placeholder');
+      await save(id, 'heal-placeholder', 'application/octet-stream');
+      assert.equal(await contentTypeOf(id), 'application/octet-stream');
+
+      await save(id, 'heal-placeholder', 'text/html');
+
+      assert.equal(await contentTypeOf(id), 'text/html');
+    });
+
+    it('fills in a null content type', async () => {
+      const id = idFor('heal-null');
+      await save(id, 'heal-null', undefined);
+      assert.equal(await contentTypeOf(id), undefined);
+
+      await save(id, 'heal-null', 'text/html');
+
+      assert.equal(await contentTypeOf(id), 'text/html');
+    });
+
+    it('matches the placeholder with parameters and odd casing', async () => {
+      const id = idFor('heal-normalized');
+      await save(id, 'heal-normalized', 'Application/Octet-Stream; x=1');
+
+      await save(id, 'heal-normalized', 'text/html');
+
+      assert.equal(await contentTypeOf(id), 'text/html');
+    });
+
+    it('never overwrites one real content type with another', async () => {
+      const id = idFor('heal-no-flap');
+      await save(id, 'heal-no-flap', 'text/html');
+
+      await save(id, 'heal-no-flap', 'image/png');
+
+      assert.equal(await contentTypeOf(id), 'text/html');
+    });
+
+    it('never falls back from a real content type to the placeholder', async () => {
+      const id = idFor('heal-no-regress');
+      await save(id, 'heal-no-regress', 'text/html');
+
+      await save(id, 'heal-no-regress', 'application/octet-stream');
+
+      assert.equal(await contentTypeOf(id), 'text/html');
+    });
+
+    it('heals a byte-identical re-upload, which shares the poisoned row', async () => {
+      // The reported symptom: re-uploading the file produced a new data item
+      // ID that hashed to the same bytes, so it inherited the placeholder and
+      // the re-upload appeared to change nothing.
+      const original = idFor('heal-reupload-original');
+      const reupload = idFor('heal-reupload-new');
+      await save(original, 'heal-reupload', 'application/octet-stream');
+      assert.equal(
+        await contentTypeOf(reupload),
+        undefined,
+        'the re-upload has no row of its own yet',
+      );
+
+      await save(reupload, 'heal-reupload', 'text/html');
+
+      assert.equal(await contentTypeOf(reupload), 'text/html');
+      assert.equal(
+        await contentTypeOf(original),
+        'text/html',
+        'the original ID shares the row, so it heals too',
+      );
+    });
+  });
+
   describe('getVerifiableDataIds', () => {
     it("should return an empty list if there's no verifiable data ids", async () => {
       const emptyDbIds = await db.getVerifiableDataIds();

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -1924,10 +1924,16 @@ export class StandaloneSqliteDatabaseWorker {
       });
     }
 
-    if (this.insertDataHashCache.get(hash)) {
+    // Dedupe on (hash, content type) rather than hash alone. `insertDataHash`
+    // can now heal a row whose content type is the `application/octet-stream`
+    // placeholder, and keying on the hash alone would let this in-process memo
+    // swallow exactly the write that heals it — the repeat suppressed is the
+    // one carrying the better value.
+    const insertDataHashCacheKey = `${hash}|${contentType ?? ''}`;
+    if (this.insertDataHashCache.get(insertDataHashCacheKey)) {
       return;
     }
-    this.insertDataHashCache.set(hash, true);
+    this.insertDataHashCache.set(insertDataHashCacheKey, true);
 
     this.stmts.data.insertDataHash.run({
       hash: hashBuffer,
@@ -4361,11 +4367,18 @@ export class StandaloneSqliteDatabase
     // suppress ones it allowed, and the extra writes are limited to genuine
     // corrections — so the protection this cache exists to give the write
     // queue is preserved.
+    //
+    // `contentType` is in the key for the same reason: a retrieval that
+    // resolved the item's content type only from the bundle around it claims
+    // the slot first, and the write carrying the item's real type — the one
+    // that heals `contiguous_data.original_source_content_type` — arrives
+    // inside the same window and would otherwise be the one dropped.
     const dedupeKey = [
       id,
       rootTransactionId ?? '',
       rootDataItemOffset ?? '',
       rootDataOffset ?? '',
+      contentType ?? '',
     ].join('|');
 
     if (this.saveDataContentAttributesCache.get(dedupeKey)) {

--- a/src/database/standalone-sqlite.ts
+++ b/src/database/standalone-sqlite.ts
@@ -4308,12 +4308,15 @@ export class StandaloneSqliteDatabase
    * position within the root transaction — for persistence.
    *
    * Writes are deduped over a {@link DEDUPE_CACHE_TTL_MS} window keyed on the
-   * item ID **and its root coordinates** (`rootTransactionId`,
-   * `rootDataItemOffset`, `rootDataOffset`). A repeat write carrying the same
-   * coordinates is dropped, which is what the cache exists for; a write that
-   * moves the item to a different root always reaches the queue. Keying on the
-   * ID alone let whichever retrieval finished first inside the window win, so a
-   * corrected root arriving behind an unchanged write was silently discarded.
+   * item ID **plus every field a write can correct**: its root coordinates
+   * (`rootTransactionId`, `rootDataItemOffset`, `rootDataOffset`) and its
+   * `contentType`. A repeat write carrying all the same values is dropped,
+   * which is what the cache exists for; a write that moves the item to a
+   * different root, or that carries a different content type, always reaches
+   * the queue. Keying on the ID alone let whichever retrieval finished first
+   * inside the window win, so a correction arriving behind an unchanged write
+   * was silently discarded — the root coordinates and the content type are in
+   * the key because each was a correction being lost that way.
    *
    * Callers that invalidate an item must clear every dedupe entry for it, not
    * just the bare ID — see {@link clearDataHash}.

--- a/src/discovery/graphql-root-tx-index.test.ts
+++ b/src/discovery/graphql-root-tx-index.test.ts
@@ -6,12 +6,12 @@
  */
 import { strict as assert } from 'node:assert';
 import { afterEach, describe, it, mock } from 'node:test';
-import winston from 'winston';
 import { LRUCache } from 'lru-cache';
 import { default as axios } from 'axios';
 import { GraphQLRootTxIndex } from './graphql-root-tx-index.js';
+import { createTestLogger } from '../../test/test-logger.js';
 
-const log = winston.createLogger({ silent: true });
+const log = createTestLogger({ suite: 'GraphQLRootTxIndex' });
 
 describe('GraphQLRootTxIndex', () => {
   afterEach(() => {
@@ -621,6 +621,130 @@ describe('GraphQLRootTxIndex', () => {
         0,
         'Should not call any gateways when rate limited',
       );
+    });
+  });
+
+  // Indexers do not reliably populate `data.type` for bundled data items —
+  // arweave.net returns null for it on ArDrive uploads whose `Content-Type`
+  // tag is present and correct. Returning no content type here is not a
+  // harmless gap: the caller is resolving an item this gateway has not
+  // indexed, and with nothing to report the item gets served with the content
+  // type of the bundle around it. Fall back to the tag `data.type` derives
+  // from.
+  describe('content type resolution', () => {
+    const dataItemId = 'ct-fallback-item';
+    const rootBundleId = 'ct-fallback-root';
+
+    const stubAxios = (node: Record<string, unknown>) => {
+      const mockAxiosInstance = {
+        post: mock.fn((_url: string, body: any) => {
+          if (body.query.includes('getBundleParents')) {
+            // Batched path: one query answers both parent and metadata.
+            return Promise.resolve({
+              status: 200,
+              data: {
+                data: {
+                  transactions: {
+                    edges: [
+                      { node: { id: dataItemId, ...node, bundledIn: null } },
+                    ],
+                  },
+                },
+              },
+            });
+          }
+          if (body.query.includes('getMetadata')) {
+            return Promise.resolve({
+              status: 200,
+              data: { data: { transaction: { id: dataItemId, ...node } } },
+            });
+          }
+          if (body.query.includes('getBundleParent')) {
+            return Promise.resolve({
+              status: 200,
+              data: {
+                data: {
+                  transaction: {
+                    id: body.variables.id,
+                    bundledIn:
+                      body.variables.id === dataItemId
+                        ? { id: rootBundleId }
+                        : null,
+                  },
+                },
+              },
+            });
+          }
+          return Promise.reject(new Error('Unexpected query'));
+        }),
+        defaults: { raxConfig: {} },
+        interceptors: {
+          request: { use: mock.fn(), eject: mock.fn() },
+          response: { use: mock.fn(), eject: mock.fn() },
+        },
+      };
+      mock.method(axios, 'create', () => mockAxiosInstance);
+      return mockAxiosInstance;
+    };
+
+    const buildIndex = (batchEnabled: boolean) => {
+      const graphqlIndex = new GraphQLRootTxIndex({
+        log,
+        trustedGatewaysUrls: { 'https://arweave-search.goldsky.com': 1 },
+        rateLimitBurstSize: 100,
+        rateLimitTokensPerInterval: 100,
+        rateLimitInterval: 'second',
+        batchEnabled,
+      });
+      // Prefill rate limiter to avoid waiting for token bucket refill
+      (graphqlIndex as any)['limiter'].content = (graphqlIndex as any)[
+        'limiter'
+      ].bucketSize;
+      return graphqlIndex;
+    };
+
+    it('falls back to the Content-Type tag when data.type is null', async () => {
+      stubAxios({
+        data: { type: null, size: '5357' },
+        tags: [
+          { name: 'Content-Type', value: 'text/html' },
+          { name: 'App-Name', value: 'ArDrive-CLI' },
+        ],
+      });
+
+      const result = await buildIndex(false).getRootTx(dataItemId);
+
+      assert.equal(result?.contentType, 'text/html');
+    });
+
+    it('falls back to the Content-Type tag on the batched path', async () => {
+      stubAxios({
+        data: { type: null, size: '5357' },
+        tags: [{ name: 'content-type', value: 'text/html' }],
+      });
+
+      const result = await buildIndex(true).getRootTx(dataItemId);
+
+      assert.equal(result?.contentType, 'text/html');
+    });
+
+    it('prefers data.type when it is populated', async () => {
+      stubAxios({
+        data: { type: 'image/png', size: '5357' },
+        tags: [{ name: 'Content-Type', value: 'text/html' }],
+      });
+
+      const result = await buildIndex(false).getRootTx(dataItemId);
+
+      assert.equal(result?.contentType, 'image/png');
+    });
+
+    it('reports no content type when neither is present', async () => {
+      stubAxios({ data: { type: null, size: '5357' }, tags: [] });
+
+      const result = await buildIndex(false).getRootTx(dataItemId);
+
+      assert.equal(result?.contentType, undefined);
     });
   });
 });

--- a/src/discovery/graphql-root-tx-index.ts
+++ b/src/discovery/graphql-root-tx-index.ts
@@ -37,7 +37,9 @@ const GRAPHQL_BUNDLE_QUERY = `
   }
 `;
 
-// Query for metadata retrieval - only used for the original item
+// Query for metadata retrieval - only used for the original item.
+// `tags` is requested alongside `data.type` because `data.type` is not
+// universally populated — see `contentTypeFromNode`.
 const GRAPHQL_METADATA_QUERY = `
   query getMetadata($id: ID!) {
     transaction(id: $id) {
@@ -45,6 +47,10 @@ const GRAPHQL_METADATA_QUERY = `
       data {
         type
         size
+      }
+      tags {
+        name
+        value
       }
     }
   }
@@ -61,11 +67,39 @@ const GRAPHQL_BATCH_QUERY = `
           id
           bundledIn { id }
           data { type size }
+          tags { name value }
         }
       }
     }
   }
 `;
+
+/**
+ * Derives a data item's content type from a GraphQL transaction node.
+ *
+ * `data.type` is the natural field, but it is not reliably populated: for
+ * bundled data items some indexers (arweave.net among them) return `null` for
+ * `data.type` while still returning the item's `Content-Type` tag verbatim. A
+ * missing content type here is not harmless — the caller is resolving an item
+ * that this gateway has not indexed, and with nothing to report the item ends
+ * up served (and cached) with the content type of the bundle that contains it.
+ * So fall back to the tag, which is the value `data.type` is derived from.
+ *
+ * The first `Content-Type` tag wins, matched case-insensitively, mirroring
+ * `ans104-offset-source`'s header parsing so both routes agree.
+ */
+const contentTypeFromNode = (node: {
+  data?: { type?: string | null } | null;
+  tags?: { name?: string | null; value?: string | null }[] | null;
+}): string | undefined => {
+  if (typeof node.data?.type === 'string' && node.data.type.length > 0) {
+    return node.data.type;
+  }
+  const tag = node.tags?.find((t) => t?.name?.toLowerCase() === 'content-type');
+  return typeof tag?.value === 'string' && tag.value.length > 0
+    ? tag.value
+    : undefined;
+};
 
 const DEFAULT_REQUEST_RETRY_COUNT = 3;
 
@@ -238,7 +272,7 @@ export class GraphQLRootTxIndex implements DataItemRootIndex {
         if (node?.id == null) continue;
         out.set(node.id, {
           bundleId: node.bundledIn?.id,
-          contentType: node.data?.type,
+          contentType: contentTypeFromNode(node),
           size: node.data?.size,
         });
       }
@@ -588,7 +622,7 @@ export class GraphQLRootTxIndex implements DataItemRootIndex {
               const transaction = response.data.data.transaction;
 
               return {
-                contentType: transaction.data?.type,
+                contentType: contentTypeFromNode(transaction),
                 size: transaction.data?.size,
               };
             }

--- a/src/lib/content-type.ts
+++ b/src/lib/content-type.ts
@@ -1,0 +1,39 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * The content type served when nothing is known about a payload, and the
+ * content type an ANS-104 bundle legitimately carries. A data item resolved
+ * without its tags ever being read inherits it from the bundle around it,
+ * which is why it doubles as the marker for "no real content type here yet".
+ */
+export const OCTET_STREAM_CONTENT_TYPE = 'application/octet-stream';
+
+/**
+ * True when `contentType` is the octet-stream placeholder rather than a
+ * specific type: bare, or followed by parameters after a `;` or whitespace.
+ *
+ * Matched as a whole media type, never as a prefix — `application/octet-stream
+ * +json` is a structured-suffix type of its own, and treating it as the
+ * placeholder would let it be replaced. Mirrors the predicate in
+ * `insertDataHash` (`src/database/sql/data/content-attributes.sql`), so the
+ * in-memory attributes cache and the persisted row agree on what counts as a
+ * placeholder.
+ */
+export const isOctetStreamPlaceholder = (
+  contentType: string | undefined | null,
+): boolean => {
+  if (contentType == null) {
+    return false;
+  }
+  const normalized = contentType.trim().toLowerCase();
+  return (
+    normalized === OCTET_STREAM_CONTENT_TYPE ||
+    normalized.startsWith(`${OCTET_STREAM_CONTENT_TYPE};`) ||
+    normalized.startsWith(`${OCTET_STREAM_CONTENT_TYPE} `)
+  );
+};


### PR DESCRIPTION
## Problem

A user reported that `https://ledpolicy.ar.io/blades/revolutionary-theatre/index.html` downloads instead of rendering: AR.IO serves it as `application/octet-stream`. The data item (`vVJvFkPOI8_36gIZAsWKpImCLYnNWWymsHEvoF2vwmM`) is tagged `Content-Type: text/html` and arweave.net serves it as `text/html`. Re-uploading the file and updating the manifest changed nothing. Other HTML files in the same manifest render fine.

## Reproduction (turbo-gateway.com)

The failing item, and a sibling from the same manifest and uploader:

```
$ curl -sI https://turbo-gateway.com/raw/vVJvFkPOI8_36gIZAsWKpImCLYnNWWymsHEvoF2vwmM
content-type: application/octet-stream
x-cache: HIT
x-ar-io-stable: false
x-ar-io-verified: true
x-ar-io-root-transaction-id: PMUG7tqhwo9dSCUDwI5xn5gyfGMTFqCizaCi8ZA-Dvk
x-ar-io-root-item-offset: 160
x-ar-io-root-data-offset: 1268
x-ar-io-root-item-size: 6465

$ curl -sI https://turbo-gateway.com/raw/jxxT7JHe7fuFlfnhmgH8K5OzNbD5ZDCgFnhz8quBivk
content-type: text/html; charset=utf-8
x-cache: MISS
x-ar-io-hops: 2
# no x-ar-io-stable, no x-ar-io-verified, no root offset headers
```

The contrast is the whole bug, and it runs the opposite way to intuition. The item the gateway has **stored attributes for** is the broken one: it serves from its own cache, emits a full set of root offsets — exactly the shape `RootParentDataSource.tryCacheAttributes` persists — and reports `application/octet-stream`. The item it knows **nothing** about is fine: no stored attributes, fetched from a peer, and the peer's `Content-Type` header happened to be right.

`x-ar-io-stable: false` on an old, mined, verified item means `getDataAttributes` found no stable index row for it, so the content type it returned came from the `contiguous_data` fallback — which is where the wrong value lives. (turbo-gateway.com's GraphQL reports `text/html` for both items, but it is served by a separate indexer stack rather than the local SQLite index the data path reads, so it is not evidence of what `getDataAttributes` sees.)

## Causal chain

**1. The bundle's content type is reported as the item's.** A data item is fetched as a byte range of its root transaction, so the root fetch's `sourceContentType` is the ANS-104 envelope's — `application/octet-stream`. `RootParentDataSource` passed it through when the item's own content type was unknown:

```ts
sourceContentType: originalContentType ?? data.sourceContentType
```

Confirmed for this item: root bundle `PMUG7tqhwo9dSCUDwI5xn5gyfGMTFqCizaCi8ZA-Dvk` is 8086 bytes of `application/octet-stream`; the item is 5357 bytes at offset 1268 — matching the offsets in the response headers above.

**2. Why the item's own content type was unknown.** `GraphQLRootTxIndex` read `data.type` only, and the indexers return `null` for it on these ArDrive items while returning the tag verbatim:

```json
"data": { "size": "5357", "type": null },
"tags": [ { "name": "Content-Type", "value": "text/html" }, ... ]
```

**3. The wrong value became permanent.** `ReadThroughDataCache` writes the served content type to `contiguous_data.original_source_content_type`, which is keyed by the data **hash**, not the data item ID. `getDataAttributes` falls back to it whenever the local index has no row carrying a content type for the item. `insertDataHash` used `ON CONFLICT DO NOTHING`, so the first writer won forever — and because the key is the hash, a byte-identical re-upload inherits the poisoned row, which is why re-uploading appeared to do nothing.

**4. It spreads.** `ar-io-data-source` and `gateways-data-source` take `sourceContentType` from the upstream response's `Content-Type` header, so one gateway's wrong answer becomes the next one's stored truth. The working sibling above is the benign side of the same coin — it was right only because the peer it landed on was right.

**Why it looks isolated to one file.** Peer selection is keyed by data ID (`selectPeersForKey` → `PeerHashRing.getHomeSet`), so each item has a deterministic home set. One item lands consistently on a gateway with the wrong answer while its siblings land elsewhere.

## Changes

- **`fix: stop serving a data item with its bundle's content type`** — when the item's own content type is unknown, report nothing and let the route handler apply its default rather than asserting the envelope's type. Applied at all four return paths in `RootParentDataSource`. The fetched type is still used when the item *is* the root transaction, where it does describe the returned bytes.
- **`fix: read the Content-Type tag when GraphQL data.type is null`** — request `tags` alongside `data.type` and fall back to the tag the field derives from. Also normalises a `null` `data.type` to `undefined`, which is what `LeafResult.contentType` declares. Measured against turbo-gateway.com: +214 bytes of response per item (single metadata query 119 → 333 bytes; two-ID batch 374 → 802).
- **`fix: let a real content type replace the octet-stream placeholder`** — `insertDataHash` now allows exactly one transition, placeholder (or NULL) → real value, never the reverse. Genuinely binary data keeps octet-stream because the only type on offer for it is also octet-stream, and nothing can overwrite one specific type with another, so two byte-identical items with conflicting tags cannot flap the row. Both dedupe caches in front of that write had to learn about the content type or they would suppress exactly the healing write — the main thread's `saveDataContentAttributes` LRU (the same failure its key already accounts for with the root coordinates) and the worker's `insertDataHashCache`. A follow-up commit matches the placeholder as a whole media type rather than a prefix, so `application/octet-stream+json` is treated as the specific type it is.
- **`fix: let a real content type displace the in-memory placeholder`** — `CompositeDataAttributesSource` preserved a cached content type against incoming writes as DB-authoritative, which also preserved the placeholder. That defeated the healing: the cache-miss path would correct the row while the process, whose attributes cache has no TTL, kept serving the old value until eviction or restart. It now yields to a specific type when it holds only the placeholder — the same one-way transition `insertDataHash` allows, extracted to `src/lib/content-type.ts` so both layers state it once. Because the data handler re-reads attributes after `getData`, the correction now lands within the same request.
- **`docs`** — glossary entry for `original_source_content_type`, recording the hash keying and the one-way transition.

Together: nothing wrong gets manufactured (1), the right value is usually available (2), and gateways already holding the wrong value heal on the next cache miss, in both the row and the process (3, 4).

## Operational note

Gateways already serving an affected item heal on its next cache miss. To fix one immediately without waiting for eviction, force the parent bundle to be indexed — a tags-derived content type takes precedence over the hash-keyed column entirely:

```
POST /ar-io/admin/queue-bundle {"id":"PMUG7tqhwo9dSCUDwI5xn5gyfGMTFqCizaCi8ZA-Dvk","bypassFilter":true}
```

Note that an edge cache in front of the gateway holds the old response independently. On turbo-gateway that is 90 days for `/raw/` (`CACHE_UNSTABLE_TRUSTED_MAX_AGE=7776000`) but only 20 minutes on the ArNS path, which is capped by the ANT TTL.

## Verified against production (turbo-gateway gw1)

Read-only, on `turbo-gw-fsn1-1`, which runs `ar-io-core:cc7bedf2` — the exact commit this PR branches from:

```
contiguous_data.original_source_content_type for vVJv's hash
  -> 'application/octet-stream', 5357 bytes, indexed 2026-08-24

stable_data_items / new_data_items for vVJv
  -> no rows
```

So the item has no local index row and the served type comes from the hash-keyed fallback, exactly as described. This deployment's configured GraphQL upstream (`arweave-search.goldsky.com`) returns `data.type: null` with a `text/html` tag for it in both the single and batched query forms, so the tag fallback applies to the real upstream here, not only to arweave.net.

Scale on that box: 8,042,307 content hashes, of which 2,090,116 carry the placeholder. Sampling 312 of those at random and checking each against its on-chain tags found 237 with no `Content-Type` tag at all (octet-stream is correct for them), 75 genuinely octet-stream, and **0 poisoned** — so under ~1% of placeholder rows at 95% confidence.

The rate is low because most cached data items carry no `Content-Type` tag, leaving nothing to get wrong. Impact concentrates in the class where the tag exists and the type matters. Scoped to the reported website, of its 396 assets the gateway has 307 cached, and exactly 2 carry the placeholder — both HTML pages, one being the reported `vVJv…` and the other `qCxi0sZPnv-Kj6fxr3zZY79qXXktXphyZ5R4jlAkPu4` (`blades/cut-the-noise/index.html`), which is broken in production and had not been reported.

So: rare in aggregate, real where it lands. Fix forward and let cache misses heal, rather than running a bulk cleanup over two million rows that are overwhelmingly correct.

## Testing

- 20 new tests across the four fixes; each was confirmed to fail without its fix (the remainder are guard tests asserting the changes do *not* over-correct).
- Full unit suite: 2310 tests, 2306 pass, 0 fail, 4 pre-existing skips.
- `eslint src test` clean; no new `tsc` errors (431 before and after, all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UbnSTu6PcyYu2bSXgp4Ww
