### PR TITLE
fix: stop a partial attributes seed from masking the database

### DIFF
--- a/src/data/composite-data-attributes-source.test.ts
+++ b/src/data/composite-data-attributes-source.test.ts
@@ -100,13 +100,12 @@ describe('CompositeDataAttributesSource', () => {
 
     it('should accept a positive integer partial seed TTL', () => {
       const source = new MockDataAttributesSource('source1');
-      assert.ok(
-        new CompositeDataAttributesSource({
-          log,
-          source,
-          partialSeedTtlMs: 1,
-        }) !== undefined,
-      );
+      const composite = new CompositeDataAttributesSource({
+        log,
+        source,
+        partialSeedTtlMs: 1,
+      });
+      assert.ok(composite instanceof CompositeDataAttributesSource);
     });
 
     it('should create instance with custom cache size', () => {

--- a/src/data/composite-data-attributes-source.test.ts
+++ b/src/data/composite-data-attributes-source.test.ts
@@ -310,6 +310,83 @@ describe('CompositeDataAttributesSource', () => {
       assert.strictEqual(source.callCount, 1); // No additional source calls
     });
 
+    it('should not let a partial seed permanently mask the source', async () => {
+      const source = new MockDataAttributesSource('source1');
+      source.setData('test-id', {
+        ...TEST_DATA_ATTRIBUTES,
+        contentType: 'image/gif',
+      });
+      const composite = new CompositeDataAttributesSource({
+        log,
+        source,
+        partialSeedTtlMs: 25,
+      });
+
+      // The shape ReadThroughDataCache writes after a retrieval whose upstream
+      // response carried no usable Content-Type: every retrieval-time field is
+      // present and contentType is undefined.
+      await composite.setDataAttributes('test-id', {
+        hash: 'partial-hash',
+        size: 1024,
+        contentType: undefined,
+        trusted: true,
+      });
+
+      // Immediately after the seed the fast path still applies: no source call.
+      const immediate = await composite.getDataAttributes('test-id');
+      assert.strictEqual(source.callCount, 0);
+      assert.strictEqual(immediate?.hash, 'partial-hash');
+      assert.strictEqual(immediate?.contentType, undefined);
+
+      // Once the seed ages out the source must be consulted again, so the
+      // authoritative content type reaches the caller instead of being masked
+      // for the life of the process.
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      const refreshed = await composite.getDataAttributes('test-id');
+      assert.strictEqual(source.callCount, 1);
+      assert.strictEqual(refreshed?.contentType, 'image/gif');
+    });
+
+    it('should keep source-backed entries cached without expiry', async () => {
+      const source = new MockDataAttributesSource('source1');
+      source.setData('test-id', TEST_DATA_ATTRIBUTES);
+      const composite = new CompositeDataAttributesSource({
+        log,
+        source,
+        partialSeedTtlMs: 25,
+      });
+
+      await composite.getDataAttributes('test-id');
+      assert.strictEqual(source.callCount, 1);
+
+      // The seed TTL must not leak onto entries that came from the source.
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      await composite.getDataAttributes('test-id');
+      assert.strictEqual(source.callCount, 1);
+    });
+
+    it('should not extend a partial seed into a permanent entry on merge', async () => {
+      const source = new MockDataAttributesSource('source1');
+      source.setData('test-id', {
+        ...TEST_DATA_ATTRIBUTES,
+        contentType: 'text/html',
+      });
+      const composite = new CompositeDataAttributesSource({
+        log,
+        source,
+        partialSeedTtlMs: 25,
+      });
+
+      await composite.setDataAttributes('test-id', { hash: 'seed-hash' });
+      // A second partial write merges into the seed; it must stay expirable.
+      await composite.setDataAttributes('test-id', { size: 2048 });
+
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      const refreshed = await composite.getDataAttributes('test-id');
+      assert.strictEqual(source.callCount, 1);
+      assert.strictEqual(refreshed?.contentType, 'text/html');
+    });
+
     it('should not allow partial updates to overwrite authoritative contentType', async () => {
       const source = new MockDataAttributesSource('source1');
       source.setData('test-id', {

--- a/src/data/composite-data-attributes-source.test.ts
+++ b/src/data/composite-data-attributes-source.test.ts
@@ -78,6 +78,37 @@ describe('CompositeDataAttributesSource', () => {
       assert.ok(composite !== undefined);
     });
 
+    it('should reject a non-positive or non-integer partial seed TTL', () => {
+      const source = new MockDataAttributesSource('source1');
+      // `ttl: 0` reaches lru-cache as "no expiry" rather than "expire
+      // immediately", which would silently restore the unbounded seed this
+      // class exists to prevent -- and report Infinity from getRemainingTTL,
+      // so merges would treat the seed as a source-backed entry too.
+      for (const partialSeedTtlMs of [0, -1, 1.5, Number.NaN, Infinity]) {
+        assert.throws(
+          () =>
+            new CompositeDataAttributesSource({
+              log,
+              source,
+              partialSeedTtlMs,
+            }),
+          /partialSeedTtlMs/,
+          `expected ${partialSeedTtlMs} to be rejected`,
+        );
+      }
+    });
+
+    it('should accept a positive integer partial seed TTL', () => {
+      const source = new MockDataAttributesSource('source1');
+      assert.ok(
+        new CompositeDataAttributesSource({
+          log,
+          source,
+          partialSeedTtlMs: 1,
+        }) !== undefined,
+      );
+    });
+
     it('should create instance with custom cache size', () => {
       const source = new MockDataAttributesSource('source1');
       const composite = new CompositeDataAttributesSource({

--- a/src/data/composite-data-attributes-source.test.ts
+++ b/src/data/composite-data-attributes-source.test.ts
@@ -387,6 +387,53 @@ describe('CompositeDataAttributesSource', () => {
       assert.strictEqual(refreshed?.contentType, 'text/html');
     });
 
+    it('should not let repeated merges postpone a seed expiry', async () => {
+      const source = new MockDataAttributesSource('source1');
+      source.setData('test-id', {
+        ...TEST_DATA_ATTRIBUTES,
+        contentType: 'image/gif',
+      });
+      const composite = new CompositeDataAttributesSource({
+        log,
+        source,
+        partialSeedTtlMs: 200,
+      });
+
+      await composite.setDataAttributes('test-id', { hash: 'seed-hash' });
+
+      // A second partial write lands inside the seed's window. It must update
+      // the value without postponing the deadline, or a steady trickle of
+      // retrieval-time writes would keep an entry that has never seen the
+      // source alive indefinitely -- the exact masking this TTL exists to stop.
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      await composite.setDataAttributes('test-id', { size: 2048 });
+
+      // Past the ORIGINAL deadline (200ms) but inside a hypothetical restarted
+      // one (120 + 200 = 320ms).
+      await new Promise((resolve) => setTimeout(resolve, 140));
+      const refreshed = await composite.getDataAttributes('test-id');
+      assert.strictEqual(source.callCount, 1);
+      assert.strictEqual(refreshed?.contentType, 'image/gif');
+    });
+
+    it('should still apply a merge to the value while the seed is live', async () => {
+      const source = new MockDataAttributesSource('source1');
+      source.setData('test-id', TEST_DATA_ATTRIBUTES);
+      const composite = new CompositeDataAttributesSource({
+        log,
+        source,
+        partialSeedTtlMs: 2000,
+      });
+
+      await composite.setDataAttributes('test-id', { hash: 'seed-hash' });
+      await composite.setDataAttributes('test-id', { size: 4096 });
+
+      const result = await composite.getDataAttributes('test-id');
+      assert.strictEqual(source.callCount, 0);
+      assert.strictEqual(result?.hash, 'seed-hash');
+      assert.strictEqual(result?.size, 4096);
+    });
+
     it('should not allow partial updates to overwrite authoritative contentType', async () => {
       const source = new MockDataAttributesSource('source1');
       source.setData('test-id', {

--- a/src/data/composite-data-attributes-source.ts
+++ b/src/data/composite-data-attributes-source.ts
@@ -54,6 +54,21 @@ export class CompositeDataAttributesSource
     cacheSize?: number;
     partialSeedTtlMs?: number;
   }) {
+    // A non-positive or fractional TTL cannot express "expire a seed after
+    // this long", and `0` in particular is not a short expiry: lru-cache reads
+    // it as no expiry at all, so seeds would mask the source indefinitely and
+    // `getRemainingTTL` would report Infinity, making `isSeededEntry` classify
+    // them as source-backed too. Fail at construction rather than silently
+    // restoring the behaviour this class exists to prevent.
+    if (
+      !Number.isInteger(partialSeedTtlMs) ||
+      (partialSeedTtlMs as number) <= 0
+    ) {
+      throw new Error(
+        `partialSeedTtlMs must be a positive integer, got ${partialSeedTtlMs}`,
+      );
+    }
+
     this.log = log.child({ class: this.constructor.name });
     this.source = source;
     this.partialSeedTtlMs = partialSeedTtlMs;

--- a/src/data/composite-data-attributes-source.ts
+++ b/src/data/composite-data-attributes-source.ts
@@ -15,11 +15,28 @@ import {
 
 const DEFAULT_MAX_CACHE_SIZE = 10000;
 
+/**
+ * How long a retrieval-time seed from {@link
+ * CompositeDataAttributesSource.setDataAttributes} may answer reads before the
+ * source is consulted again.
+ *
+ * Seeded entries are partial by construction -- callers write what retrieval
+ * knew, which for `contentType` is frequently nothing -- and a cache hit
+ * short-circuits `fetchAndCache`. Without a bound, one partial seed masks the
+ * database record for the life of the process, so an item whose stored content
+ * type is correct is still served as `application/octet-stream` until the entry
+ * happens to be evicted by capacity pressure. The window is long enough to
+ * cover the gap between retrieval and the corresponding database write, which
+ * is the reason the seed exists.
+ */
+const DEFAULT_PARTIAL_SEED_TTL_MS = 30000;
+
 export class CompositeDataAttributesSource
   implements ContiguousDataAttributesStore
 {
   private log: winston.Logger;
   private source: DataAttributesSource;
+  private partialSeedTtlMs: number;
   private cache: LRUCache<string, ContiguousDataAttributes>;
   private pendingPromises: Map<
     string,
@@ -30,17 +47,37 @@ export class CompositeDataAttributesSource
     log,
     source,
     cacheSize = DEFAULT_MAX_CACHE_SIZE,
+    partialSeedTtlMs = DEFAULT_PARTIAL_SEED_TTL_MS,
   }: {
     log: winston.Logger;
     source: DataAttributesSource;
     cacheSize?: number;
+    partialSeedTtlMs?: number;
   }) {
     this.log = log.child({ class: this.constructor.name });
     this.source = source;
+    this.partialSeedTtlMs = partialSeedTtlMs;
     this.cache = new LRUCache<string, ContiguousDataAttributes>({
       max: cacheSize,
+      // Entries written by `fetchAndCache` are set without a TTL and so never
+      // expire; only seeded entries pass one to `set`. `ttlAutopurge` keeps
+      // expired seeds from occupying capacity until they are next read.
+      ttlAutopurge: true,
     });
     this.pendingPromises = new Map();
+  }
+
+  /**
+   * True when `id` is held by a seed rather than a source-backed record.
+   * Source-backed entries are written without a TTL, so their remaining TTL is
+   * `Infinity`; a live seed reports a positive finite value. An absent key
+   * reports `0`, which is excluded here so that a caller reaching this with no
+   * entry gets the permanent (source-backed) default rather than being told the
+   * entry is a seed.
+   */
+  private isSeededEntry(id: string): boolean {
+    const remainingTtl = this.cache.getRemainingTTL(id);
+    return remainingTtl > 0 && Number.isFinite(remainingTtl);
   }
 
   async getDataAttributes(
@@ -112,6 +149,9 @@ export class CompositeDataAttributesSource
   ): Promise<void> {
     this.log.debug('Setting data attributes in cache', { id });
     const existingAttributes = this.cache.get(id);
+    // Read before the write below, which would otherwise reset the TTL and
+    // make the answer meaningless.
+    const wasSeeded = this.isSeededEntry(id);
     if (existingAttributes != null) {
       // Preserve DB-authoritative fields from the existing entry
       const authoritative: Partial<ContiguousDataAttributes> = {};
@@ -121,17 +161,31 @@ export class CompositeDataAttributesSource
       if (existingAttributes.isManifest != null) {
         authoritative.isManifest = existingAttributes.isManifest;
       }
-      this.cache.set(id, {
-        ...existingAttributes,
-        ...attributes,
-        ...authoritative,
-      });
+      this.cache.set(
+        id,
+        {
+          ...existingAttributes,
+          ...attributes,
+          ...authoritative,
+        },
+        // Merging another partial write into a seed must not promote it to a
+        // permanent entry, or a steady trickle of writes would keep an entry
+        // that has never seen the source alive indefinitely.
+        wasSeeded ? { ttl: this.partialSeedTtlMs } : undefined,
+      );
     } else {
-      // Seed cache with partial attributes. Callers like
-      // ReadThroughDataCache rely on this to populate hash/size/contentType
-      // after data retrieval. The next getDataAttributes call will fetch
-      // the complete DB record and merge on top via fetchAndCache.
-      this.cache.set(id, attributes as ContiguousDataAttributes);
+      // Seed the cache with partial attributes. Callers like
+      // ReadThroughDataCache rely on this to serve hash/size/contentType in
+      // the window between retrieval and the corresponding database write.
+      //
+      // The TTL is what keeps that a shortcut rather than a replacement: a
+      // cache hit returns without consulting the source, so an unbounded seed
+      // -- typically carrying `contentType: undefined`, because the upstream
+      // response had no usable Content-Type -- would answer every later read
+      // with a value the database could have corrected.
+      this.cache.set(id, attributes as ContiguousDataAttributes, {
+        ttl: this.partialSeedTtlMs,
+      });
     }
   }
 }

--- a/src/data/composite-data-attributes-source.ts
+++ b/src/data/composite-data-attributes-source.ts
@@ -171,7 +171,14 @@ export class CompositeDataAttributesSource
         // Merging another partial write into a seed must not promote it to a
         // permanent entry, or a steady trickle of writes would keep an entry
         // that has never seen the source alive indefinitely.
-        wasSeeded ? { ttl: this.partialSeedTtlMs } : undefined,
+        //
+        // `noUpdateTTL` is what makes that true: `set` otherwise restarts the
+        // countdown, so writes arriving more often than the TTL would postpone
+        // the deadline forever. The value is still updated -- only the expiry
+        // is left alone.
+        wasSeeded
+          ? { ttl: this.partialSeedTtlMs, noUpdateTTL: true }
+          : undefined,
       );
     } else {
       // Seed the cache with partial attributes. Callers like


### PR DESCRIPTION
A retrieval-time seed in the data attributes cache can answer every later read for the life of the process, so an item whose stored content type is correct is served as `application/octet-stream` and the browser downloads it instead of rendering it.

### Mechanism

`getDataAttributes` returns any cache hit without consulting the source:

```ts
const cachedResult = this.cache.get(id);
if (cachedResult) return cachedResult;   // never reaches fetchAndCache
```

`setDataAttributes` seeds that cache with partial attributes when no entry exists. Its comment says the next read repairs it:

> Seed cache with partial attributes. Callers like ReadThroughDataCache rely on this to populate hash/size/contentType after data retrieval. **The next getDataAttributes call will fetch the complete DB record and merge on top via fetchAndCache.**

It does not — the hit short-circuits that call — and the LRU is constructed with `max` only, no `ttl`. The entry therefore persists until capacity pressure evicts it.

Retrieval frequently has no content type to seed. `ReadThroughDataCache` writes `contentType: data.sourceContentType`, which is `undefined` whenever the upstream response carried no usable `Content-Type`. `setDataHeaders` then resolves `dataAttributes?.contentType ?? data.sourceContentType ?? DEFAULT_CONTENT_TYPE` to the octet-stream default, while the database holds the right value and is never asked.

### Observed on a production gateway

Same item, same bytes, same digest, the two nodes behind one load balancer disagreeing — so users got a coin flip between rendering and downloading:

```
gw1  ->  application/octet-stream   (3/3, over several hours)
gw2  ->  image/gif                  (3/3)
```

Running the real `selectDataAttributes` against gw1's own database for that item returns `content_type='image/gif'`, verified and trusted. The bad response still carried `x-ar-io-root-transaction-id` and the root offsets, so `dataAttributes` was **defined and populated but typeless** — the partial-seed signature, not a failed lookup.

It later corrected itself with no restart and no deploy, which is the eviction path: gw1 churns well past 10,000 distinct IDs in a few hours, the entry was dropped, and the next read fell through to the database.

### The fix

Bound the seed with a TTL rather than removing it. The seed exists to cover the window between retrieval and the corresponding database write, and that purpose is preserved.

- Seeded entries are written with `ttl: partialSeedTtlMs` (default 30s, constructor-overridable).
- Source-backed entries from `fetchAndCache` are still written **without** a TTL and never expire.
- Merging a further partial write into a seed keeps it expirable, so a trickle of writes cannot promote an entry that has never seen the source into a permanent one.
- `ttlAutopurge: true` so expired seeds release capacity instead of waiting to be read.

Deliberately **not** removing the seed: dropping it would push a database read into the path immediately after retrieval and reopen the write-lag window the seed covers.

`getRemainingTTL` returns `Infinity` for a no-TTL entry, a positive finite value for a live seed, and `0` for an absent key; `isSeededEntry` excludes the `0` case so a missing entry defaults to permanent rather than being misread as a seed.

### Behaviour this deliberately keeps

The existing test `should seed cache with partial attributes when no entry exists` asserts `source.callCount === 0` immediately after a seed. That fast path is intentional and still passes — the change bounds how long it lasts, it does not remove it.

### Testing

3 new tests, failing-first verified — before the fix exactly two fail, and only those two:

```
not ok 4 - should not let a partial seed permanently mask the source
not ok 6 - should not extend a partial seed into a permanent entry on merge
```

The third (`should keep source-backed entries cached without expiry`) passes before and after; it is the guard that the seed TTL does not leak onto source-backed entries.

- `composite-data-attributes-source.test.ts`: **17 pass, 0 fail**
- all `src/data`: **604 pass, 0 fail**
- all `src/routes/data`: 143 pass, 1 fail
- `lint:check`: clean
- `build`: clean

Two caveats, each verified against clean `develop` with the change stashed rather than assumed:

- The one `src/routes/data` failure is `should override pre-set ArNS Cache-Control with short TTL on fallback range requests` (PE-9072). It fails identically without this change.
- The sqlite-backed suites cannot run on this machine — `better-sqlite3`'s native binding is absent and `npm rebuild` fails on this toolchain. `standalone-sqlite.test.ts` reports 71 tests / 0 pass with the same binding error on clean `develop`. **Those suites need CI to confirm.**
- `yarn typecheck` exits 2 both with and without the change; output is byte-identical after normalising line numbers, so no new type errors.

### Relationship to #875

Complementary, no file overlap. #875 fixes the *stored* value — the bundle envelope's content type being recorded as the item's, and `insertDataHash`'s first-writer-wins keeping it. This fixes the *cache* that sits in front of that value.

They compose in one direction worth noting: #875 makes `RootParentDataSource` report nothing when the item's own content type is unknown, which increases the number of seeds carrying `contentType: undefined`. Without this change those seeds mask the corrected database row, so #875's healing write would not reach the response until the entry was evicted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFr9Nd5w92uj2RiHFggFXW
