### PR TITLE
fix(chunk): classify an internal abort as 404, not 502

### DIFF
--- a/src/routes/chunk/classify-chunk-retrieval-error.test.ts
+++ b/src/routes/chunk/classify-chunk-retrieval-error.test.ts
@@ -1,0 +1,81 @@
+/**
+ * AR.IO Gateway
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { ChunkNotFoundError } from '../../data/chunk-retrieval-service.js';
+import {
+  ChunkServeTimeoutError,
+  classifyChunkRetrievalError,
+} from './handlers.js';
+
+/**
+ * Cancellation cases for `classifyChunkRetrievalError`.
+ *
+ * These live here rather than in `handlers.test.ts` because that file is not
+ * writable in every working tree. The cases in `handlers.test.ts` still cover
+ * the timeout, not-found and unrecognized-failure paths; nothing is
+ * duplicated between the two.
+ */
+describe('classifyChunkRetrievalError - cancellation', () => {
+  const abortError = () =>
+    Object.assign(new Error('This operation was aborted'), {
+      name: 'AbortError',
+    });
+
+  it('maps an internal AbortError to 404 upstream_aborted, not 502', () => {
+    // A client disconnect returns 499 in the branch above, so an AbortError
+    // reaching the rest of the classifier is internal: a source's own abort
+    // signal, or a losing peer cancelled once another won. Observed on a live
+    // gateway as 'This operation was aborted' reported with statusCode 502,
+    // which contradicts the timeout-as-not-found contract the wall-clock
+    // deadline was built around.
+    const verdict = classifyChunkRetrievalError(abortError(), false);
+
+    assert.strictEqual(verdict.statusCode, 404);
+    assert.strictEqual(verdict.errorType, 'upstream_aborted');
+  });
+
+  it('maps a client-aborted request to 499 even when the error is an abort', () => {
+    const verdict = classifyChunkRetrievalError(abortError(), true);
+
+    assert.strictEqual(verdict.statusCode, 499);
+    assert.strictEqual(verdict.errorType, 'client_disconnected');
+  });
+
+  it('keeps the serve deadline on 404 rather than the new abort branch', () => {
+    // The deadline rejects before it aborts, so it must still surface as
+    // serve_deadline_exceeded and stay attributable to the deadline metric.
+    const verdict = classifyChunkRetrievalError(
+      new ChunkServeTimeoutError(12000),
+      false,
+    );
+
+    assert.strictEqual(verdict.statusCode, 404);
+    assert.strictEqual(verdict.errorType, 'serve_deadline_exceeded');
+  });
+
+  it('leaves a genuine upstream failure on 502', () => {
+    const verdict = classifyChunkRetrievalError(
+      new Error('Failed to fetch chunk from AR.IO peers'),
+      false,
+    );
+
+    assert.strictEqual(verdict.statusCode, 502);
+    assert.strictEqual(verdict.errorType, 'upstream_unavailable');
+  });
+
+  it('preserves the errorType of a ChunkNotFoundError', () => {
+    const verdict = classifyChunkRetrievalError(
+      new ChunkNotFoundError('nope', 'boundary_not_found'),
+      false,
+    );
+
+    assert.strictEqual(verdict.statusCode, 404);
+    assert.strictEqual(verdict.errorType, 'boundary_not_found');
+  });
+});

--- a/src/routes/chunk/handlers.ts
+++ b/src/routes/chunk/handlers.ts
@@ -122,6 +122,7 @@ export function withChunkServeDeadline<T>(
  *
  *   - client hung up mid-retrieval                    → 499 (Client Closed Request)
  *   - chunk not locatable / not retrievable in time   → 404 (Not Found)
+ *   - retrieval cancelled internally                  → 404 (Not Found)
  *   - upstreams reachable but served bad data         → 502 (Bad Gateway)
  *
  * Timeouts — both per-source timeouts and our own wall-clock serve deadline —
@@ -160,6 +161,16 @@ export function classifyChunkRetrievalError(
   // not-retrievable-in-time → 404, same as a wrapped ChunkNotFoundError.
   if (error?.name === 'TimeoutError' || /timeout/i.test(error?.message ?? '')) {
     return { statusCode: 404, errorType: 'upstream_timeout' };
+  }
+  // An AbortError that reaches here is an *internal* cancellation, because a
+  // client disconnect already returned above: a source's own abort signal, or
+  // a losing peer cancelled once another won. That is the same condition as a
+  // timeout, so it takes the same 404 rather than falling through to 502.
+  // Without this a cancelled fetch is reported as a server-side gateway fault,
+  // which inflates the 5xx count the wall-clock deadline exists to protect and
+  // denies nginx the cacheable negative it gets for every other failure.
+  if (error?.name === 'AbortError') {
+    return { statusCode: 404, errorType: 'upstream_aborted' };
   }
   return { statusCode: 502, errorType: 'upstream_unavailable' };
 }


### PR DESCRIPTION
## What changed

An `AbortError` reaching `classifyChunkRetrievalError` now returns **404 `upstream_aborted`** instead of falling through to the 502 default.

## Why

A client disconnect is already handled in the branch above, which returns 499. So an `AbortError` that reaches the rest of the classifier is an **internal** cancellation: a source's own abort signal, or a losing peer cancelled once another peer won the `Promise.any` race in `ar-io-chunk-source.ts`.

Reporting that as 502 contradicts the contract the wall-clock deadline was built around, stated in `handlers.ts` itself: a chunk fetch that fails for any reason is a 404, which keeps slow and failed serves out of the 5xx count, lets the cascade fall through, and lets nginx serve a cached negative. An internal cancellation is the same condition as a timeout, which already maps to 404.

## Evidence

Observed on a live gateway:

```
warn: Unable to retrieve chunk from upstream sources This operation was aborted
  errorType: "upstream_unavailable"  statusCode: 502  offset: 383419471572868
```

`This operation was aborted` is the `AbortError` message. In one 3-minute window, **22 of 292** inbound `/chunk/:offset` requests were reported as 502 this way, and the logs carried 28 occurrences in 25 minutes. The same offset repeats across requests, so peers retry against a status that is neither cacheable as a negative nor accurate.

## Verification

The new test reproduces the bug before it fixes it:

```
$ git checkout develop -- src/routes/chunk/handlers.ts
not ok 1 - maps an internal AbortError to 404 upstream_aborted, not 502
  expected: 404
  actual: 502
# pass 4  # fail 1

$ git checkout HEAD -- src/routes/chunk/handlers.ts
# pass 5  # fail 0
```

The suite also asserts the paths this must not disturb: a client-aborted request still returns 499, `ChunkServeTimeoutError` still returns `serve_deadline_exceeded` so it stays attributable to `chunk_serve_deadline_exceeded_total`, a genuine upstream failure still returns 502, and `ChunkNotFoundError` keeps its own `errorType`.

## Note on the test file

The cases are in a new `classify-chunk-retrieval-error.test.ts` rather than appended to `handlers.test.ts`, because that file is owned by root in some working trees and cannot be written without a chown. Nothing is duplicated between the two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
