### PR TITLE
perf(docker): install dependencies before copying source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,34 @@
 ARG NODE_VERSION=20.19.6
 ARG NODE_VERSION_SHORT=20
 
-# Build
-FROM node:${NODE_VERSION}-bookworm-slim AS builder
-
+# Toolchain plus the manifests, shared by both dependency stages. Nothing here
+# depends on source, so editing src/ leaves every layer below this cached.
+FROM node:${NODE_VERSION}-bookworm-slim AS base
 WORKDIR /app
 RUN apt-get update \
     && apt-get install -y build-essential curl git python3
+# .yarnrc carries `ignore-engines true`, which some transitive dependencies need
+# to install at all. It was previously swept in by `COPY . .`; copying the
+# manifests without it breaks the install.
+COPY package.json yarn.lock .yarnrc ./
+
+# Full dependency tree, used only to compile.
+FROM base AS deps
+RUN yarn install
+
+# Runtime dependency tree. Deliberately a sibling of `deps` rather than a step
+# after the build: it depends only on the manifests, so editing source does not
+# re-resolve it. Previously this ran as `rm -rf node_modules && yarn install
+# --production` below the source COPY, so every source change reinstalled the
+# whole tree twice.
+FROM base AS proddeps
+RUN yarn install --production
+
+# Compile. Source changes invalidate this stage and nothing above it.
+# node_modules is in .dockerignore, so this cannot clobber the install above.
+FROM deps AS builder
 COPY . .
-RUN yarn install \
-    && yarn build \
-    && rm -rf node_modules \
-    && yarn install --production
+RUN yarn build
 
 # Runtime
 FROM gcr.io/distroless/nodejs${NODE_VERSION_SHORT}-debian12
@@ -21,7 +38,7 @@ WORKDIR /app
 COPY --from=busybox:1.35.0-uclibc /bin/sh /bin/sh
 COPY --from=busybox:1.35.0-uclibc /bin/mkdir /bin/mkdir
 
-COPY --from=builder /app/node_modules ./node_modules/
+COPY --from=proddeps /app/node_modules ./node_modules/
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/dist/ ./dist/
 COPY ./migrations /app/migrations


### PR DESCRIPTION
A one-line source edit currently costs a full dependency reinstall — twice.

`COPY . .` sits above `yarn install`, so any source change invalidates that layer and everything below it. The build then re-resolves the whole tree for the compile, and again for the production prune that runs *after* the source copy.

### Measured

Same machine, both with warm caches, identical one-line source edit:

| | source-only rebuild |
|---|---|
| current | **3m37s** |
| this PR | **14.5s** |

Most of the saving comes from moving the production install into its own stage. It depends only on the manifests, so editing source no longer re-resolves it — previously it ran as `rm -rf node_modules && yarn install --production` below the source copy and was rebuilt every time.

### Output is unchanged

Built from identical source, both Dockerfiles produce:

- compiled dist: `721e6960bb4659a7`, 469 files — **byte-identical**
- runtime `node_modules`: `04d87018b84258a5`, 1010 packages — **identical**

### No new requirements

Deliberately avoids BuildKit-only features. A yarn cache mount would also speed up genuine dependency changes, but the Dockerfile currently builds under the legacy builder and `--mount=type=cache` would make BuildKit a hard requirement for anyone building locally. **Verified this still builds with `DOCKER_BUILDKIT=0`.** CI is unaffected either way — it uses `docker/setup-buildx-action`.

### One trap worth knowing

`.yarnrc` has to be copied alongside the manifests. It carries `ignore-engines true`, which some transitive dependencies need to install at all (`@permaweb/aoconnect` declares `"engines": {"yarn": "please-use-npm"}`). It was previously swept in by `COPY . .`; copying the manifests without it fails the install outright. That cost me one build to discover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015R5EBQvBycT5dbNq2YRAgJ